### PR TITLE
Use method DI instead of constructor DI to allow packages like Laravel tenancy works with Fortify out of the box

### DIFF
--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -20,24 +20,6 @@ use Laravel\Fortify\Http\Requests\LoginRequest;
 class AuthenticatedSessionController extends Controller
 {
     /**
-     * The guard implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected $guard;
-
-    /**
-     * Create a new controller instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
-     * @return void
-     */
-    public function __construct(StatefulGuard $guard)
-    {
-        $this->guard = $guard;
-    }
-
-    /**
      * Show the login view.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -93,11 +75,12 @@ class AuthenticatedSessionController extends Controller
      * Destroy an authenticated session.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard $guard
      * @return \Laravel\Fortify\Contracts\LogoutResponse
      */
-    public function destroy(Request $request): LogoutResponse
+    public function destroy(Request $request,StatefulGuard $guard): LogoutResponse
     {
-        $this->guard->logout();
+        $guard->logout();
 
         $request->session()->invalidate();
 

--- a/src/Http/Controllers/ConfirmablePasswordController.php
+++ b/src/Http/Controllers/ConfirmablePasswordController.php
@@ -13,24 +13,6 @@ use Laravel\Fortify\Contracts\PasswordConfirmedResponse;
 class ConfirmablePasswordController extends Controller
 {
     /**
-     * The guard implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected $guard;
-
-    /**
-     * Create a new controller instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
-     * @return void
-     */
-    public function __construct(StatefulGuard $guard)
-    {
-        $this->guard = $guard;
-    }
-
-    /**
      * Show the confirm password view.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -45,12 +27,13 @@ class ConfirmablePasswordController extends Controller
      * Confirm the user's password.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard $guard
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request)
+    public function store(Request $request,StatefulGuard $guard)
     {
         $confirmed = app(ConfirmPassword::class)(
-            $this->guard, $request->user(), $request->input('password')
+            $guard, $request->user(), $request->input('password')
         );
 
         if ($confirmed) {

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -18,24 +18,6 @@ use Laravel\Fortify\Fortify;
 class NewPasswordController extends Controller
 {
     /**
-     * The guard implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected $guard;
-
-    /**
-     * Create a new controller instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
-     * @return void
-     */
-    public function __construct(StatefulGuard $guard)
-    {
-        $this->guard = $guard;
-    }
-
-    /**
      * Show the new password view.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -50,9 +32,10 @@ class NewPasswordController extends Controller
      * Reset the user's password.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard $guard
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request): Responsable
+    public function store(Request $request,StatefulGuard $guard): Responsable
     {
         $request->validate([
             'token' => 'required',
@@ -64,10 +47,10 @@ class NewPasswordController extends Controller
         // database. Otherwise we will parse the error and return the response.
         $status = $this->broker()->reset(
             $request->only(Fortify::email(), 'password', 'password_confirmation', 'token'),
-            function ($user) use ($request) {
+            function ($user) use ($request, $guard) {
                 app(ResetsUserPasswords::class)->reset($user, $request->all());
 
-                app(CompletePasswordReset::class)($this->guard, $user);
+                app(CompletePasswordReset::class)($guard, $user);
             }
         );
 

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -13,24 +13,6 @@ use Laravel\Fortify\Contracts\RegisterViewResponse;
 class RegisteredUserController extends Controller
 {
     /**
-     * The guard implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected $guard;
-
-    /**
-     * Create a new controller instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
-     * @return void
-     */
-    public function __construct(StatefulGuard $guard)
-    {
-        $this->guard = $guard;
-    }
-
-    /**
      * Show the registration view.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -13,24 +13,6 @@ use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 class TwoFactorAuthenticatedSessionController extends Controller
 {
     /**
-     * The guard implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected $guard;
-
-    /**
-     * Create a new controller instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
-     * @return void
-     */
-    public function __construct(StatefulGuard $guard)
-    {
-        $this->guard = $guard;
-    }
-
-    /**
      * Show the two factor authentication challenge view.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -45,9 +27,10 @@ class TwoFactorAuthenticatedSessionController extends Controller
      * Attempt to authenticate a new session using the two factor authentication code.
      *
      * @param  \Laravel\Fortify\Http\Requests\TwoFactorLoginRequest  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard $guard
      * @return mixed
      */
-    public function store(TwoFactorLoginRequest $request)
+    public function store(TwoFactorLoginRequest $request,StatefulGuard $guard)
     {
         $user = $request->challengedUser();
 
@@ -57,7 +40,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
             return app(FailedTwoFactorLoginResponse::class);
         }
 
-        $this->guard->login($user, $request->remember());
+        $guard->login($user, $request->remember());
 
         return app(TwoFactorLoginResponse::class);
     }


### PR DESCRIPTION
As you can read at #163

According to:

https://tenancyforlaravel.com/docs/v3/early-identification

Using constructor DI avoids tenancy route middleware to works. The reason is Constructor DI is executed before middleware. 

AFAIK the proposed changes will solve the issue and will make building web apps with Laravel Tenancy package and Fortify/Jetstream easier but feel free to close this PR for any reason...
