### PR TITLE
Add name to Profile update and Password update routes.

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -82,13 +82,15 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     // Profile Information...
     if (Features::enabled(Features::updateProfileInformation())) {
         Route::put('/user/profile-information', [ProfileInformationController::class, 'update'])
-            ->middleware(['auth']);
+            ->middleware(['auth'])
+            ->name('user-profile-information.update');
     }
 
     // Passwords...
     if (Features::enabled(Features::updatePasswords())) {
         Route::put('/user/password', [PasswordController::class, 'update'])
-            ->middleware(['auth']);
+            ->middleware(['auth'])
+            ->name('user-password.update');
     }
 
     // Password Confirmation...


### PR DESCRIPTION
Add name to `/user/profile-information` and `/user/password` routes.

```php
Route::put('/user/profile-information', [ProfileInformationController::class, 'update'])
            ->middleware(['auth'])
            ->name('user-profile-information.update');
```

```php
Route::put('/user/password', [PasswordController::class, 'update'])
            ->middleware(['auth'])
            ->name('user-password.update');
```

## Benifit
Who extend Fortify package will easily access update profile and update password route by name.