### PR TITLE
Fix for missing current password during update

### DIFF
--- a/stubs/UpdateUserPassword.php
+++ b/stubs/UpdateUserPassword.php
@@ -23,7 +23,7 @@ class UpdateUserPassword implements UpdatesUserPasswords
             'current_password' => ['required', 'string'],
             'password' => $this->passwordRules(),
         ])->after(function ($validator) use ($user, $input) {
-            if (! Hash::check($input['current_password'], $user->password)) {
+            if (! isset($input['current_password']) || ! Hash::check($input['current_password'], $user->password)) {
                 $validator->errors()->add('current_password', __('The provided password does not match your current password.'));
             }
         })->validateWithBag('updatePassword');

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -27,4 +27,13 @@ class PasswordControllerTest extends OrchestraTestCase
 
         $response->assertStatus(200);
     }
+	
+	public function test_password_update_can_fail_without_current_password()
+	{
+        $user = Mockery::mock(Authenticatable::class);
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/password', []);	
+		$response->assertSessionHasErrorsIn('updatePassword',['current_password']);
+
+	}
 }


### PR DESCRIPTION
Allow the current password not be set and let it behave as an invalid password. 

Before this fix, if the user leaves the (current password) field empty (e.g. with a disabled front-end validation), a server error (missing 'current_password' index) would occur. Now a validation error will show as expected.

see #174 