### PR TITLE
Allow 'confirmPasswordView' to use view prefixes

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -90,6 +90,7 @@ class Fortify
         static::requestPasswordResetLinkView($prefix.'forgot-password');
         static::resetPasswordView($prefix.'reset-password');
         static::verifyEmailView($prefix.'verify-email');
+        static::confirmPasswordView($prefix.'confirm-password');
     }
 
     /**


### PR DESCRIPTION
Hi,

'confirmPasswordView' was not working when working with prefixes for views. It seems that the required function call was missing. This PR is to add this function call.

Thanks