### PR TITLE
Remove serialize when encrypting secret and recovery codes

### DIFF
--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -35,10 +35,10 @@ class EnableTwoFactorAuthentication
     public function __invoke($user)
     {
         $user->forceFill([
-            'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
+            'two_factor_secret' => encrypt($this->provider->generateSecretKey(), false),
             'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
                 return RecoveryCode::generate();
-            })->all())),
+            })->all()), false),
         ])->save();
     }
 }

--- a/src/Actions/GenerateNewRecoveryCodes.php
+++ b/src/Actions/GenerateNewRecoveryCodes.php
@@ -18,7 +18,7 @@ class GenerateNewRecoveryCodes
         $user->forceFill([
             'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
                 return RecoveryCode::generate();
-            })->all())),
+            })->all()), false),
         ])->save();
     }
 }

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -22,7 +22,7 @@ class RecoveryCodeController extends Controller
         }
 
         return response()->json(json_decode(decrypt(
-            $request->user()->two_factor_recovery_codes
+            $request->user()->two_factor_recovery_codes, false
         ), true));
     }
 

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -55,7 +55,7 @@ class TwoFactorLoginRequest extends FormRequest
     public function hasValidCode()
     {
         return $this->code && app(TwoFactorAuthenticationProvider::class)->verify(
-            decrypt($this->challengedUser()->two_factor_secret), $this->code
+            decrypt($this->challengedUser()->two_factor_secret, false), $this->code
         );
     }
 

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -19,7 +19,7 @@ trait TwoFactorAuthenticatable
      */
     public function recoveryCodes()
     {
-        return json_decode(decrypt($this->two_factor_recovery_codes), true);
+        return json_decode(decrypt($this->two_factor_recovery_codes, false), true);
     }
 
     /**
@@ -34,8 +34,8 @@ trait TwoFactorAuthenticatable
             'two_factor_recovery_codes' => encrypt(str_replace(
                 $code,
                 RecoveryCode::generate(),
-                decrypt($this->two_factor_recovery_codes)
-            )),
+                decrypt($this->two_factor_recovery_codes, false)
+            ), false),
         ])->save();
     }
 
@@ -66,7 +66,7 @@ trait TwoFactorAuthenticatable
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
             $this->email,
-            decrypt($this->two_factor_secret)
+            decrypt($this->two_factor_secret, false)
         );
     }
 }

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -144,7 +144,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
-            'two_factor_secret' => encrypt('test-secret'),
+            'two_factor_secret' => encrypt('test-secret', false),
         ]);
 
         $response = $this->withSession([
@@ -168,7 +168,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code'])),
+            'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code']), false),
         ]);
 
         $response = $this->withSession([
@@ -180,7 +180,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
         $response->assertRedirect('/home');
         $this->assertNotNull(Auth::getUser());
-        $this->assertNotContains('valid-code', json_decode(decrypt($user->fresh()->two_factor_recovery_codes), true));
+        $this->assertNotContains('valid-code', json_decode(decrypt($user->fresh()->two_factor_recovery_codes, false), true));
     }
 
     public function test_two_factor_challenge_can_fail_via_recovery_code()
@@ -194,7 +194,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code'])),
+            'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code']), false),
         ]);
 
         $response = $this->withSession([

--- a/tests/RecoveryCodeControllerTest.php
+++ b/tests/RecoveryCodeControllerTest.php
@@ -27,7 +27,7 @@ class RecoveryCodeControllerTest extends OrchestraTestCase
         $user->fresh();
 
         $this->assertNotNull($user->two_factor_recovery_codes);
-        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
+        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes, false), true));
     }
 
     protected function getPackageProviders($app)

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -29,7 +29,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
 
         $this->assertNotNull($user->two_factor_secret);
         $this->assertNotNull($user->two_factor_recovery_codes);
-        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
+        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes, false), true));
         $this->assertNotNull($user->twoFactorQrCodeSvg());
     }
 
@@ -42,8 +42,8 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
-            'two_factor_secret' => encrypt('foo'),
-            'two_factor_recovery_codes' => encrypt(json_encode([])),
+            'two_factor_secret' => encrypt('foo', false),
+            'two_factor_recovery_codes' => encrypt(json_encode([]), false),
         ]);
 
         $response = $this->withoutExceptionHandling()->actingAs($user)->deleteJson(


### PR DESCRIPTION
This remove the serialization when encrypting the secret and the recovery codes as it seems unnecessary because the secret and the recovery codes are already strings (the recovery codes are json encoded before encryption).

This also helps when interacting with the database from other languages as the serialize format is only used in PHP so it’s hard to parse in non-PHP applications.

And I think now is the only time it’s possible to change this because after Fortify is released it would require to decrypt and encrypt all users with 2FA in the database to make this simple change and it's almost impossible with lot of users.