### PR TITLE
[1.x] Add routes middleware option to configuration

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -4,6 +4,7 @@ use Laravel\Fortify\Features;
 
 return [
     'guard' => 'web',
+    'middleware' => ['web'],
     'passwords' => 'users',
     'username' => 'email',
     'email' => 'email',

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -29,7 +29,7 @@ Route::middleware(config('fortify.middleware'))->group(function () {
     Route::post('/login', [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
             'guest',
-            $limiter ? 'throttle:' . $limiter : null,
+            $limiter ? 'throttle:'.$limiter : null,
         ]));
 
     Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -18,7 +18,7 @@ use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 
-Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
+Route::middleware(config('fortify.middleware'))->group(function () {
     // Authentication...
     Route::get('/login', [AuthenticatedSessionController::class, 'create'])
         ->middleware(['guest'])
@@ -29,7 +29,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     Route::post('/login', [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
             'guest',
-            $limiter ? 'throttle:'.$limiter : null,
+            $limiter ? 'throttle:' . $limiter : null,
         ]));
 
     Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -20,6 +20,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fortify Routes Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which middleware Fortify will use while processing
+    | the requested route. This configured value must be an array. You may
+    | change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
     | Fortify Password Broker
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Hi everyone!. 

I have created this PR with the idea of ​​being able to provide the end user with a mechanism to modify which ```middleware``` Laravel Fortify is going to use in each of its routes.

Basically the user would just have to go to the config file: ```config/fortify.php``` and adjust the value of the ```middleware``` key according to their needs.

By default the value of this key is:

```
'middleware' => ['web'],
```

I have also added a short description to the option within the configuration file. Regards