### PR TITLE
cleanup unused imports and phpdocs

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -84,7 +84,7 @@ class RedirectIfTwoFactorAuthenticatable
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  mixed  $user
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function twoFactorChallengeResponse($request, $user)
     {

--- a/src/Http/Controllers/EmailVerificationPromptController.php
+++ b/src/Http/Controllers/EmailVerificationPromptController.php
@@ -11,7 +11,7 @@ class EmailVerificationPromptController extends Controller
     /**
      * Display the email verification prompt.
      *
-     * @param  \Laravel\Fortify\Http\Requests\VerifyEmailRequest  $request
+     * @param  \Illuminate\Http\Request  $request
      * @return \Laravel\Fortify\Contracts\VerifyEmailViewResponse
      */
     public function __invoke(Request $request)

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -45,8 +45,7 @@ class RegisteredUserController extends Controller
      * Create a new registered user.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Fortify\Contracts\ValidateUserRegistration  $validate
-     * @param  \Laravel\Fortify\Contracts\CreatesNewUsers  $register
+     * @param  \Laravel\Fortify\Contracts\CreatesNewUsers  $creator
      * @return \Laravel\Fortify\Contracts\RegisterResponse
      */
     public function store(Request $request,

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -5,7 +5,6 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Session;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 use Laravel\Fortify\Http\Responses\FailedTwoFactorLoginResponse;

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -14,7 +14,7 @@ class TwoFactorAuthenticationController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function store(Request $request, EnableTwoFactorAuthentication $enable)
     {
@@ -30,7 +30,7 @@ class TwoFactorAuthenticationController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Fortify\Actions\DisableTwoFactorAuthentication  $disable
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function destroy(Request $request, DisableTwoFactorAuthentication $disable)
     {

--- a/src/Http/Controllers/TwoFactorQrCodeController.php
+++ b/src/Http/Controllers/TwoFactorQrCodeController.php
@@ -11,7 +11,7 @@ class TwoFactorQrCodeController extends Controller
      * Get the SVG element for the user's two factor authentication QR code.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function show(Request $request)
     {

--- a/src/Http/Responses/FailedPasswordResetResponse.php
+++ b/src/Http/Responses/FailedPasswordResetResponse.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
 

--- a/src/Http/Responses/FailedTwoFactorLoginResponse.php
+++ b/src/Http/Responses/FailedTwoFactorLoginResponse.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Http\Response;
 use Illuminate\Validation\ValidationException;
 
 class FailedTwoFactorLoginResponse implements Responsable

--- a/src/Http/Responses/LoginResponse.php
+++ b/src/Http/Responses/LoginResponse.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 
 class LoginResponse implements LoginResponseContract

--- a/src/Http/Responses/PasswordResetResponse.php
+++ b/src/Http/Responses/PasswordResetResponse.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\PasswordResetResponse as PasswordResetResponseContract;
 
 class PasswordResetResponse implements PasswordResetResponseContract

--- a/src/Http/Responses/TwoFactorLoginResponse.php
+++ b/src/Http/Responses/TwoFactorLoginResponse.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Http\Response;
 
 class TwoFactorLoginResponse implements Responsable
 {

--- a/stubs/ResetUserPassword.php
+++ b/stubs/ResetUserPassword.php
@@ -5,7 +5,6 @@ namespace App\Actions\Fortify;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
-use Laravel\Fortify\Rules\Password;
 
 class ResetUserPassword implements ResetsUserPasswords
 {

--- a/stubs/UpdateUserPassword.php
+++ b/stubs/UpdateUserPassword.php
@@ -5,7 +5,6 @@ namespace App\Actions\Fortify;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
-use Laravel\Fortify\Rules\Password;
 
 class UpdateUserPassword implements UpdatesUserPasswords
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR remove some unused imports and do the phpdocs cleanup listed below:

- Normalize all responses `toResponse`  phpdocs `@return` tag to be `\Symfony\Component\HttpFoundation\Response`
  - Most of the Response classes are already using that as their phpdoc `@return`, I changed the others to do also use it, as come return `RedirectResponse` and `JsonResponse` which are not subclasses from Illuminate's `Response`. But all of them are subclasses of the Symfony one.
- Removed an unused param from phpdocs on `RegisteredUserController`'s `store` method
