### PR TITLE
[1.x] Make TFA rememberable

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -20,4 +20,5 @@ return [
         Features::updatePasswords(),
         Features::twoFactorAuthentication(),
     ],
+    'two_factor_timeout' => 604800,
 ];

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -96,11 +96,17 @@ class AuthenticatedSessionController extends Controller
      */
     public function destroy(Request $request): LogoutResponse
     {
+        $two_factor_backup = $request->session()->pull('2fa', null);
+
         $this->guard->logout();
 
         $request->session()->invalidate();
 
         $request->session()->regenerateToken();
+
+        if ($two_factor_backup) {
+            $request->session()->put(['2fa' => $two_factor_backup]);
+        }
 
         return app(LogoutResponse::class);
     }


### PR DESCRIPTION
It's based on the `ConfirmPassword` function from jetstream, it stores a timestamp in your session and later compares it.
Also a check for the user_id had to be implemented, as the session data for `2fa` will get restored after logout.

With this you can add a checkbox to the to the `two-factor-challenge.blade.php` inside jetstream and if it's checked the current device wont be bothered.

Currently if you log in as another user your remembered state would get overridden.

I'm not sure if this is the correct approach to this, so please let me know what you think.

Closes #95 