### PR TITLE
Rename route to avoid name duplication

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -50,7 +50,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     if (Features::enabled(Features::registration())) {
         Route::get('/register', 'RegisteredUserController@create')
                     ->middleware(['guest'])
-                    ->name('register');
+                    ->name('register.show');
 
         Route::post('/register', 'RegisteredUserController@store')
                     ->middleware(['guest'])

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -50,11 +50,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     if (Features::enabled(Features::registration())) {
         Route::get('/register', 'RegisteredUserController@create')
                     ->middleware(['guest'])
-                    ->name('register.show');
+                    ->name('register');
 
         Route::post('/register', 'RegisteredUserController@store')
-                    ->middleware(['guest'])
-                    ->name('register');
+                    ->middleware(['guest']);
     }
 
     // Email Verification...


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR fixes #3. It renames the route that displays the register view to `register.show` to not conflict with the route that handles the form submission. With this all route names are unique which allows laravel to cache the routes. 
