### PR TITLE
Added validation to the reset password page

### DIFF
--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -57,6 +57,7 @@ class NewPasswordController extends Controller
         $request->validate([
             'token' => 'required',
             Fortify::email() => 'required|email',
+            'password' => 'required|min:8|confirmed',
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we


### PR DESCRIPTION
Validations for `password` and `password_confirmation` inputs were not present when resetting a password.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
