### PR TITLE
[1.x] Use "email" rule for default username

### DIFF
--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -24,8 +24,10 @@ class LoginRequest extends FormRequest
      */
     public function rules()
     {
+        $username = Fortify::username();
+        $type = $username == 'email' ? 'email' : 'string'; 
         return [
-            Fortify::username() => 'required|string',
+            $username => ['required', $type],
             'password' => 'required|string',
         ];
     }

--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -26,6 +26,7 @@ class LoginRequest extends FormRequest
     {
         $username = Fortify::username();
         $type = $username == 'email' ? 'email' : 'string';
+        
         return [
             $username => ['required', $type],
             'password' => 'required|string',

--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -25,7 +25,7 @@ class LoginRequest extends FormRequest
     public function rules()
     {
         $username = Fortify::username();
-        $type = $username == 'email' ? 'email' : 'string'; 
+        $type = $username == 'email' ? 'email' : 'string';
         return [
             $username => ['required', $type],
             'password' => 'required|string',


### PR DESCRIPTION
A quick verification of username type in LoginRequest..
I started a brand new Laravel project using fortify, and having the email as the default username in a fresh laravel install, I noticed the validator isn't checking whether the email field is actually an email or not(It's using the string rule but it should be using the email rule if i'm using the default username chosen by Laravel)