### PR TITLE
Allow running code after the user is registered

### DIFF
--- a/src/Contracts/CreatesNewUsers.php
+++ b/src/Contracts/CreatesNewUsers.php
@@ -11,4 +11,12 @@ interface CreatesNewUsers
      * @return mixed
      */
     public function create(array $input);
+
+    /**
+     * The user has been created.
+     *
+     * @param  mixed  $user
+     * @return mixed
+     */
+    public function created($user);
 }

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -48,13 +48,12 @@ class RegisteredUserController extends Controller
      * @param  \Laravel\Fortify\Contracts\CreatesNewUsers  $creator
      * @return \Laravel\Fortify\Contracts\RegisterResponse
      */
-    public function store(Request $request,
-                          CreatesNewUsers $creator): RegisterResponse
+    public function store(Request $request, CreatesNewUsers $creator): RegisterResponse
     {
         event(new Registered($user = $creator->create($request->all())));
 
         $this->guard->login($user);
 
-        return app(RegisterResponse::class);
+        return $creator->created($user) ?? app(RegisterResponse::class);
     }
 }

--- a/stubs/CreateNewUser.php
+++ b/stubs/CreateNewUser.php
@@ -31,4 +31,15 @@ class CreateNewUser implements CreatesNewUsers
             'password' => Hash::make($input['password']),
         ]);
     }
+
+    /**
+     * The user has been created.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function created($user)
+    {
+        //
+    }
 }

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -26,7 +26,9 @@ class RegisteredUserControllerTest extends OrchestraTestCase
     {
         $this->mock(CreatesNewUsers::class)
                     ->shouldReceive('create')
-                    ->andReturn(Mockery::mock(Authenticatable::class));
+                    ->andReturn(Mockery::mock(Authenticatable::class))
+                    ->shouldReceive('created')
+                    ->andReturnNull();
 
         $this->mock(StatefulGuard::class)
                     ->shouldReceive('login')

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
+use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Mockery;
 
 class RegisteredUserControllerTest extends OrchestraTestCase
@@ -37,5 +38,29 @@ class RegisteredUserControllerTest extends OrchestraTestCase
         $response = $this->post('/register', []);
 
         $response->assertRedirect('/home');
+    }
+
+    public function test_users_can_override_the_default_response()
+    {
+        $this->withoutExceptionHandling();
+
+        $response = $this->mock(RegisterResponse::class)
+                ->shouldReceive('toResponse')
+                ->andReturn(redirect('/custom-route'))
+                ->getMock();
+
+        $this->mock(CreatesNewUsers::class)
+                    ->shouldReceive('create')
+                    ->andReturn(Mockery::mock(Authenticatable::class))
+                    ->shouldReceive('created')
+                    ->andReturn($response);
+
+        $this->mock(StatefulGuard::class)
+                    ->shouldReceive('login')
+                    ->once();
+
+        $response = $this->post('/register', []);
+
+        $response->assertRedirect('/custom-route');
     }
 }


### PR DESCRIPTION
This PR introduces a `created()` method similar to the old `registered()` method. It not only allows running code after the user has been created and logged in but also allows the user to return a custom response from this method that will override the default registration response.

The PR is targeted to `master` because updating contracts is a breaking change, which could be removed by using `method_exists` and not adding the method to the contract. Let me know if that's a preferred implementation.