### PR TITLE
Per-environment fortify features

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ The `fortify` configuration file contains a `features` configuration array. This
 
 If you are not using Laravel Jetstream, you should implement user profile updates, password updates, and two-factor authentication yourself.
 
+If you wish to enable or disable features on a per-environment basis, you may pass an options array to each Fortify feature:
+
+
+    'features' => [
+        Features::registration(),
+        Features::resetPasswords(),
+        Features::emailVerification([
+            'enabled' => env('EMAIL_VERIFICATION', true)
+        ]),
+        Features::updatePasswords()
+    ],
+
 <a name="authentication"></a>
 ### Authentication
 

--- a/src/Features.php
+++ b/src/Features.php
@@ -83,61 +83,91 @@ class Features
     /**
      * Enable the registration feature.
      *
+     * @param array $options
      * @return string
      */
-    public static function registration()
+    public static function registration(array $options = [])
     {
+        if(! empty($options) && isset($options['enabled'])) {
+            return $options['enabled'] === true ? 'registration' : null;
+        }
+
         return 'registration';
     }
 
     /**
      * Enable the password reset feature.
      *
-     * @return string
+     * @param array $options
+     * @return string|null
      */
-    public static function resetPasswords()
+    public static function resetPasswords(array $options = [])
     {
+        if(! empty($options) && isset($options['enabled'])) {
+            return $options['enabled'] === true ? 'reset-passwords' : null;
+        }
+
         return 'reset-passwords';
     }
 
     /**
      * Enable the email verification feature.
      *
-     * @return string
+     * @param array $options
+     * @return string|null
      */
-    public static function emailVerification()
+    public static function emailVerification(array $options = [])
     {
+        if(! empty($options) && isset($options['enabled'])) {
+            return $options['enabled'] === true ? 'email-verification' : null;
+        }
+
         return 'email-verification';
     }
 
     /**
      * Enable the update profile information feature.
      *
-     * @return string
+     * @param array $options
+     * @return string|null
      */
-    public static function updateProfileInformation()
+    public static function updateProfileInformation(array $options = [])
     {
+        if(! empty($options) && isset($options['enabled'])) {
+            return $options['enabled'] === true ? 'update-profile-information' : null;
+        }
+
         return 'update-profile-information';
     }
 
     /**
      * Enable the update password feature.
      *
-     * @return string
+     * @param array $options
+     * @return string|null
      */
-    public static function updatePasswords()
+    public static function updatePasswords(array $options = [])
     {
+        if(! empty($options) && isset($options['enabled'])) {
+            return $options['enabled'] === true ? 'update-passwords' : null;
+        }
+
         return 'update-passwords';
     }
 
     /**
      * Enable the two factor authentication feature.
      *
+     * @param array $options
      * @return string
      */
     public static function twoFactorAuthentication(array $options = [])
     {
         if (! empty($options)) {
+            if(isset($options['enabled']) && $options['enabled'] === false) {
+                return null;
+            }
+
             static::$featureOptions['two-factor-authentication'] = $options;
         }
 


### PR DESCRIPTION
This change allows fortify features to be enabled/disabled via environment config, for example - enabling/disabling email verification with an `EMAIL_VERIFICATION` line in the `.env` file, e.g.:

```php
    'features' => [
        Features::registration(),
        Features::emailVerification([
            'enabled' => env('EMAIL_VERIFICATION', true)
    ]),
```

This gives the option for local/staging environments to remove barriers to testing without having to commit environment specific changes to VCS.

Some of these options I do not see this being particularly useful on, but I figured giving the option to all was better than trying to decide which would be potentially used. This change is fully backwards compatible.