### PR TITLE
[1.x] Fix for empty password during confirmation

### DIFF
--- a/src/Actions/ConfirmPassword.php
+++ b/src/Actions/ConfirmPassword.php
@@ -29,10 +29,10 @@ class ConfirmPassword
      * Confirm the user's password using a custom callback.
      *
      * @param  mixed  $user
-     * @param  string  $password
+     * @param  string|null  $password
      * @return bool
      */
-    protected function confirmPasswordUsingCustomCallback($user, string $password)
+    protected function confirmPasswordUsingCustomCallback($user, ?string $password = null)
     {
         return call_user_func(
             Fortify::$confirmPasswordsUsingCallback,

--- a/src/Actions/ConfirmPassword.php
+++ b/src/Actions/ConfirmPassword.php
@@ -12,10 +12,10 @@ class ConfirmPassword
      *
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @param  mixed  $user
-     * @param  string  $password
+     * @param  string|null  $password
      * @return bool
      */
-    public function __invoke(StatefulGuard $guard, $user, string $password)
+    public function __invoke(StatefulGuard $guard, $user, ?string $password = null)
     {
         $username = config('fortify.username');
 

--- a/tests/ConfirmablePasswordControllerTest.php
+++ b/tests/ConfirmablePasswordControllerTest.php
@@ -105,6 +105,26 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         Fortify::$confirmPasswordsUsingCallback = null;
     }
 
+    public function test_password_confirmation_can_be_customized_and_fail_without_password()
+    {
+        Fortify::$confirmPasswordsUsingCallback = function () {
+            return true;
+        };
+
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['url.intended' => 'http://foo.com/bar'])
+            ->post(
+                '/user/confirm-password',
+                ['password' => null]
+            );
+
+        $response->assertSessionHas('auth.password_confirmed_at');
+        $response->assertRedirect('http://foo.com/bar');
+
+        Fortify::$confirmPasswordsUsingCallback = null;
+    }
+
     public function test_password_can_be_confirmed_with_json()
     {
         $response = $this->actingAs($this->user)

--- a/tests/ConfirmablePasswordControllerTest.php
+++ b/tests/ConfirmablePasswordControllerTest.php
@@ -53,7 +53,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         $response->assertRedirect('http://foo.com/bar');
     }
 
-    public function test_password_confirmation_can_fail()
+    public function test_password_confirmation_can_fail_with_an_invalid_password()
     {
         $response = $this->withoutExceptionHandling()
             ->actingAs($this->user)
@@ -61,6 +61,22 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
             ->post(
                 '/user/confirm-password',
                 ['password' => 'invalid']
+            );
+
+        $response->assertSessionHasErrors(['password']);
+        $response->assertSessionMissing('auth.password_confirmed_at');
+        $response->assertRedirect();
+        $this->assertNotEquals($response->getTargetUrl(), 'http://foo.com/bar');
+    }
+
+    public function test_password_confirmation_can_fail_without_a_password()
+    {
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['url.intended' => 'http://foo.com/bar'])
+            ->post(
+                '/user/confirm-password',
+                ['password' => null]
             );
 
         $response->assertSessionHasErrors(['password']);


### PR DESCRIPTION
Allow an empty password to be given and let it behave as an invalid password.

Before this fix, if the user leaves the field empty, a server error would occur. Now, a nice validation error will show.

---

Fixes https://github.com/laravel/fortify/issues/86