### PR TITLE
Redirect to intended after two factor login

### DIFF
--- a/src/Http/Responses/TwoFactorLoginResponse.php
+++ b/src/Http/Responses/TwoFactorLoginResponse.php
@@ -17,6 +17,6 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 204)
-                    : redirect(config('fortify.home'));
+                    : redirect()->intended(config('fortify.home'));
     }
 }


### PR DESCRIPTION
This brings parity with the response send after a standard (non two-factor) login is completed. We're using Fortify to authenticate users for use with Passport, and if they're using two-factor auth, they are currently not redirected to the intended route (Passport callback route), due to this method not redirecting to the intended route.
