### PR TITLE
Allow specifying a prefix for routes

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -112,6 +112,7 @@ class FortifyServiceProvider extends ServiceProvider
         Route::group([
             'namespace' => 'Laravel\Fortify\Http\Controllers',
             'domain' => config('fortify.domain', null),
+            'prefix' => config('fortify.path'),
         ], function () {
             $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
         });


### PR DESCRIPTION
This PR introduces a way of setting a prefix for the authentication routes, which should enable the original use case proposed on #9. The implementation has been taken from other Laravel packages, such as Horizon, and I've kept the option named `path` to follow the convention (although I believe `prefix` would make more sense in this case).

This option wasn't added to the configuration file by default following the existing `domain` option, which is also missing from this file.