### PR TITLE
[1.x] Allow Fortify views to accept Responsable objects

### DIFF
--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -51,6 +51,7 @@ class SimpleViewResponse implements
         }
 
         $response = call_user_func($this->view, $request);
+
         if ($response instanceof Responsable) {
             return $response->toResponse($request);
         }

--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
+use Illuminate\Contracts\Support\Responsable;
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
@@ -45,8 +46,15 @@ class SimpleViewResponse implements
      */
     public function toResponse($request)
     {
-        return is_callable($this->view) && ! is_string($this->view)
-                    ? call_user_func($this->view, $request)
-                    : view($this->view, ['request' => $request]);
+        if (! is_callable($this->view) || is_string($this->view)) {
+            return view($this->view, ['request' => $request]);
+        }
+
+        $response = call_user_func($this->view, $request);
+        if ($response instanceof Responsable) {
+            return $response->toResponse($request);
+        }
+
+        return $response;
     }
 }

--- a/tests/FortifyServiceProviderTest.php
+++ b/tests/FortifyServiceProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Fortify\Tests;
+
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Fortify;
+
+class FortifyServiceProviderTest extends OrchestraTestCase
+{
+    public function test_views_can_be_customized()
+    {
+        Fortify::loginView(function () {
+            return 'foo';
+        });
+
+        $response = $this->get('/login');
+
+        $response->assertOk();
+        $this->assertSame('foo', $response->content());
+    }
+
+    public function test_customized_views_can_return_their_own_responsable()
+    {
+        Fortify::loginView(function () {
+            return new class implements Responsable {
+                public function toResponse($request)
+                {
+                    return new JsonResponse(['foo' => 'bar']);
+                }
+            };
+        });
+
+        $response = $this->get('/login');
+
+        $response->assertOk();
+        $response->assertExactJson(['foo' => 'bar']);
+    }
+}


### PR DESCRIPTION
This fix allow methods such as `Fortify::loginView` to return (amongst others) an Inertia response without running into this error: [Argument 1 passed to Symfony\Component\HttpFoundation\Response::setContent() must be of the type string or null, object given](https://flareapp.io/share/dmkdzMYP)

This happens because Laravel's router calls `->toResponse()` on `Responsable`, which SimpleViewResponse is an implementation of. After the object is converted to a response, other methods inside the router make sure that the response is properly generated.

However, because views such as Inertia's have their own Responsable implementation, this never gets triggered, because it never gets called by the SimpleViewResponse. This PR fixes this behaviour, preventing the user the need to do something like this:

```php
Fortify::loginView(function (Request $request) {
    return Inertia::render('Auth/Login')->toResponse($request);
});
```