### PR TITLE
[1.x] Allow the expected email address request variable to be changed

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -6,6 +6,7 @@ return [
     'guard' => 'web',
     'passwords' => 'users',
     'username' => 'email',
+    'email_address' => 'email',
     'home' => '/home',
     'limiters' => [
         'login' => null,

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -6,7 +6,7 @@ return [
     'guard' => 'web',
     'passwords' => 'users',
     'username' => 'email',
-    'email_address' => 'email',
+    'email' => 'email',
     'home' => '/home',
     'limiters' => [
         'login' => null,

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -46,6 +46,14 @@ class Fortify
     public static $registersRoutes = true;
 
     /**
+     * Get the name of the email address request variable.
+     */
+    public static function emailAddress()
+    {
+        return config('fortify.email_address', 'email');
+    }
+
+    /**
      * Get the username used for authentication.
      */
     public static function username(): string

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -48,9 +48,9 @@ class Fortify
     /**
      * Get the name of the email address request variable.
      */
-    public static function emailAddress()
+    public static function email()
     {
-        return config('fortify.email_address', 'email');
+        return config('fortify.email', 'email');
     }
 
     /**

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -13,6 +13,7 @@ use Laravel\Fortify\Contracts\FailedPasswordResetResponse;
 use Laravel\Fortify\Contracts\PasswordResetResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
+use Laravel\Fortify\Fortify;
 
 class NewPasswordController extends Controller
 {
@@ -55,14 +56,14 @@ class NewPasswordController extends Controller
     {
         $request->validate([
             'token' => 'required',
-            'email' => 'required|email',
+            Fortify::emailAddress() => 'required|email',
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = $this->broker()->reset(
-            $request->only('email', 'password', 'password_confirmation', 'token'),
+            $request->only(Fortify::emailAddress(), 'password', 'password_confirmation', 'token'),
             function ($user, $password) use ($request) {
                 app(ResetsUserPasswords::class)->reset($user, $request->all());
 

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -56,14 +56,14 @@ class NewPasswordController extends Controller
     {
         $request->validate([
             'token' => 'required',
-            Fortify::emailAddress() => 'required|email',
+            Fortify::email() => 'required|email',
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = $this->broker()->reset(
-            $request->only(Fortify::emailAddress(), 'password', 'password_confirmation', 'token'),
+            $request->only(Fortify::email(), 'password', 'password_confirmation', 'token'),
             function ($user, $password) use ($request) {
                 app(ResetsUserPasswords::class)->reset($user, $request->all());
 

--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -33,13 +33,13 @@ class PasswordResetLinkController extends Controller
      */
     public function store(Request $request): Responsable
     {
-        $request->validate([Fortify::emailAddress() => 'required|email']);
+        $request->validate([Fortify::email() => 'required|email']);
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $status = $this->broker()->sendResetLink(
-            $request->only(Fortify::emailAddress())
+            $request->only(Fortify::email())
         );
 
         return $status == Password::RESET_LINK_SENT

--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Fortify;
 
 class PasswordResetLinkController extends Controller
 {
@@ -32,13 +33,13 @@ class PasswordResetLinkController extends Controller
      */
     public function store(Request $request): Responsable
     {
-        $request->validate(['email' => 'required|email']);
+        $request->validate([Fortify::emailAddress() => 'required|email']);
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $status = $this->broker()->sendResetLink(
-            $request->only('email')
+            $request->only(Fortify::emailAddress())
         );
 
         return $status == Password::RESET_LINK_SENT

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -54,7 +54,7 @@ return [
     | needs another name, you are free to set the name of it here.
     |
     */
-    'email_address' => 'email',
+    'email' => 'email',
 
     /*
     |--------------------------------------------------------------------------

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -46,6 +46,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Email Address
+    |--------------------------------------------------------------------------
+    |
+    | Out of the box, Fortify expects forgot password and reset password
+    | requests to have a field set named 'email'. If your application
+    | needs another name, you are free to set the name of it here.
+    |
+    */
+    'email_address' => 'email',
+
+    /*
+    |--------------------------------------------------------------------------
     | Home Path
     |--------------------------------------------------------------------------
     |

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -100,7 +100,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
 
     public function test_password_can_be_reset_with_customized_email_address_field()
     {
-        Config::set('fortify.email_address', 'emailAddress');
+        Config::set('fortify.email', 'emailAddress');
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
         $guard = $this->mock(StatefulGuard::class);

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Tests;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
@@ -95,5 +96,38 @@ class NewPasswordControllerTest extends OrchestraTestCase
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors('email');
+    }
+
+    public function test_password_can_be_reset_with_customized_email_address_field()
+    {
+        Config::set('fortify.email_address', 'emailAddress');
+        Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
+
+        $guard = $this->mock(StatefulGuard::class);
+        $user = Mockery::mock(Authenticatable::class);
+
+        $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('save')->once();
+
+        $guard->shouldReceive('login')->never();
+
+        $updater = $this->mock(ResetsUserPasswords::class);
+        $updater->shouldReceive('reset')->once()->with($user, Mockery::type('array'));
+
+        $broker->shouldReceive('reset')->andReturnUsing(function ($input, $callback) use ($user) {
+            $callback($user, 'password');
+
+            return Password::PASSWORD_RESET;
+        });
+
+        $response = $this->withoutExceptionHandling()->post('/reset-password', [
+            'token' => 'token',
+            'emailAddress' => 'taylor@laravel.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/login');
     }
 }

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -66,7 +66,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
 
     public function test_reset_link_can_be_successfully_requested_with_customized_email_field()
     {
-        Config::set('fortify.email_address', 'emailAddress');
+        Config::set('fortify.email', 'emailAddress');
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
         $broker->shouldReceive('sendResetLink')->andReturn(Password::RESET_LINK_SENT);

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Tests;
 
 use Illuminate\Contracts\Auth\PasswordBroker;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Mockery;
@@ -61,5 +62,21 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors('email');
+    }
+
+    public function test_reset_link_can_be_successfully_requested_with_customized_email_field()
+    {
+        Config::set('fortify.email_address', 'emailAddress');
+        Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
+
+        $broker->shouldReceive('sendResetLink')->andReturn(Password::RESET_LINK_SENT);
+
+        $response = $this->from(url('/forgot-password'))
+            ->post('/forgot-password', ['emailAddress' => 'taylor@laravel.com']);
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/forgot-password');
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
     }
 }


### PR DESCRIPTION
This pull requests gives the ability to change the expected name of the variable in the request that holds the email address when making requests for forgotten passwords and when setting a new password. As it is implemented currently, the request variable name `email` is hard coded into the controllers for both requesting a password reset link and for setting the new password after visiting the reset link. This pull request adds a new config option, similar to the `username` option that is currently there, to allow for changing the expected variable name.

The implementation maintains the `email` name as a default value so that any existing applications should not experience any BC breaks.

The ability to set the expected name of the email address request variable via a config value makes it much easier to integrate a new Laravel application that uses Fortify into an existing system that already has an established database schema that cannot be changed. Without the ability to change that hard coded value via config value, it appears as though the only solution to this problem would be to re-implement all of the password reset logic and controllers simply to change the one request variable.
