### PR TITLE
Custom login verification rule.

### DIFF
--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -24,9 +24,6 @@ class LoginRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            Fortify::username() => 'required|string',
-            'password' => 'required|string',
-        ];
+        return config('fortify.rules.login');
     }
 }

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -2,6 +2,7 @@
 
 use App\Providers\RouteServiceProvider;
 use Laravel\Fortify\Features;
+use Laravel\Fortify\Fortify;
 
 return [
 
@@ -139,6 +140,24 @@ return [
         Features::twoFactorAuthentication([
             'confirmPassword' => true,
         ]),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | rules
+    |--------------------------------------------------------------------------
+    |
+    | Some of the Fortify features are optional. You may disable the features
+    | by removing them from this array. You're free to only remove some of
+    | these features or you can even remove all of these if you need to.
+    |
+    */
+
+    'rules' => [
+        'login' => [
+            Fortify::username() => 'required|string',
+            'password' => 'required|string',
+        ]
     ],
 
 ];


### PR DESCRIPTION
before:
When logging in, only username and password can be verified. Users cannot add custom verification rules, such as adding verification code rules.

After:
Users can customize the verification rules in the configuration file,
E.g, when using `mews/captcha`, add rules for verification codes.

```
'rules' => [
        'login' => [
            Fortify::username() => 'required|string',
            'password' => 'required|string',
            'validCode' => 'required|captcha' // add captcha rules
        ]
    ],
```