### PR TITLE
Fix 2FA disabled routes via `views` config

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -138,13 +138,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::delete('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'destroy'])
             ->middleware($twoFactorMiddleware);
 
-        if ($enableViews) {
-            Route::get('/user/two-factor-qr-code', [TwoFactorQrCodeController::class, 'show'])
-                ->middleware($twoFactorMiddleware);
+        Route::get('/user/two-factor-qr-code', [TwoFactorQrCodeController::class, 'show'])
+            ->middleware($twoFactorMiddleware);
 
-            Route::get('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'index'])
-                ->middleware($twoFactorMiddleware);
-        }
+        Route::get('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'index'])
+            ->middleware($twoFactorMiddleware);
 
         Route::post('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'store'])
             ->middleware($twoFactorMiddleware);


### PR DESCRIPTION
2FA routes `GET: /user/two-factor-qr-code` and `GET: /user/two-factor-recovery-codes` should not be disabled via `views` configuration option.

They are necessary / useful in SPA.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
