### PR TITLE
[1.x] Fix route prefix

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -125,7 +125,7 @@ class FortifyServiceProvider extends ServiceProvider
             Route::group([
                 'namespace' => 'Laravel\Fortify\Http\Controllers',
                 'domain' => config('fortify.domain', null),
-                'prefix' => config('fortify.path'),
+                'prefix' => config('fortify.prefix'),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -68,7 +68,7 @@ return [
     | Fortify Routes Prefix / Subdomain
     |--------------------------------------------------------------------------
     |
-    | Here you may specify which prefix Fortify will assign to the all routes
+    | Here you may specify which prefix Fortify will assign to all the routes
     | that it registers with the application. If necessary, you may change
     | subdomain under which all of the Fortify routes will be available.
     |


### PR DESCRIPTION
Right now the `prefix` configuration option does not work because the ServiceProvider uses the wrong configuration key. 
