### PR TITLE
Fix a typo and add a missing return statement

### DIFF
--- a/src/LoginRateLimiter.php
+++ b/src/LoginRateLimiter.php
@@ -49,7 +49,7 @@ class LoginRateLimiter
     }
 
     /**
-     * Determine the numebr of seconds until logging in is available again.
+     * Determine the number of seconds until logging in is available again.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return int

--- a/src/LoginRateLimiter.php
+++ b/src/LoginRateLimiter.php
@@ -56,7 +56,7 @@ class LoginRateLimiter
      */
     public function availableIn(Request $request)
     {
-        $this->limiter->availableIn($this->throttleKey($request));
+        return $this->limiter->availableIn($this->throttleKey($request));
     }
 
     /**


### PR DESCRIPTION
In the LoginRateLimiter::availableIn method there were a typo in the doc block a the method should return something but wasn't returning anyting.
