### PR TITLE
Add verify email response contract

### DIFF
--- a/src/Contracts/VerifyEmailResponse.php
+++ b/src/Contracts/VerifyEmailResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface VerifyEmailResponse extends Responsable
+{
+    //
+}

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -19,6 +19,7 @@ use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 use Laravel\Fortify\Http\Responses\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
@@ -31,6 +32,7 @@ use Laravel\Fortify\Http\Responses\PasswordResetResponse;
 use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
+use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -74,6 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(PasswordResetResponseContract::class, PasswordResetResponse::class);
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(SuccessfulPasswordResetLinkRequestResponseContract::class, SuccessfulPasswordResetLinkRequestResponse::class);
+        $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
     }
 
     /**

--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -3,8 +3,8 @@
 namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Contracts\VerifyEmailResponse;
 use Laravel\Fortify\Http\Requests\VerifyEmailRequest;
 
 class VerifyEmailController extends Controller
@@ -13,18 +13,18 @@ class VerifyEmailController extends Controller
      * Mark the authenticated user's email address as verified.
      *
      * @param  \Laravel\Fortify\Http\Requests\VerifyEmailRequest  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Laravel\Fortify\Contracts\VerifyEmailResponse
      */
-    public function __invoke(VerifyEmailRequest $request): RedirectResponse
+    public function __invoke(VerifyEmailRequest $request): VerifyEmailResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(config('fortify.home').'?verified=1');
+            return app(VerifyEmailResponse::class);
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(config('fortify.home').'?verified=1');
+        return app(VerifyEmailResponse::class);
     }
 }

--- a/src/Http/Responses/FailedPasswordConfirmationResponse.php
+++ b/src/Http/Responses/FailedPasswordConfirmationResponse.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswordConfirmationResponseContract;
 

--- a/src/Http/Responses/LogoutResponse.php
+++ b/src/Http/Responses/LogoutResponse.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 
 class LogoutResponse implements LogoutResponseContract

--- a/src/Http/Responses/PasswordConfirmedResponse.php
+++ b/src/Http/Responses/PasswordConfirmedResponse.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 
 class PasswordConfirmedResponse implements PasswordConfirmedResponseContract

--- a/src/Http/Responses/VerifyEmailResponse.php
+++ b/src/Http/Responses/VerifyEmailResponse.php
@@ -17,6 +17,6 @@ class VerifyEmailResponse implements VerifyEmailResponseContract
     {
         return $request->wantsJson()
             ? new JsonResponse('', 200)
-            : redirect()->intended(config('fortify.home') . '?verified=1');
+            : redirect()->intended(config('fortify.home').'?verified=1');
     }
 }

--- a/src/Http/Responses/VerifyEmailResponse.php
+++ b/src/Http/Responses/VerifyEmailResponse.php
@@ -3,9 +3,9 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 
-class RegisterResponse implements RegisterResponseContract
+class VerifyEmailResponse implements VerifyEmailResponseContract
 {
     /**
      * Create an HTTP response that represents the object.
@@ -16,7 +16,7 @@ class RegisterResponse implements RegisterResponseContract
     public function toResponse($request)
     {
         return $request->wantsJson()
-                    ? new JsonResponse('', 201)
-                    : redirect(config('fortify.home'));
+            ? new JsonResponse('', 200)
+            : redirect()->intended(config('fortify.home') . '?verified=1');
     }
 }

--- a/tests/VerifyEmailControllerTest.php
+++ b/tests/VerifyEmailControllerTest.php
@@ -97,4 +97,50 @@ class VerifyEmailControllerTest extends OrchestraTestCase
 
         $response->assertStatus(403);
     }
+
+    public function test_the_email_can_be_verified_json_response()
+    {
+        $url = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            [
+                'id' => 1,
+                'hash' => sha1('taylor@laravel.com'),
+            ]
+        );
+
+        $user = Mockery::mock(Authenticatable::class);
+        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $user->shouldReceive('getEmailForVerification')->andReturn('taylor@laravel.com');
+        $user->shouldReceive('hasVerifiedEmail')->andReturn(false);
+        $user->shouldReceive('markEmailAsVerified')->once();
+
+        $response = $this->actingAs($user)->getJson($url);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_email_is_already_verified_json_response()
+    {
+        $url = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            [
+                'id' => 1,
+                'hash' => sha1('taylor@laravel.com'),
+            ]
+        );
+
+        $user = Mockery::mock(Authenticatable::class);
+        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $user->shouldReceive('getEmailForVerification')->andReturn('taylor@laravel.com');
+        $user->shouldReceive('hasVerifiedEmail')->andReturn(true);
+        $user->shouldReceive('markEmailAsVerified')->never();
+
+        $response = $this->actingAs($user)->getJson($url);
+
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
Added verify email response to handle JSON requests and customize redirect locations.

Use cases
1. Complete verify email flow from JSON requests

Added two more test cases to verify JSON responses
![image](https://user-images.githubusercontent.com/13897936/98460215-36b5ec00-21c8-11eb-8b9e-bb1425d1bc9a.png)

Please let me know if anything wrong with this PR or Please add ability to handle JSON requests 
Thanks.