### PR TITLE
Fix flawed logic in the UpdateUserProfileInformation action

### DIFF
--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -30,15 +30,18 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             ],
         ])->validateWithBag('updateProfileInformation');
 
-        if ($input['email'] !== $user->email &&
-            $user instanceof MustVerifyEmail) {
+        if ($input['email'] !== $user->email && $user instanceof MustVerifyEmail) {
+            $user->forceFill([
+                'name' => $input['name'],
+                'email' => $input['email'],
+                'email_verified_at' => null,
+            ])->save();
             $user->sendEmailVerificationNotification();
         }
 
         $user->forceFill([
             'name' => $input['name'],
-            'email' => $input['email'],
-            'email_verified_at' => null,
+            'email' => $input['email']
         ])->save();
     }
 }

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -36,6 +36,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'email' => $input['email'],
                 'email_verified_at' => null,
             ])->save();
+
             $user->sendEmailVerificationNotification();
 
             return;

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -37,7 +37,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'email_verified_at' => null,
             ])->save();
             $user->sendEmailVerificationNotification();
-            
+
             return;
         }
 

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -37,6 +37,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'email_verified_at' => null,
             ])->save();
             $user->sendEmailVerificationNotification();
+            
             return;
         }
 

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -37,6 +37,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'email_verified_at' => null,
             ])->save();
             $user->sendEmailVerificationNotification();
+            return;
         }
 
         $user->forceFill([

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -42,7 +42,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
 
         $user->forceFill([
             'name' => $input['name'],
-            'email' => $input['email']
+            'email' => $input['email'],
         ])->save();
     }
 }


### PR DESCRIPTION
The issue at hand has already been disclosed in #67 . In short, this PR prevents the package from forcing a user to reverify their email when simply updating their profile information (without changing their email).

Closes #67 