### PR TITLE
Fix a typo in fortify config stub

### DIFF
--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -37,7 +37,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This value defines which model attribute should be considered as your
-    | application's "useranme" field. Typically, this might be the email
+    | application's "username" field. Typically, this might be the email
     | address of the users but you are free to change this value here.
     |
     */


### PR DESCRIPTION
I was trying out Laravel 8/Jetstream and noticed a typo in the config file for fortify. This PR corrects that typo, nothing else
