### PR TITLE
[1.x] tfa should not be allowed to use twice

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -39,6 +39,7 @@ class AddTwoFactorColumnsToUsersTable extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('two_factor_secret');
             $table->dropColumn('two_factor_recovery_codes');
+            $table->dropColumn('two_factor_timestamp');
         });
     }
 }

--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -21,6 +21,11 @@ class AddTwoFactorColumnsToUsersTable extends Migration
             $table->text('two_factor_recovery_codes')
                     ->after('two_factor_secret')
                     ->nullable();
+
+            $table->string('two_factor_timestamp')
+                    ->after('two_factor_recovery_codes')
+                    ->default('1')
+                    ->nullable();
         });
     }
 

--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -21,11 +21,6 @@ class AddTwoFactorColumnsToUsersTable extends Migration
             $table->text('two_factor_recovery_codes')
                     ->after('two_factor_secret')
                     ->nullable();
-
-            $table->string('two_factor_timestamp')
-                    ->after('two_factor_recovery_codes')
-                    ->default('1')
-                    ->nullable();
         });
     }
 
@@ -39,7 +34,6 @@ class AddTwoFactorColumnsToUsersTable extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('two_factor_secret');
             $table->dropColumn('two_factor_recovery_codes');
-            $table->dropColumn('two_factor_timestamp');
         });
     }
 }

--- a/src/Contracts/TwoFactorAuthenticationProvider.php
+++ b/src/Contracts/TwoFactorAuthenticationProvider.php
@@ -30,12 +30,4 @@ interface TwoFactorAuthenticationProvider
      * @return int|bool
      */
     public function verify($secret, $code, $ts = null);
-
-    /**
-     * Provide current otp code based on secret.
-     *
-     * @param  string $secret
-     * @return string
-     */
-    public function getCurrentOtp($secret);
 }

--- a/src/Contracts/TwoFactorAuthenticationProvider.php
+++ b/src/Contracts/TwoFactorAuthenticationProvider.php
@@ -32,7 +32,7 @@ interface TwoFactorAuthenticationProvider
     public function verify($secret, $code, $ts = null);
 
     /**
-     * Provide current otp code based on secret
+     * Provide current otp code based on secret.
      *
      * @param  string $secret
      * @return string

--- a/src/Contracts/TwoFactorAuthenticationProvider.php
+++ b/src/Contracts/TwoFactorAuthenticationProvider.php
@@ -26,7 +26,16 @@ interface TwoFactorAuthenticationProvider
      *
      * @param  string  $secret
      * @param  string  $code
-     * @return bool
+     * @param  string  $ts
+     * @return int|bool
      */
-    public function verify($secret, $code);
+    public function verify($secret, $code, $ts = null);
+
+    /**
+     * Provide current otp code based on secret
+     *
+     * @param  string $secret
+     * @return string
+     */
+    public function getCurrentOtp($secret);
 }

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -50,11 +50,18 @@ class TwoFactorAuthenticatedSessionController extends Controller
     public function store(TwoFactorLoginRequest $request)
     {
         $user = $request->challengedUser();
+        $timestamp = false;
 
         if ($code = $request->validRecoveryCode()) {
             $user->replaceRecoveryCode($code);
-        } elseif (! $request->hasValidCode()) {
+        } elseif (! $timestamp = $request->hasValidCode()) {
             return app(FailedTwoFactorLoginResponse::class);
+        }
+
+        if ($timestamp) {
+            $user->forceFill([
+                'two_factor_timestamp' => $timestamp,
+            ])->save();
         }
 
         $this->guard->login($user, $request->remember());

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -59,9 +59,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
         }
 
         if ($timestamp) {
-            $user->forceFill([
-                'two_factor_timestamp' => $timestamp,
-            ])->save();
+            cache()->put("user-{$user->id}-2fa-timestamp", $timestamp, now()->addMinutes(5));
         }
 
         $this->guard->login($user, $request->remember());

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -54,11 +54,19 @@ class TwoFactorLoginRequest extends FormRequest
      */
     public function hasValidCode()
     {
+        $timestamp = 1;
+        $user = $this->challengedUser();
+
+        $timestampKey = "user-{$user->id}-2fa-timestamp";
+        if (cache()->has($timestampKey)) {
+            $timestamp = cache()->get($timestampKey);
+        }
+
         if ($this->code) {
             return app(TwoFactorAuthenticationProvider::class)->verify(
-                decrypt($this->challengedUser()->two_factor_secret),
+                decrypt($user->two_factor_secret),
                 $this->code,
-                $this->challengedUser()->two_factor_timestamp
+                $timestamp
             );
         }
 

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -50,13 +50,19 @@ class TwoFactorLoginRequest extends FormRequest
     /**
      * Determine if the request has a valid two factor code.
      *
-     * @return bool
+     * @return int|bool
      */
     public function hasValidCode()
     {
-        return $this->code && app(TwoFactorAuthenticationProvider::class)->verify(
-            decrypt($this->challengedUser()->two_factor_secret), $this->code
-        );
+        if ($this->code) {
+            return app(TwoFactorAuthenticationProvider::class)->verify(
+                decrypt($this->challengedUser()->two_factor_secret),
+                $this->code,
+                $this->challengedUser()->two_factor_timestamp
+            );
+        }
+
+        return false;
     }
 
     /**

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -53,10 +53,21 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
      *
      * @param  string  $secret
      * @param  string  $code
-     * @return bool
+     * @return int|bool
      */
-    public function verify($secret, $code)
+    public function verify($secret, $code, $ts = null)
     {
-        return $this->engine->verifyKey($secret, $code);
+        return $this->engine->verifyKeyNewer($secret, $code, $ts);
+    }
+
+    /**
+     * Provide current otp code based on secret
+     *
+     * @param  string $secret
+     * @return string
+     */
+    public function getCurrentOtp($secret)
+    {
+        return $this->engine->getCurrentOtp(decrypt($secret));
     }
 }

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -59,15 +59,4 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     {
         return $this->engine->verifyKeyNewer($secret, $code, $ts);
     }
-
-    /**
-     * Provide current otp code based on secret.
-     *
-     * @param  string $secret
-     * @return string
-     */
-    public function getCurrentOtp($secret)
-    {
-        return $this->engine->getCurrentOtp(decrypt($secret));
-    }
 }

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -61,7 +61,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     }
 
     /**
-     * Provide current otp code based on secret
+     * Provide current otp code based on secret.
      *
      * @param  string $secret
      * @return string

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -2,18 +2,17 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Mockery;
-use Carbon\Carbon;
-use PragmaRX\Google2FA\Google2FA;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
-use Laravel\Fortify\LoginRateLimiter;
 use Illuminate\Support\Facades\Schema;
-use Laravel\Fortify\FortifyServiceProvider;
-use Laravel\Fortify\TwoFactorAuthenticatable;
-use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\FortifyServiceProvider;
+use Laravel\Fortify\LoginRateLimiter;
+use Laravel\Fortify\TwoFactorAuthenticatable;
+use Mockery;
+use PragmaRX\Google2FA\Google2FA;
 
 class AuthenticatedSessionControllerTest extends OrchestraTestCase
 {

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -2,17 +2,18 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Illuminate\Contracts\Auth\Authenticatable;
+use Mockery;
+use Carbon\Carbon;
+use PragmaRX\Google2FA\Google2FA;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\LoginRateLimiter;
 use Illuminate\Support\Facades\Schema;
+use Laravel\Fortify\FortifyServiceProvider;
+use Laravel\Fortify\TwoFactorAuthenticatable;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
-use Laravel\Fortify\FortifyServiceProvider;
-use Laravel\Fortify\LoginRateLimiter;
-use Laravel\Fortify\TwoFactorAuthenticatable;
-use Mockery;
-use PragmaRX\Google2FA\Google2FA;
 
 class AuthenticatedSessionControllerTest extends OrchestraTestCase
 {

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -2,17 +2,17 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Mockery;
-use PragmaRX\Google2FA\Google2FA;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
-use Laravel\Fortify\LoginRateLimiter;
 use Illuminate\Support\Facades\Schema;
-use Laravel\Fortify\FortifyServiceProvider;
-use Laravel\Fortify\TwoFactorAuthenticatable;
-use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\FortifyServiceProvider;
+use Laravel\Fortify\LoginRateLimiter;
+use Laravel\Fortify\TwoFactorAuthenticatable;
+use Mockery;
+use PragmaRX\Google2FA\Google2FA;
 
 class AuthenticatedSessionControllerTest extends OrchestraTestCase
 {


### PR DESCRIPTION
Two factor authentication code was previously being able to use twice. So when a user is logged in, if anyone knows password and current OTP, they will be allowed to login.

Now, with this PR, OTP will be only allowed one time. This does not affect recovery code and it will work as it is.

