### PR TITLE
[1.x] Add `disable_views` configuration

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -8,6 +8,7 @@ return [
     'passwords' => 'users',
     'username' => 'email',
     'email' => 'email',
+    'disable_views' => false,
     'home' => '/home',
     'limiters' => [
         'login' => null,

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -52,6 +52,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Disable Views
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify if the routes returning views should be disabled.
+    | You might want to activate this configuration if you are using your
+    | own front-end and you want to keep your application routes clean.
+    |
+    */
+
+    'disable_views' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Home Path
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This PR is the implementation for the following issue: https://github.com/laravel/fortify/issues/128

It allows the user to disable routes returning views if they are using their own front-end (SPA, etc...).