### PR TITLE
Make routes more dynamic

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -18,7 +18,6 @@ use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 
-
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
     // Authentication...
     Route::get('/login', [AuthenticatedSessionController::class, 'create'])

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -3,20 +3,20 @@
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
-use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController;
-use Laravel\Fortify\Http\Controllers\PasswordResetLinkController;
-use Laravel\Fortify\Http\Controllers\NewPasswordController;
-use Laravel\Fortify\Http\Controllers\RegisteredUserController;
-use Laravel\Fortify\Http\Controllers\EmailVerificationPromptController;
-use Laravel\Fortify\Http\Controllers\VerifyEmailController;
-use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
-use Laravel\Fortify\Http\Controllers\ProfileInformationController;
-use Laravel\Fortify\Http\Controllers\PasswordController;
 use Laravel\Fortify\Http\Controllers\ConfirmablePasswordController;
 use Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController;
+use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
+use Laravel\Fortify\Http\Controllers\EmailVerificationPromptController;
+use Laravel\Fortify\Http\Controllers\NewPasswordController;
+use Laravel\Fortify\Http\Controllers\PasswordController;
+use Laravel\Fortify\Http\Controllers\PasswordResetLinkController;
+use Laravel\Fortify\Http\Controllers\ProfileInformationController;
+use Laravel\Fortify\Http\Controllers\RecoveryCodeController;
+use Laravel\Fortify\Http\Controllers\RegisteredUserController;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController;
 use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
-use Laravel\Fortify\Http\Controllers\RecoveryCodeController;
+use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 
 
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -2,118 +2,134 @@
 
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
+use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController;
+use Laravel\Fortify\Http\Controllers\PasswordResetLinkController;
+use Laravel\Fortify\Http\Controllers\NewPasswordController;
+use Laravel\Fortify\Http\Controllers\RegisteredUserController;
+use Laravel\Fortify\Http\Controllers\EmailVerificationPromptController;
+use Laravel\Fortify\Http\Controllers\VerifyEmailController;
+use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
+use Laravel\Fortify\Http\Controllers\ProfileInformationController;
+use Laravel\Fortify\Http\Controllers\PasswordController;
+use Laravel\Fortify\Http\Controllers\ConfirmablePasswordController;
+use Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
+use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
+use Laravel\Fortify\Http\Controllers\RecoveryCodeController;
+
 
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
     // Authentication...
-    Route::get('/login', 'AuthenticatedSessionController@create')
-                ->middleware(['guest'])
-                ->name('login');
+    Route::get('/login', [AuthenticatedSessionController::class, 'create'])
+        ->middleware(['guest'])
+        ->name('login');
 
     $limiter = config('fortify.limiters.login');
 
-    Route::post('/login', 'AuthenticatedSessionController@store')
-                ->middleware(array_filter([
-                    'guest',
-                    $limiter ? 'throttle:'.$limiter : null,
-                ]));
+    Route::post('/login', [AuthenticatedSessionController::class, 'store'])
+        ->middleware(array_filter([
+            'guest',
+            $limiter ? 'throttle:'.$limiter : null,
+        ]));
 
-    Route::get('/two-factor-challenge', 'TwoFactorAuthenticatedSessionController@create')
-                ->middleware(['guest'])
-                ->name('two-factor.login');
+    Route::get('/two-factor-challenge', [TwoFactorAuthenticatedSessionController::class, 'create'])
+        ->middleware(['guest'])
+        ->name('two-factor.login');
 
-    Route::post('/two-factor-challenge', 'TwoFactorAuthenticatedSessionController@store')
-                ->middleware(['guest']);
+    Route::post('/two-factor-challenge', [TwoFactorAuthenticatedSessionController::class, 'store'])
+        ->middleware(['guest']);
 
-    Route::post('/logout', 'AuthenticatedSessionController@destroy')
-                ->name('logout');
+    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+        ->name('logout');
 
     // Password Reset...
     if (Features::enabled(Features::resetPasswords())) {
-        Route::get('/forgot-password', 'PasswordResetLinkController@create')
-                    ->middleware(['guest'])
-                    ->name('password.request');
+        Route::get('/forgot-password', [PasswordResetLinkController::class, 'create'])
+            ->middleware(['guest'])
+            ->name('password.request');
 
-        Route::post('/forgot-password', 'PasswordResetLinkController@store')
-                    ->middleware(['guest'])
-                    ->name('password.email');
+        Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
+            ->middleware(['guest'])
+            ->name('password.email');
 
-        Route::get('/reset-password/{token}', 'NewPasswordController@create')
-                    ->middleware(['guest'])
-                    ->name('password.reset');
+        Route::get('/reset-password/{token}', [NewPasswordController::class, 'create'])
+            ->middleware(['guest'])
+            ->name('password.reset');
 
-        Route::post('/reset-password', 'NewPasswordController@store')
-                    ->middleware(['guest'])
-                    ->name('password.update');
+        Route::post('/reset-password', [NewPasswordController::class, 'store'])
+            ->middleware(['guest'])
+            ->name('password.update');
     }
 
     // Registration...
     if (Features::enabled(Features::registration())) {
-        Route::get('/register', 'RegisteredUserController@create')
-                    ->middleware(['guest'])
-                    ->name('register');
+        Route::get('/register', [RegisteredUserController::class, 'create'])
+            ->middleware(['guest'])
+            ->name('register');
 
-        Route::post('/register', 'RegisteredUserController@store')
-                    ->middleware(['guest']);
+        Route::post('/register', [RegisteredUserController::class, 'store'])
+            ->middleware(['guest']);
     }
 
     // Email Verification...
     if (Features::enabled(Features::emailVerification())) {
-        Route::get('/email/verify', 'EmailVerificationPromptController')
-                    ->middleware(['auth'])
-                    ->name('verification.notice');
+        Route::get('/email/verify', [EmailVerificationPromptController::class])
+            ->middleware(['auth'])
+            ->name('verification.notice');
 
-        Route::get('/email/verify/{id}/{hash}', 'VerifyEmailController')
-                    ->middleware(['auth', 'signed', 'throttle:6,1'])
-                    ->name('verification.verify');
+        Route::get('/email/verify/{id}/{hash}', [VerifyEmailController::class])
+            ->middleware(['auth', 'signed', 'throttle:6,1'])
+            ->name('verification.verify');
 
-        Route::post('/email/verification-notification', 'EmailVerificationNotificationController@store')
-                    ->middleware(['auth', 'throttle:6,1'])
-                    ->name('verification.send');
+        Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+            ->middleware(['auth', 'throttle:6,1'])
+            ->name('verification.send');
     }
 
     // Profile Information...
     if (Features::enabled(Features::updateProfileInformation())) {
-        Route::put('/user/profile-information', 'ProfileInformationController@update')
-                    ->middleware(['auth']);
+        Route::put('/user/profile-information', [ProfileInformationController::class, 'update'])
+            ->middleware(['auth']);
     }
 
     // Passwords...
     if (Features::enabled(Features::updatePasswords())) {
-        Route::put('/user/password', 'PasswordController@update')
-                    ->middleware(['auth']);
+        Route::put('/user/password', [PasswordController::class, 'update'])
+            ->middleware(['auth']);
     }
 
     // Password Confirmation...
-    Route::get('/user/confirm-password', 'ConfirmablePasswordController@show')
-                    ->middleware(['auth'])
-                    ->name('password.confirm');
+    Route::get('/user/confirm-password', [ConfirmablePasswordController::class, 'show'])
+        ->middleware(['auth'])
+        ->name('password.confirm');
 
-    Route::post('/user/confirm-password', 'ConfirmablePasswordController@store')
-                    ->middleware(['auth']);
+    Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware(['auth']);
 
-    Route::get('/user/confirmed-password-status', 'ConfirmedPasswordStatusController@show')
-                    ->middleware(['auth'])
-                    ->name('password.confirmation');
+    Route::get('/user/confirmed-password-status', [ConfirmedPasswordStatusController::class, 'show'])
+        ->middleware(['auth'])
+        ->name('password.confirmation');
 
     // Two Factor Authentication...
     if (Features::enabled(Features::twoFactorAuthentication())) {
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
-                        ? ['auth', 'password.confirm']
-                        : ['auth'];
+            ? ['auth', 'password.confirm']
+            : ['auth'];
 
-        Route::post('/user/two-factor-authentication', 'TwoFactorAuthenticationController@store')
-                    ->middleware($twoFactorMiddleware);
+        Route::post('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'store'])
+            ->middleware($twoFactorMiddleware);
 
-        Route::delete('/user/two-factor-authentication', 'TwoFactorAuthenticationController@destroy')
-                    ->middleware($twoFactorMiddleware);
+        Route::delete('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'destroy'])
+            ->middleware($twoFactorMiddleware);
 
-        Route::get('/user/two-factor-qr-code', 'TwoFactorQrCodeController@show')
-                    ->middleware($twoFactorMiddleware);
+        Route::get('/user/two-factor-qr-code', [TwoFactorQrCodeController::class, 'show'])
+            ->middleware($twoFactorMiddleware);
 
-        Route::get('/user/two-factor-recovery-codes', 'RecoveryCodeController@index')
-                    ->middleware($twoFactorMiddleware);
+        Route::get('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'index'])
+            ->middleware($twoFactorMiddleware);
 
-        Route::post('/user/two-factor-recovery-codes', 'RecoveryCodeController@store')
-                    ->middleware($twoFactorMiddleware);
+        Route::post('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'store'])
+            ->middleware($twoFactorMiddleware);
     }
 });

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -74,11 +74,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     // Email Verification...
     if (Features::enabled(Features::emailVerification())) {
-        Route::get('/email/verify', EmailVerificationPromptController::class)
+        Route::get('/email/verify', [EmailVerificationPromptController::class, '__invoke'])
             ->middleware(['auth'])
             ->name('verification.notice');
 
-        Route::get('/email/verify/{id}/{hash}', VerifyEmailController::class)
+        Route::get('/email/verify/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
             ->middleware(['auth', 'signed', 'throttle:6,1'])
             ->name('verification.verify');
 

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -74,11 +74,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     // Email Verification...
     if (Features::enabled(Features::emailVerification())) {
-        Route::get('/email/verify', [EmailVerificationPromptController::class])
+        Route::get('/email/verify', EmailVerificationPromptController::class)
             ->middleware(['auth'])
             ->name('verification.notice');
 
-        Route::get('/email/verify/{id}/{hash}', [VerifyEmailController::class])
+        Route::get('/email/verify/{id}/{hash}', VerifyEmailController::class)
             ->middleware(['auth', 'signed', 'throttle:6,1'])
             ->name('verification.verify');
 


### PR DESCRIPTION
Addition for issue #13, This makes customizing routes easier.
Jetstream routes are also defined this way.

For instance: I needed to customize the url paths. So i turned the default routes off with the Fortify::ignoreRoutes(); option in my provider and copied the routes file. After that, the controller paths were broken. This commit fixes that scenario.
