### PR TITLE
[1.x] Option to customize translations

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Laravel Fortify Validation Language Lines
+|--------------------------------------------------------------------------
+|
+| The following language lines contain the default error messages used by
+| the validator class inside Laravel Fortify. Feel free to tweak each
+| of these messages here.
+|
+*/
+
+return [
+    'password' => [
+        'min' => 'The :attribute must be at least :length characters.',
+        'uppercase' => 'The :attribute must be at least :length characters and contain at least one uppercase character.',
+        'numeric' => 'The :attribute must be at least :length characters and contain at least one number.',
+        'special_character' => 'The :attribute must be at least :length characters and contain at least one special character.',
+        'uppercase_or_numeric' => 'The :attribute must be at least :length characters and contain at least one uppercase character and one number.',
+        'uppercase_or_special_character' => 'The :attribute must be at least :length characters and contain at least one uppercase character and one special character.',
+        'uppercase_or_numeric_or_special_character' => 'The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.',
+    ]
+];

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -82,6 +82,7 @@ class FortifyServiceProvider extends ServiceProvider
     {
         $this->configurePublishing();
         $this->configureRoutes();
+        $this->loadTranslations();
     }
 
     /**
@@ -108,6 +109,10 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
+
+            $this->publishes([
+                __DIR__.'/../resources/lang' => resource_path('lang/vendor/fortify'),
+            ], 'fortify-translations');
         }
     }
 
@@ -127,5 +132,15 @@ class FortifyServiceProvider extends ServiceProvider
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });
         }
+    }
+
+    /**
+     * Load translations offered by the package.
+     *
+     * @return void
+     */
+    protected function loadTranslations()
+    {
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'fortify');
     }
 }

--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -81,47 +81,47 @@ class Password implements Rule
             case $this->requireUppercase
                 && ! $this->requireNumeric
                 && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character.', [
+                return __('fortify::validation.password.uppercase', [
                     'length' => $this->length,
                 ]);
 
             case $this->requireNumeric
                 && ! $this->requireUppercase
                 && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one number.', [
+                return __('fortify::validation.password.numeric', [
                     'length' => $this->length,
                 ]);
 
             case $this->requireSpecialCharacter
                 && ! $this->requireUppercase
                 && ! $this->requireNumeric:
-                return __('The :attribute must be at least :length characters and contain at least one special character.', [
+                return __('fortify::validation.password.special_character', [
                     'length' => $this->length,
                 ]);
 
             case $this->requireUppercase
                 && $this->requireNumeric
                 && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character and one number.', [
+                return __('fortify::validation.password.uppercase_or_numeric', [
                     'length' => $this->length,
                 ]);
 
             case $this->requireUppercase
                 && $this->requireSpecialCharacter
                 && ! $this->requireNumeric:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character and one special character.', [
+                return __('fortify::validation.password.uppercase_or_special_character', [
                     'length' => $this->length,
                 ]);
 
             case $this->requireUppercase
                 && $this->requireNumeric
                 && $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.', [
+                return __('fortify::validation.passwor  d.uppercase_or_numeric_or_special_character', [
                     'length' => $this->length,
                 ]);
 
             default:
-                return __('The :attribute must be at least :length characters.', [
+                return __('fortify::validation.password.min', [
                     'length' => $this->length,
                 ]);
         }


### PR DESCRIPTION
Hello, as a result of having read issue #73, I have motivated myself to create a solution that can solve the problem. Basically this PR, adds the option to be able to customize the validation messages, and creates the bases to be able to make use of the translations if it is required in the future. 

Initially I have only created a file:
```
resources/lang/en/validation.php
```
that contains the validation messages that are required in the rules file:
```
src/Rules/Password.php
```

In this way, if the user wanted to modify the message returned by the validation, he would only have to publish the translations of the package in this way:

```
php artisan vendor:publish --tag fortify-translations
```
As a consequence of the result of this command, a file should be created in the application within the path:

```
resources/lang/vendor/fortify/en/validation.php
```

In this way, I think it is much more convenient for the user to be able to modify these messages. 

@taylorotwell I haven't really come up with a better name for the keys within the array of the file that contains the validation messages. I hope my idea can be accepted .. Regards!