### PR TITLE
[1.x] Switch the TwoFactorLoginResponse for a contract bound in container

### DIFF
--- a/src/Contracts/TwoFactorLoginResponse.php
+++ b/src/Contracts/TwoFactorLoginResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface TwoFactorLoginResponse extends Responsable
+{
+    //
+}

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -11,6 +11,7 @@ use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPa
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
 use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 use Laravel\Fortify\Contracts\PasswordResetResponse as PasswordResetResponseContract;
@@ -22,6 +23,7 @@ use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
 use Laravel\Fortify\Http\Responses\LockoutResponse;
 use Laravel\Fortify\Http\Responses\LoginResponse;
+use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
 use Laravel\Fortify\Http\Responses\LogoutResponse;
 use Laravel\Fortify\Http\Responses\PasswordConfirmedResponse;
 use Laravel\Fortify\Http\Responses\PasswordResetResponse;
@@ -63,6 +65,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(FailedPasswordResetResponseContract::class, FailedPasswordResetResponse::class);
         $this->app->singleton(LockoutResponseContract::class, LockoutResponse::class);
         $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
+        $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
         $this->app->singleton(LogoutResponseContract::class, LogoutResponse::class);
         $this->app->singleton(PasswordConfirmedResponseContract::class, PasswordConfirmedResponse::class);
         $this->app->singleton(PasswordResetResponseContract::class, PasswordResetResponse::class);

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -6,9 +6,9 @@ use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 use Laravel\Fortify\Http\Responses\FailedTwoFactorLoginResponse;
-use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
 
 class TwoFactorAuthenticatedSessionController extends Controller
 {

--- a/src/Http/Responses/TwoFactorLoginResponse.php
+++ b/src/Http/Responses/TwoFactorLoginResponse.php
@@ -3,8 +3,9 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Contracts\Support\Responsable;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 
-class TwoFactorLoginResponse implements Responsable
+class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
 {
     /**
      * Create an HTTP response that represents the object.


### PR DESCRIPTION
By binding a contract for the TwoFactorLoginResponse, projects can substitute their own implementation in order to use some conditional routing in the login response (eg, admin user directed to admin dashboard).  This was already possible for the regular login, but not for the 2fa login.

Contract, classes and bindings replicate the LoginResponse, but keeps the original TwoFactor response.

Answers #31 feature request
