### PR TITLE
Fire Failed events

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Fortify\Actions;
 
+use Illuminate\Auth\Events\Failed;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Fortify;
@@ -71,6 +72,8 @@ class AttemptToAuthenticate
         $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
 
         if (! $user) {
+            $this->fireFailedEvent($request);
+
             return $this->throwFailedAuthenticationException($request);
         }
 
@@ -94,5 +97,18 @@ class AttemptToAuthenticate
         throw ValidationException::withMessages([
             Fortify::username() => [trans('auth.failed')],
         ]);
+    }
+
+    /**
+     * Fire the failed authentication attempt event with the given arguments.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function fireFailedEvent($request) {
+        event(new Failed(config('fortify.guard'), null, [
+            Fortify::username() => $request->{Fortify::username()},
+            'password' => $request->password,
+        ]));
     }
 }

--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -105,7 +105,8 @@ class AttemptToAuthenticate
      * @param  \Illuminate\Http\Request  $request
      * @return void
      */
-    protected function fireFailedEvent($request) {
+    protected function fireFailedEvent($request)
+    {
         event(new Failed(config('fortify.guard'), null, [
             Fortify::username() => $request->{Fortify::username()},
             'password' => $request->password,

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Fortify\Actions;
 
+use Illuminate\Auth\Events\Failed;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
@@ -68,6 +69,8 @@ class RedirectIfTwoFactorAuthenticatable
         if (Fortify::$authenticateUsingCallback) {
             return tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request) {
                 if (! $user) {
+                    $this->fireFailedEvent($request);
+
                     $this->throwFailedAuthenticationException($request);
                 }
             });
@@ -77,6 +80,8 @@ class RedirectIfTwoFactorAuthenticatable
 
         return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use ($request) {
             if (! $user || ! Hash::check($request->password, $user->password)) {
+                $this->fireFailedEvent($request, $user);
+
                 $this->throwFailedAuthenticationException($request);
             }
         });
@@ -97,6 +102,20 @@ class RedirectIfTwoFactorAuthenticatable
         throw ValidationException::withMessages([
             Fortify::username() => [trans('auth.failed')],
         ]);
+    }
+
+    /**
+     * Fire the failed authentication attempt event with the given arguments.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @return void
+     */
+    protected function fireFailedEvent($request, $user = null) {
+        event(new Failed(config('fortify.guard'), $user, [
+            Fortify::username() => $request->{Fortify::username()},
+            'password' => $request->password,
+        ]));
     }
 
     /**

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -111,7 +111,8 @@ class RedirectIfTwoFactorAuthenticatable
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return void
      */
-    protected function fireFailedEvent($request, $user = null) {
+    protected function fireFailedEvent($request, $user = null)
+    {
         event(new Failed(config('fortify.guard'), $user, [
             Fortify::username() => $request->{Fortify::username()},
             'password' => $request->password,


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR attempts to address the issue described in #145 

That issue states the `Failed` event is not being dispatched when a user provides faulty credentials. From my assessment this happens when 2-Factor Auth is enabled, or when the developer uses the `Fortify::$authenticateUsingCallback` feature.

Reason I found is the `Failed` event is only dispatched inside the `\Illuminate\Auth\SessionGuard@attempt` method after a failed login attempt.

As the `RedirectIfTwoFactorAuthenticatable` action is executed before the `AttemptToAuthenticate` in the default Fortify's login pipeline, when a user provides faulty credentials the `\Illuminate\Auth\SessionGuard@attempt` is not executed, and thus the `Failed` event never gets dispatched.

I added the code to dispatch the `Failed` event in 3 spots:

1. From the `AttemptToAuthenticate@handleUsingCustomCallback` method, as it skips using the `\Illuminate\Auth\SessionGuard@attempt`, but later uses the guard's login method, so I thought in increased consistency.
2. From the `RedirectIfTwoFactorAuthenticatable@validateCredentials` inside the first `if` clause, when the developer configured a `Fortify::$authenticateUsingCallback`.
3. From the `RedirectIfTwoFactorAuthenticatable@validateCredentials` inside the `return` callback, executed when the developer did NOT configured a `Fortify::$authenticateUsingCallback`.

In the `RedirectIfTwoFactorAuthenticatable` action I considered dispatching the `Failed` event from within the  `throwFailedAuthenticationException` method. But I decided to keep it separated to increase consistency between the `RedirectIfTwoFactorAuthenticatable` and `AttemptToAuthenticate` actions code.

Let me know if you prefer to have it consolidated inside that method.

As there no tests to assess the other events dispatched by Fortify (`Registered`, `PasswordReset`, `Lockout`, and `Verified` events), I did not add tests for checking if the `Failed` event gets dispatched.

