### PR TITLE
Semi colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Fortify::authenticateUsing(function (Request $request) {
         Hash::check($request->password, $user->password)) {
         return $user;
     }
-})
+});
 ```
 
 ### Registration


### PR DESCRIPTION
Missing semi colon on **Customizing User Authentication** sample code.