### PR TITLE
Add support for password confirmation middleware.

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -84,6 +84,14 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                     ->middleware(['auth']);
     }
 
+    // Password Verification...
+    Route::get('/user/password/verify', 'VerifyPasswordController@show')
+                    ->middleware(['auth'])
+                    ->name('password.confirm');
+
+    Route::post('/user/password/verify', 'VerifyPasswordController@store')
+                    ->middleware(['auth']);
+
     // Two Factor Authentication...
     if (Features::enabled(Features::twoFactorAuthentication())) {
         Route::post('/user/two-factor-authentication', 'TwoFactorAuthenticationController@store')

--- a/src/Contracts/FailedPasswordVerifyResponse.php
+++ b/src/Contracts/FailedPasswordVerifyResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface FailedPasswordVerifyResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/PasswordVerifiedResponse.php
+++ b/src/Contracts/PasswordVerifiedResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface PasswordVerifiedResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/VerifyPasswordViewResponse.php
+++ b/src/Contracts/VerifyPasswordViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface VerifyPasswordViewResponse extends Responsable
+{
+    //
+}

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -117,6 +117,19 @@ class Fortify
     }
 
     /**
+     * Specify which view should be used as the password verification prompt.
+     *
+     * @param  string  $view
+     * @return void
+     */
+    public static function verifyPasswordView($view)
+    {
+        app()->singleton(VerifyPasswordViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
+    }
+
+    /**
      * Specify which view should be used as the request password reset link view.
      *
      * @param  string  $view

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -2,27 +2,31 @@
 
 namespace Laravel\Fortify;
 
-use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
-use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
-use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
-use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
-use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
-use Laravel\Fortify\Contracts\PasswordResetResponse as PasswordResetResponseContract;
-use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
-use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
-use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
-use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
-use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
-use Laravel\Fortify\Http\Responses\LockoutResponse;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Laravel\Fortify\Http\Responses\LoginResponse;
 use Laravel\Fortify\Http\Responses\LogoutResponse;
-use Laravel\Fortify\Http\Responses\PasswordResetResponse;
+use Laravel\Fortify\Http\Responses\LockoutResponse;
 use Laravel\Fortify\Http\Responses\RegisterResponse;
+use Laravel\Fortify\Http\Responses\PasswordResetResponse;
+use Laravel\Fortify\Http\Responses\PasswordVerifiedResponse;
+use Laravel\Fortify\Http\Responses\FailedPasswordVerifyResponse;
+use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
+use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
+use Laravel\Fortify\Contracts\PasswordVerifiedResponse as PasswordVerifiedResponseContract;
+use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse as FailedPasswordVerifyResponseContract;
+use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Contracts\PasswordResetResponse as PasswordResetResponseContract;
+use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
+use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -62,6 +66,8 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(FailedPasswordResetLinkRequestResponseContract::class, FailedPasswordResetLinkRequestResponse::class);
         $this->app->singleton(PasswordResetResponseContract::class, PasswordResetResponse::class);
         $this->app->singleton(FailedPasswordResetResponseContract::class, FailedPasswordResetResponse::class);
+        $this->app->singleton(PasswordVerifiedResponseContract::class, PasswordVerifiedResponse::class);
+        $this->app->singleton(FailedPasswordVerifyResponseContract::class, FailedPasswordVerifyResponse::class);
     }
 
     /**

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -2,31 +2,31 @@
 
 namespace Laravel\Fortify;
 
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Contracts\Auth\StatefulGuard;
-use Laravel\Fortify\Http\Responses\LoginResponse;
-use Laravel\Fortify\Http\Responses\LogoutResponse;
-use Laravel\Fortify\Http\Responses\LockoutResponse;
-use Laravel\Fortify\Http\Responses\RegisterResponse;
-use Laravel\Fortify\Http\Responses\PasswordResetResponse;
-use Laravel\Fortify\Http\Responses\PasswordVerifiedResponse;
-use Laravel\Fortify\Http\Responses\FailedPasswordVerifyResponse;
-use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
+use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
+use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse as FailedPasswordVerifyResponseContract;
+use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
-use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
-use Laravel\Fortify\Contracts\PasswordVerifiedResponse as PasswordVerifiedResponseContract;
-use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse as FailedPasswordVerifyResponseContract;
-use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
-use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
-use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\PasswordResetResponse as PasswordResetResponseContract;
-use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
-use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
-use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Contracts\PasswordVerifiedResponse as PasswordVerifiedResponseContract;
+use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
+use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
+use Laravel\Fortify\Http\Responses\FailedPasswordVerifyResponse;
+use Laravel\Fortify\Http\Responses\LockoutResponse;
+use Laravel\Fortify\Http\Responses\LoginResponse;
+use Laravel\Fortify\Http\Responses\LogoutResponse;
+use Laravel\Fortify\Http\Responses\PasswordResetResponse;
+use Laravel\Fortify\Http\Responses\PasswordVerifiedResponse;
+use Laravel\Fortify\Http\Responses\RegisterResponse;
+use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 
 class FortifyServiceProvider extends ServiceProvider
 {

--- a/src/Http/Controllers/VerifyPasswordController.php
+++ b/src/Http/Controllers/VerifyPasswordController.php
@@ -2,17 +2,17 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Routing\Controller;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse;
 use Laravel\Fortify\Contracts\PasswordVerifiedResponse;
 use Laravel\Fortify\Contracts\VerifyPasswordViewResponse;
-use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse;
 
 class VerifyPasswordController extends Controller
 {
-   /**
+    /**
      * The guard implementation.
      *
      * @var \Illuminate\Contracts\Auth\StatefulGuard
@@ -36,7 +36,7 @@ class VerifyPasswordController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Laravel\Fortify\Contracts\VerifyPasswordViewResponse
      */
-    public function show(Request $request, VerifyPasswordViewResponse $response) : VerifyPasswordViewResponse
+    public function show(Request $request, VerifyPasswordViewResponse $response): VerifyPasswordViewResponse
     {
         return $response;
     }
@@ -47,12 +47,12 @@ class VerifyPasswordController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request) : Responsable
+    public function store(Request $request): Responsable
     {
         $username = config('fortify.username');
         if ($status = $this->guard->validate([
             $username => $request->user()->{$username},
-            'password' => $request->input('password')
+            'password' => $request->input('password'),
         ])) {
             $request->session()->put('auth.password_confirmed_at', time());
         }

--- a/src/Http/Controllers/VerifyPasswordController.php
+++ b/src/Http/Controllers/VerifyPasswordController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Fortify\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Contracts\Support\Responsable;
+use Laravel\Fortify\Contracts\PasswordVerifiedResponse;
+use Laravel\Fortify\Contracts\VerifyPasswordViewResponse;
+use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse;
+
+class VerifyPasswordController extends Controller
+{
+   /**
+     * The guard implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected $guard;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard
+     * @return void
+     */
+    public function __construct(StatefulGuard $guard)
+    {
+        $this->guard = $guard;
+    }
+
+    /**
+     * Show the verify password view.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Laravel\Fortify\Contracts\VerifyPasswordViewResponse
+     */
+    public function show(Request $request, VerifyPasswordViewResponse $response) : VerifyPasswordViewResponse
+    {
+        return $response;
+    }
+
+    /**
+     * Verify the user's password.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Contracts\Support\Responsable
+     */
+    public function store(Request $request) : Responsable
+    {
+        $username = config('fortify.username');
+        if ($status = $this->guard->validate([
+            $username => $request->user()->{$username},
+            'password' => $request->input('password')
+        ])) {
+            $request->session()->put('auth.password_confirmed_at', time());
+        }
+
+        return $status
+                    ? app(PasswordVerifiedResponse::class)
+                    : app(FailedPasswordVerifyResponse::class);
+    }
+}

--- a/src/Http/Controllers/VerifyPasswordController.php
+++ b/src/Http/Controllers/VerifyPasswordController.php
@@ -50,6 +50,7 @@ class VerifyPasswordController extends Controller
     public function store(Request $request): Responsable
     {
         $username = config('fortify.username');
+
         if ($status = $this->guard->validate([
             $username => $request->user()->{$username},
             'password' => $request->input('password'),

--- a/src/Http/Responses/FailedPasswordVerifyResponse.php
+++ b/src/Http/Responses/FailedPasswordVerifyResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Http\Response;
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Contracts\FailedPasswordVerifyResponse as FailedPasswordVerifyResponseContract;
+
+class FailedPasswordVerifyResponse implements FailedPasswordVerifyResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        $message = __('The provided password was incorrect.');
+
+        if ($request->wantsJson()) {
+            throw ValidationException::withMessages([
+                'password' => [$message],
+            ]);
+        }
+
+        return redirect()->back()->withErrors(['password' => $message]);
+    }
+}

--- a/src/Http/Responses/PasswordVerifiedResponse.php
+++ b/src/Http/Responses/PasswordVerifiedResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Http\Response;
+use Laravel\Fortify\Contracts\PasswordVerifiedResponse as PasswordVerifiedResponseContract;
+
+class PasswordVerifiedResponse implements PasswordVerifiedResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $request->wantsJson()
+                    ? new Response('', 201)
+                    : redirect()->intended(config('fortify.home'));
+    }
+}

--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -8,6 +8,7 @@ use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
+use Laravel\Fortify\Contracts\VerifyPasswordViewResponse;
 
 class SimpleViewResponse implements
     LoginViewResponse,
@@ -15,7 +16,8 @@ class SimpleViewResponse implements
     RegisterViewResponse,
     RequestPasswordResetLinkViewResponse,
     TwoFactorChallengeViewResponse,
-    VerifyEmailViewResponse
+    VerifyEmailViewResponse,
+    VerifyPasswordViewResponse
 {
     /**
      * The name of the view.

--- a/tests/VerifyPasswordControllerTest.php
+++ b/tests/VerifyPasswordControllerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Fortify\Tests;
+
+use Mockery;
+use Illuminate\Foundation\Auth\User;
+use Laravel\Fortify\Contracts\VerifyPasswordViewResponse;
+
+class VerifyPasswordControllerTest extends OrchestraTestCase
+{
+    protected $user;
+
+    public function test_the_verify_password_view_is_returned()
+    {
+        $this->mock(VerifyPasswordViewResponse::class)
+            ->shouldReceive('toResponse')
+            ->andReturn(response('hello world'));
+
+
+        $response = $this->withoutExceptionHandling()->actingAs($this->user)->get(
+            '/user/password/verify'
+        );
+
+        $response->assertStatus(200);
+        $response->assertSeeText('hello world');
+    }
+
+    public function test_password_can_be_verified()
+    {
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['url.intended' => 'http://foo.com/bar'])
+            ->post(
+                '/user/password/verify',
+                ['password' => 'secret',]
+            );
+
+        $response->assertSessionHas('auth.password_confirmed_at');
+        $response->assertRedirect('http://foo.com/bar');
+    }
+
+    public function test_password_verification_can_fail()
+    {
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['url.intended' => 'http://foo.com/bar'])
+            ->post(
+                '/user/password/verify',
+                ['password' => 'invalid',]
+            );
+
+        $response->assertSessionHasErrors(['password']);
+        $response->assertSessionMissing('auth.password_confirmed_at');
+        $response->assertRedirect();
+        $this->assertNotEquals($response->getTargetUrl(), 'http://foo.com/bar');
+    }
+
+    public function test_password_can_be_verified_with_json()
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson(
+                '/user/password/verify',
+                ['password' => 'secret',]
+            );
+        $response->assertStatus(201);
+    }
+
+    public function test_password_verification_can_fail_with_json()
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson(
+                '/user/password/verify',
+                ['password' => 'invalid',]
+            );
+
+        $response->assertJsonValidationErrors('password');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $this->user = TestVerifyPasswordUser::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['migrator']->path(__DIR__.'/../database/migrations');
+
+        $app['config']->set('auth.providers.users.model', TestVerifyPasswordUser::class);
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+}
+
+class TestVerifyPasswordUser extends User
+{
+    protected $table = 'users';
+}

--- a/tests/VerifyPasswordControllerTest.php
+++ b/tests/VerifyPasswordControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Mockery;
 use Illuminate\Foundation\Auth\User;
 use Laravel\Fortify\Contracts\VerifyPasswordViewResponse;
 
@@ -15,7 +14,6 @@ class VerifyPasswordControllerTest extends OrchestraTestCase
         $this->mock(VerifyPasswordViewResponse::class)
             ->shouldReceive('toResponse')
             ->andReturn(response('hello world'));
-
 
         $response = $this->withoutExceptionHandling()->actingAs($this->user)->get(
             '/user/password/verify'
@@ -32,7 +30,7 @@ class VerifyPasswordControllerTest extends OrchestraTestCase
             ->withSession(['url.intended' => 'http://foo.com/bar'])
             ->post(
                 '/user/password/verify',
-                ['password' => 'secret',]
+                ['password' => 'secret']
             );
 
         $response->assertSessionHas('auth.password_confirmed_at');
@@ -46,7 +44,7 @@ class VerifyPasswordControllerTest extends OrchestraTestCase
             ->withSession(['url.intended' => 'http://foo.com/bar'])
             ->post(
                 '/user/password/verify',
-                ['password' => 'invalid',]
+                ['password' => 'invalid']
             );
 
         $response->assertSessionHasErrors(['password']);
@@ -60,7 +58,7 @@ class VerifyPasswordControllerTest extends OrchestraTestCase
         $response = $this->actingAs($this->user)
             ->postJson(
                 '/user/password/verify',
-                ['password' => 'secret',]
+                ['password' => 'secret']
             );
         $response->assertStatus(201);
     }
@@ -70,7 +68,7 @@ class VerifyPasswordControllerTest extends OrchestraTestCase
         $response = $this->actingAs($this->user)
             ->postJson(
                 '/user/password/verify',
-                ['password' => 'invalid',]
+                ['password' => 'invalid']
             );
 
         $response->assertJsonValidationErrors('password');


### PR DESCRIPTION
This PR adds controller methods to support the 'password.confirm' middleware from Illuminate/Auth. 

The idea here is that this could eventually be used to implement a solution for issues like:
https://github.com/laravel/jetstream/issues/17
https://github.com/laravel/jetstream/pull/20

Where certain high risk actions (deleting an API key, deleting the user account, disabling 2FA, etc) could require a password verification prior to accessing the route. This is the pattern that Github follows (a re-auth redirect), and I think it's the most flexible approach.

Thanks for considering!