### PR TITLE
otp real test without mock

### DIFF
--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Fortify\Contracts\LoginViewResponse;
-use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\FortifyServiceProvider;
 use Laravel\Fortify\LoginRateLimiter;
 use Laravel\Fortify\TwoFactorAuthenticatable;


### PR DESCRIPTION
Updating two factor authentication test to work without mock, like using real otp code generated from Google2FA package.