### PR TITLE
google2fa v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.3",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^2.0",
-        "pragmarx/google2fa": "^7.0"
+        "pragmarx/google2fa": "^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
PHP 8 support was the only thing that was changed apparently. There's more changes in the diff between v7 and v8 but I think all of those are cosmetic/code cleanup.

Fixes https://github.com/laravel/jetstream/issues/151