### PR TITLE
Allows email address column name to be changed.

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -6,7 +6,7 @@ return [
     'guard' => 'web',
     'passwords' => 'users',
     'username' => 'email',
-    'emailaddress' => 'email',
+    'email_address' => 'email',
     'home' => '/home',
     'limiters' => [
         'login' => null,

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -6,6 +6,7 @@ return [
     'guard' => 'web',
     'passwords' => 'users',
     'username' => 'email',
+    'emailaddress' => 'email',
     'home' => '/home',
     'limiters' => [
         'login' => null,

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -50,7 +50,7 @@ class Fortify
      */
     public static function email(): string
     {
-        return config('fortify.emailaddress', 'email');
+        return config('fortify.email_address', 'email');
     }
 
     /**

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -46,6 +46,14 @@ class Fortify
     public static $registersRoutes = true;
 
     /**
+     * Get the email address column name
+     */
+    public static function email(): string
+    {
+        return config('fortify.emailaddress', 'email');
+    }
+
+    /**
      * Get the username used for authentication.
      */
     public static function username(): string

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -46,7 +46,7 @@ class Fortify
     public static $registersRoutes = true;
 
     /**
-     * Get the email address column name
+     * Get the email address column name.
      */
     public static function email(): string
     {

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -13,6 +13,7 @@ use Laravel\Fortify\Contracts\FailedPasswordResetResponse;
 use Laravel\Fortify\Contracts\PasswordResetResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
+use Laravel\Fortify\Fortify;
 
 class NewPasswordController extends Controller
 {
@@ -55,7 +56,7 @@ class NewPasswordController extends Controller
     {
         $request->validate([
             'token' => 'required',
-            'email' => 'required|email',
+            Fortify::email() => 'required|email',
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -63,7 +63,7 @@ class NewPasswordController extends Controller
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = $this->broker()->reset(
-            $request->only('email', 'password', 'password_confirmation', 'token'),
+            $request->only(Fortify::email(), 'password', 'password_confirmation', 'token'),
             function ($user, $password) use ($request) {
                 app(ResetsUserPasswords::class)->reset($user, $request->all());
 

--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Fortify;
 
 class PasswordResetLinkController extends Controller
 {
@@ -32,13 +33,13 @@ class PasswordResetLinkController extends Controller
      */
     public function store(Request $request): Responsable
     {
-        $request->validate(['email' => 'required|email']);
+        $request->validate([Fortify::email() => 'required|email']);
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $status = $this->broker()->sendResetLink(
-            $request->only('email')
+            $request->only(Fortify::email())
         );
 
         return $status == Password::RESET_LINK_SENT

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Tests;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
@@ -95,5 +96,38 @@ class NewPasswordControllerTest extends OrchestraTestCase
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors('email');
+    }
+
+    public function test_password_can_be_reset_with_custom_email_address_column()
+    {
+        Config::set('fortify.emailaddress', 'emailAddress');
+        Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
+
+        $guard = $this->mock(StatefulGuard::class);
+        $user = Mockery::mock(Authenticatable::class);
+
+        $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('save')->once();
+
+        $guard->shouldReceive('login')->never();
+
+        $updater = $this->mock(ResetsUserPasswords::class);
+        $updater->shouldReceive('reset')->once()->with($user, Mockery::type('array'));
+
+        $broker->shouldReceive('reset')->andReturnUsing(function ($input, $callback) use ($user) {
+            $callback($user, 'password');
+
+            return Password::PASSWORD_RESET;
+        });
+
+        $response = $this->withoutExceptionHandling()->post('/reset-password', [
+            'token' => 'token',
+            'emailAddress' => 'taylor@laravel.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/login');
     }
 }

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -100,7 +100,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
 
     public function test_password_can_be_reset_with_custom_email_address_column()
     {
-        Config::set('fortify.emailaddress', 'emailAddress');
+        Config::set('fortify.email_address', 'emailAddress');
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
         $guard = $this->mock(StatefulGuard::class);

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -66,7 +66,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
 
     public function test_reset_link_email_column_can_be_customized()
     {
-        Config::set('fortify.emailaddress', 'emailAddress');
+        Config::set('fortify.email_address', 'emailAddress');
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
         $broker->shouldReceive('sendResetLink')->andReturn(Password::RESET_LINK_SENT);


### PR DESCRIPTION
I am working to build a new application that uses an existing database that uses 'emailAddress' as the column name in the users table. 

This pull request adds a config value to allow the email address property to be customized instead of relying a hard coded property name. It follows the same logic that is used to allow the username field to be set in the config file.



