### PR TITLE
Use PasswordValidationRules trait in CreateNewUser action

### DIFF
--- a/stubs/CreateNewUser.php
+++ b/stubs/CreateNewUser.php
@@ -6,10 +6,11 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
-use Laravel\Fortify\Rules\Password;
 
 class CreateNewUser implements CreatesNewUsers
 {
+    use PasswordValidationRules;
+
     /**
      * Validate and create a newly registered user.
      *
@@ -21,7 +22,7 @@ class CreateNewUser implements CreatesNewUsers
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', new Password, 'confirmed'],
+            'password' => $this->passwordRules(),
         ])->validate();
 
         return User::create([


### PR DESCRIPTION
Currently, the CreateNewUser action has the exact same list of rules as the PasswordValidationRules trait that is used by ResetUserPassword and UpdateUserPassword. None of the projects I've worked on have ever purposefully had different validation rules between creating a password or updating it, and by having the same list in multiple places it is likely that some developers will miss the difference and make one way (creating versus updating/resetting) less secure than the other.