### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -180,7 +180,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
         $response->assertRedirect('/home');
         $this->assertNotNull(Auth::getUser());
-        $this->assertFalse(in_array('valid-code', json_decode(decrypt($user->fresh()->two_factor_recovery_codes), true)));
+        $this->assertNotContains('valid-code', json_decode(decrypt($user->fresh()->two_factor_recovery_codes), true));
     }
 
     public function test_two_factor_challenge_can_fail_via_recovery_code()

--- a/tests/RecoveryCodeControllerTest.php
+++ b/tests/RecoveryCodeControllerTest.php
@@ -27,7 +27,7 @@ class RecoveryCodeControllerTest extends OrchestraTestCase
         $user->fresh();
 
         $this->assertNotNull($user->two_factor_recovery_codes);
-        $this->assertTrue(is_array(json_decode(decrypt($user->two_factor_recovery_codes), true)));
+        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
     }
 
     protected function getPackageProviders($app)

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -29,7 +29,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
 
         $this->assertNotNull($user->two_factor_secret);
         $this->assertNotNull($user->two_factor_recovery_codes);
-        $this->assertTrue(is_array(json_decode(decrypt($user->two_factor_recovery_codes), true)));
+        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
         $this->assertNotNull($user->twoFactorQrCodeSvg());
     }
 


### PR DESCRIPTION
# Changed log

- Using the `assertNotContains` to assert specific key is existed on result array.
- Using the `assertIsArray` to assert result value type is `array`.