### PR TITLE
[1.x] Document password reset gotcha when disabling views

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ By default, Fortify define routes that are intended to return views, such as a l
 'views' => false,
 ```
 
-Note that disabling views still requires you to define a `password.reset` for resetting passwords. This is because internally Fortify makes use of Laravel's `PasswordBroker` to send a `ResetPassword` notification to the user which makes use of this route to direct the user to the proper page to reset their password.
+> **Note:** If you choose to disable Fortify's views, you should still define a route named `password.reset` that is responsible for displaying your application's "reset password" view. This is necessary because Laravel's `Illuminate\Auth\Notifications\ResetPassword` notification will generate the password reset URL via the `password.reset` named route.
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ By default, Fortify define routes that are intended to return views, such as a l
 'views' => false,
 ```
 
+Note that disabling views still requires you to define a `password.reset` for resetting passwords. This is because internally Fortify makes use of Laravel's `PasswordBroker` to send a `ResetPassword` notification to the user which makes use of this route to direct the user to the proper page to reset their password.
+
 ### Authentication
 
 To get started, we need to instruct Fortify how to return our `login` view. Remember, Fortify is a headless authentication library. If you would like a frontend implementation of Fortify that is already completed for you, you should use [Laravel Jetstream](https://jetstream.laravel.com).


### PR DESCRIPTION
There's a small gotcha when disabling views that you still need a `password.reset` route for the password reset notification from Laravel. I've tried documenting this based on @rodrigopedra's great comment [here](https://github.com/laravel/fortify/issues/155#issuecomment-732531717) but I'm sure it can be improved even further.