### PR TITLE
Provide a way of customizing/disabling the default routes

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -17,6 +17,13 @@ use Laravel\Fortify\Http\Responses\SimpleViewResponse;
 class Fortify
 {
     /**
+     * Indicates if Fortify routes will be registered.
+     *
+     * @var bool
+     */
+    public static $registersRoutes = true;
+
+    /**
      * Get the username used for authentication.
      */
     public static function username(): string
@@ -171,5 +178,17 @@ class Fortify
     public static function resetUserPasswordsUsing(string $callback)
     {
         return app()->singleton(ResetsUserPasswords::class, $callback);
+    }
+
+    /**
+     * Configure Fortify to not register its routes.
+     *
+     * @return static
+     */
+    public static function ignoreRoutes()
+    {
+        static::$registersRoutes = false;
+
+        return new static;
     }
 }

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -109,11 +109,13 @@ class FortifyServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
-        Route::group([
-            'namespace' => 'Laravel\Fortify\Http\Controllers',
-            'domain' => config('fortify.domain', null),
-        ], function () {
-            $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
-        });
+        if (Fortify::$registersRoutes) {
+            Route::group([
+                'namespace' => 'Laravel\Fortify\Http\Controllers',
+                'domain' => config('fortify.domain', null),
+            ], function () {
+                $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
+            });
+        }
     }
 }

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -99,6 +99,10 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
+
+            $this->publishes([
+                __DIR__.'/../routes/routes.php' => base_path('routes/fortify'),
+            ], 'fortify-routes');
         }
     }
 

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -99,10 +99,6 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
-
-            $this->publishes([
-                __DIR__.'/../routes/routes.php' => base_path('routes/fortify'),
-            ], 'fortify-routes');
         }
     }
 


### PR DESCRIPTION
A mirror of Jetstream's https://github.com/laravel/jetstream/pull/67

Enables a user to call Fortify::ignoreRoutes() in a provider's register method to disable the default routes and provide their own.
Also enables publishing of default routes into userland.

Relevant are https://github.com/laravel/fortify/issues/9, https://github.com/laravel/fortify/pull/10
