### PR TITLE
[1.x] Only use two factor action when enabled

### DIFF
--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -13,6 +13,7 @@ use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\LoginResponse;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\LogoutResponse;
+use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Requests\LoginRequest;
 
@@ -82,7 +83,7 @@ class AuthenticatedSessionController extends Controller
 
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
-            RedirectIfTwoFactorAuthenticatable::class,
+            Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
             AttemptToAuthenticate::class,
             PrepareAuthenticatedSession::class,
         ]));


### PR DESCRIPTION
## Purpose

This PR resolves the issue of validating credentials twice when two-factor is disabled and the default login pipeline is used:

https://github.com/laravel/fortify/blob/c77b1832eed4223fa9e8fe1a5afc795c00c126a5/src/Http/Controllers/AuthenticatedSessionController.php#L83-L88

## Description

When two-factor authentication is disabled via the configuration file, users credentials are still validated twice, even though the action can be bypassed completely and another database call / `$authenticateUsing` callback execution can be avoided.

This is due to the `RedirectIfTwoFactorAuthenticatable` action, as well as the `AttemptToAuthenticate` action.

This was brought to light when overriding the `$authenticateUsing` callback, since it will be called twice, even when two-factor is omitted in `features`.
