### PR TITLE
Send JSON response if request is an AJAX request

### DIFF
--- a/src/Http/Controllers/EmailVerificationNotificationController.php
+++ b/src/Http/Controllers/EmailVerificationNotificationController.php
@@ -2,9 +2,8 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
 class EmailVerificationNotificationController extends Controller

--- a/src/Http/Controllers/EmailVerificationNotificationController.php
+++ b/src/Http/Controllers/EmailVerificationNotificationController.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 
 class EmailVerificationNotificationController extends Controller
@@ -18,14 +19,14 @@ class EmailVerificationNotificationController extends Controller
     {
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
-                        ? new Response('', 204)
+                        ? new JsonResponse('', 204)
                         : redirect(config('fortify.home'));
         }
 
         $request->user()->sendEmailVerificationNotification();
 
         return $request->wantsJson()
-                    ? new Response('', 202)
+                    ? new JsonResponse('', 202)
                     : back()->with('status', 'verification-link-sent');
     }
 }

--- a/src/Http/Controllers/PasswordController.php
+++ b/src/Http/Controllers/PasswordController.php
@@ -2,9 +2,8 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 

--- a/src/Http/Controllers/PasswordController.php
+++ b/src/Http/Controllers/PasswordController.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
@@ -21,7 +22,7 @@ class PasswordController extends Controller
         $updater->update($request->user(), $request->all());
 
         return $request->wantsJson()
-                    ? new Response('', 200)
+                    ? new JsonResponse('', 200)
                     : back()->with('status', 'password-updated');
     }
 }

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
@@ -22,7 +23,7 @@ class ProfileInformationController extends Controller
         $updater->update($request->user(), $request->all());
 
         return $request->wantsJson()
-                    ? new Response('', 200)
+                    ? new JsonResponse('', 200)
                     : back()->with('status', 'profile-information-updated');
     }
 }

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -2,9 +2,8 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 
@@ -38,7 +39,7 @@ class RecoveryCodeController extends Controller
         $generate($request->user());
 
         return $request->wantsJson()
-                    ? response('', 200)
+                    ? new JsonResponse('', 200)
                     : back()->with('status', 'recovery-codes-generated');
     }
 }

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
@@ -21,7 +22,7 @@ class TwoFactorAuthenticationController extends Controller
         $enable($request->user());
 
         return $request->wantsJson()
-                    ? response('', 200)
+                    ? new JsonResponse('', 200)
                     : back()->with('status', 'two-factor-authentication-enabled');
     }
 
@@ -37,7 +38,7 @@ class TwoFactorAuthenticationController extends Controller
         $disable($request->user());
 
         return $request->wantsJson()
-                    ? response('', 200)
+                    ? new JsonResponse('', 200)
                     : back()->with('status', 'two-factor-authentication-disabled');
     }
 }

--- a/src/Http/Responses/LogoutResponse.php
+++ b/src/Http/Responses/LogoutResponse.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 
 class LogoutResponse implements LogoutResponseContract
@@ -16,7 +17,7 @@ class LogoutResponse implements LogoutResponseContract
     public function toResponse($request)
     {
         return $request->wantsJson()
-                    ? new Response('', 204)
+                    ? new JsonResponse('', 204)
                     : redirect('/');
     }
 }

--- a/src/Http/Responses/LogoutResponse.php
+++ b/src/Http/Responses/LogoutResponse.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 
 class LogoutResponse implements LogoutResponseContract

--- a/src/Http/Responses/PasswordConfirmedResponse.php
+++ b/src/Http/Responses/PasswordConfirmedResponse.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 
 class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
@@ -16,7 +17,7 @@ class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
     public function toResponse($request)
     {
         return $request->wantsJson()
-                    ? new Response('', 201)
+                    ? new JsonResponse('', 201)
                     : redirect()->intended(config('fortify.home'));
     }
 }

--- a/src/Http/Responses/PasswordConfirmedResponse.php
+++ b/src/Http/Responses/PasswordConfirmedResponse.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 
 class PasswordConfirmedResponse implements PasswordConfirmedResponseContract

--- a/src/Http/Responses/RegisterResponse.php
+++ b/src/Http/Responses/RegisterResponse.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 
 class RegisterResponse implements RegisterResponseContract
@@ -16,7 +17,7 @@ class RegisterResponse implements RegisterResponseContract
     public function toResponse($request)
     {
         return $request->wantsJson()
-                    ? new Response('', 201)
+                    ? new JsonResponse('', 201)
                     : redirect(config('fortify.home'));
     }
 }

--- a/src/Http/Responses/RegisterResponse.php
+++ b/src/Http/Responses/RegisterResponse.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 
 class RegisterResponse implements RegisterResponseContract

--- a/src/Http/Responses/TwoFactorLoginResponse.php
+++ b/src/Http/Responses/TwoFactorLoginResponse.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
+use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 
 class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
@@ -15,7 +16,7 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
     public function toResponse($request)
     {
         return $request->wantsJson()
-                    ? response('', 204)
+                    ? new JsonResponse('', 204)
                     : redirect(config('fortify.home'));
     }
 }


### PR DESCRIPTION
Hi,

If client has requested for a JSON response, as in case of an AJAX request, then Fortify should return JSON response. Currently Fortify returns a plain response which may throw errors on client side (jQuery for ex).

This PR fixes this bug.

Thanks