### PR TITLE
[1.x] Fix GenerateNewRecoveryCodes description

### DIFF
--- a/src/Actions/GenerateNewRecoveryCodes.php
+++ b/src/Actions/GenerateNewRecoveryCodes.php
@@ -8,7 +8,7 @@ use Laravel\Fortify\RecoveryCode;
 class GenerateNewRecoveryCodes
 {
     /**
-     * Disable two factor authentication for the user.
+     * Generate new recovery codes for the user.
      *
      * @param  mixed  $user
      * @return void


### PR DESCRIPTION
This PR fixes the docblock description of the invoke method of the `GenerateNewRecoveryCodes` action, which currently has the same description as `DisableTwoFactorAuthentication`.