### PR TITLE
added optional $secret variable to EnableTwoFactorAuthentication.php

### DIFF
--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -31,7 +31,7 @@ class EnableTwoFactorAuthentication
     }
 
     /**
-     * Enable two factor authentication for the user after checking if a optional given secret is valid
+     * Enable two factor authentication for the user after checking if a optional given secret is valid.
      *
      * @param  mixed  $user
      * @param ?string $secret
@@ -47,7 +47,7 @@ class EnableTwoFactorAuthentication
         }
 
         $user->forceFill([
-            'two_factor_secret' => (!$secret ? encrypt($this->provider->generateSecretKey()) : encrypt($secret)),
+            'two_factor_secret' => (! $secret ? encrypt($this->provider->generateSecretKey()) : encrypt($secret)),
             'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
                 return RecoveryCode::generate();
             })->all())),

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -5,6 +5,10 @@ namespace Laravel\Fortify\Actions;
 use Illuminate\Support\Collection;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\RecoveryCode;
+use PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException;
+use PragmaRX\Google2FA\Exceptions\InvalidCharactersException;
+use PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException;
+use PragmaRX\Google2FA\Support\Constants;
 
 class EnableTwoFactorAuthentication
 {
@@ -27,18 +31,122 @@ class EnableTwoFactorAuthentication
     }
 
     /**
-     * Enable two factor authentication for the user.
+     * Enable two factor authentication for the user after checking if a optional given secret is valid
      *
      * @param  mixed  $user
+     * @param ?string $secret
+     * @throws \PragmaRX\Google2FA\Exceptions\InvalidCharactersException
+     * @throws \PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException
+     * @throws \PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException
      * @return void
      */
-    public function __invoke($user)
+    public function __invoke($user, $secret = null)
     {
+        if ($secret) {
+            $this->validateSecret($secret);
+        }
+
         $user->forceFill([
-            'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
+            'two_factor_secret' => (!$secret ? encrypt($this->provider->generateSecretKey()) : encrypt($secret)),
             'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
                 return RecoveryCode::generate();
             })->all())),
         ])->save();
     }
+
+    /**
+     * Validate the secret.
+     *
+     * @param string $b32
+     *
+     * @throws InvalidCharactersException
+     * @throws SecretKeyTooShortException
+     * @throws IncompatibleWithGoogleAuthenticatorException
+     */
+    protected function validateSecret($b32)
+    {
+        $this->checkForValidCharacters($b32);
+
+        $this->checkGoogleAuthenticatorCompatibility($b32);
+
+        $this->checkIsBigEnough($b32);
+    }
+
+    /**
+     * Calculate char count bits.
+     *
+     * @param string $b32
+     *
+     * @return int
+     */
+    protected function charCountBits($b32)
+    {
+        return strlen($b32) * 8;
+    }
+
+    /**
+     * Check if the string length is power of two.
+     *
+     * @param string $b32
+     *
+     * @return bool
+     */
+    protected function isCharCountNotAPowerOfTwo($b32)
+    {
+        return (strlen($b32) & (strlen($b32) - 1)) !== 0;
+    }
+
+    /**
+     * Check if the secret key is compatible with Google Authenticator.
+     *
+     * @param string $b32
+     *
+     * @throws IncompatibleWithGoogleAuthenticatorException
+     */
+    protected function checkGoogleAuthenticatorCompatibility($b32)
+    {
+        if (
+            $this->isCharCountNotAPowerOfTwo($b32) // Google Authenticator requires it to be a power of 2 base32 length string
+        ) {
+            throw new IncompatibleWithGoogleAuthenticatorException();
+        }
+    }
+
+    /**
+     * Check if all secret key characters are valid.
+     *
+     * @param string $b32
+     *
+     * @throws InvalidCharactersException
+     */
+    protected function checkForValidCharacters($b32)
+    {
+        if (
+            preg_replace('/[^'.Constants::VALID_FOR_B32.']/', '', $b32) !==
+            $b32
+        ) {
+            throw new InvalidCharactersException();
+        }
+    }
+
+    /**
+     * Check if secret key length is big enough.
+     *
+     * @param string $b32
+     *
+     * @throws SecretKeyTooShortException
+     */
+    protected function checkIsBigEnough($b32)
+    {
+        // Minimum = 128 bits
+        // Recommended = 160 bits
+        // Compatible with Google Authenticator = 256 bits
+
+        if (
+            $this->charCountBits($b32) < 128
+        ) {
+            throw new SecretKeyTooShortException();
+        }
+    }
+
 }

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -148,5 +148,4 @@ class EnableTwoFactorAuthentication
             throw new SecretKeyTooShortException();
         }
     }
-
 }


### PR DESCRIPTION
With this PR it is possible to enable TwoFactorAuthentication with an already generated secret
This is necessary if you want to check if the user successfully activated his device before you save the encrypted secret to the database. Logic for checking has to be in the front-end (e.g. jetstream).
Related to : https://github.com/laravel/fortify/issues/47
Related to: https://github.com/laravel/jetstream/issues/74


