### PR TITLE
[1.x] Improve Email Verification For SPA's using Laravel as an API

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -12,6 +12,7 @@ return [
     'home' => '/home',
     'prefix' => '',
     'domain' => null,
+    'signed' => 'signed',
     'limiters' => [
         'login' => null,
     ],

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -80,8 +80,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->name('verification.notice');
         }
 
+        $signed = config('fortify.signed');
+
         Route::get('/email/verify/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-            ->middleware(['auth', 'signed', 'throttle:6,1'])
+            ->middleware(['auth', $signed ? $signed : 'signed', 'throttle:6,1'])
             ->name('verification.verify');
 
         Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])

--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -3,7 +3,7 @@
 namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Http\Requests\VerifyEmailRequest;
 
@@ -13,18 +13,22 @@ class VerifyEmailController extends Controller
      * Mark the authenticated user's email address as verified.
      *
      * @param  \Laravel\Fortify\Http\Requests\VerifyEmailRequest  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
-    public function __invoke(VerifyEmailRequest $request): RedirectResponse
+    public function __invoke(VerifyEmailRequest $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(config('fortify.home').'?verified=1');
+            return $request->wantsJson()
+                ? new JsonResponse('', 204)
+                : redirect()->intended(config('fortify.home').'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(config('fortify.home').'?verified=1');
+        return $request->wantsJson()
+            ? new JsonResponse('', 204)
+            : redirect()->intended(config('fortify.home').'?verified=1');
     }
 }

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -80,6 +80,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fortify Verify Email
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify whether Fortify will assign the Email Verification
+    | route signed or signed:relative for validating relative urls.
+    */
+
+    'signed' => 'signed',
+
+    /*
+    |--------------------------------------------------------------------------
     | Fortify Routes Middleware
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Currently you are unable to use the VerifyEmailController with Fortify if you want to have an SPA which doesn't use Laravel's view templates. The reason for this is Laravel set's the route middleware to be `signed` and doesn't allow for using `signed:relative`. Also the VerifyEmailController currently only redirects to the home url set in the config template.

This PR enables a config variable for setting `signed:relative` but defaults to `signed` and returns json within the VerifyEmailController if the request wantsJson.
