### PR TITLE
Redirect to intended URL after email verification

### DIFF
--- a/src/Http/Controllers/EmailVerificationNotificationController.php
+++ b/src/Http/Controllers/EmailVerificationNotificationController.php
@@ -19,7 +19,7 @@ class EmailVerificationNotificationController extends Controller
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
                         ? new JsonResponse('', 204)
-                        : redirect(config('fortify.home'));
+                        : redirect()->intended(config('fortify.home'));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/src/Http/Controllers/EmailVerificationPromptController.php
+++ b/src/Http/Controllers/EmailVerificationPromptController.php
@@ -17,7 +17,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request)
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect(config('fortify.home'))
+                    ? redirect()->intended(config('fortify.home'))
                     : app(VerifyEmailViewResponse::class);
     }
 }

--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -18,13 +18,13 @@ class VerifyEmailController extends Controller
     public function __invoke(VerifyEmailRequest $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect(config('fortify.home').'?verified=1');
+            return redirect()->intended(config('fortify.home').'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect(config('fortify.home').'?verified=1');
+        return redirect()->intended(config('fortify.home').'?verified=1');
     }
 }

--- a/tests/EmailVerificationNotificationControllerTest.php
+++ b/tests/EmailVerificationNotificationControllerTest.php
@@ -36,4 +36,20 @@ class EmailVerificationNotificationControllerTest extends OrchestraTestCase
 
         $response->assertRedirect('/home');
     }
+
+    public function test_user_is_redirect_to_intended_url_if_already_verified()
+    {
+        $user = Mockery::mock(Authenticatable::class);
+
+        $user->shouldReceive('hasVerifiedEmail')->andReturn(true);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $user->shouldReceive('sendEmailVerificationNotification')->never();
+
+        $response = $this->from('/email/verify')
+                        ->actingAs($user)
+                        ->withSession(['url.intended' => 'http://foo.com/bar'])
+                        ->post('/email/verification-notification');
+
+        $response->assertRedirect('http://foo.com/bar');
+    }
 }

--- a/tests/EmailVerificationPromptControllerTest.php
+++ b/tests/EmailVerificationPromptControllerTest.php
@@ -22,4 +22,34 @@ class EmailVerificationPromptControllerTest extends OrchestraTestCase
         $response->assertStatus(200);
         $response->assertSeeText('hello world');
     }
+
+    public function test_user_is_redirect_home_if_already_verified()
+    {
+        $this->mock(VerifyEmailViewResponse::class)
+                ->shouldReceive('toResponse')
+                ->andReturn(response('hello world'));
+
+        $user = Mockery::mock(Authenticatable::class);
+        $user->shouldReceive('hasVerifiedEmail')->andReturn(true);
+
+        $response = $this->actingAs($user)->get('/email/verify');
+
+        $response->assertRedirect('/home');
+    }
+
+    public function test_user_is_redirect_to_intended_url_if_already_verified()
+    {
+        $this->mock(VerifyEmailViewResponse::class)
+                ->shouldReceive('toResponse')
+                ->andReturn(response('hello world'));
+
+        $user = Mockery::mock(Authenticatable::class);
+        $user->shouldReceive('hasVerifiedEmail')->andReturn(true);
+
+        $response = $this->actingAs($user)
+            ->withSession(['url.intended' => 'http://foo.com/bar'])
+            ->get('/email/verify');
+
+        $response->assertRedirect('http://foo.com/bar');
+    }
 }

--- a/tests/VerifyEmailControllerTest.php
+++ b/tests/VerifyEmailControllerTest.php
@@ -26,9 +26,11 @@ class VerifyEmailControllerTest extends OrchestraTestCase
         $user->shouldReceive('hasVerifiedEmail')->andReturn(false);
         $user->shouldReceive('markEmailAsVerified')->once();
 
-        $response = $this->actingAs($user)->get($url);
+        $response = $this->actingAs($user)
+            ->withSession(['url.intended' => 'http://foo.com/bar'])
+            ->get($url);
 
-        $response->assertStatus(302);
+        $response->assertRedirect('http://foo.com/bar');
     }
 
     public function test_redirected_if_email_is_already_verified()


### PR DESCRIPTION
This allows users to redirect to the intended URL instead of the home page, after they have verified their email address, as described in https://github.com/laravel/framework/pull/34808

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
