### PR TITLE
[1.x] Add illuminate/support dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": "^7.3",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^2.0",
+        "illuminate/support": "^8.0",
         "pragmarx/google2fa": "^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
This at least makes sure that composer can resolve Fortify's dependency on the Laravel framework properly.