### PR TITLE
[1.x] Resend email verification after user update

### DIFF
--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -37,9 +37,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             ])->save();
 
             $user->sendEmailVerificationNotification();
-        }
-
-        else {
+        } else {
             $user->forceFill([
                 'name' => $input['name'],
                 'email' => $input['email'],


### PR DESCRIPTION
When Email Verification is enabled, send a verification request to the new email address when a user updates their email address.
Optional commented line will null the email_verified_at value, which will force the user to verify the new address before doing anything else while logged in.