### PR TITLE
Removed unnecessary/unused variable

### DIFF
--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -64,7 +64,7 @@ class NewPasswordController extends Controller
         // database. Otherwise we will parse the error and return the response.
         $status = $this->broker()->reset(
             $request->only(Fortify::email(), 'password', 'password_confirmation', 'token'),
-            function ($user, $password) use ($request) {
+            function ($user) use ($request) {
                 app(ResetsUserPasswords::class)->reset($user, $request->all());
 
                 app(CompletePasswordReset::class)($this->guard, $user);


### PR DESCRIPTION
I believe `, $password` was a typo or copied by mistake from the reset password documentation (here)[https://laravel.com/docs/8.x/passwords#resetting-the-password].

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
