### PR TITLE
[1.x] Rate limit two factor auth

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
 use Laravel\Fortify\Http\Controllers\ConfirmablePasswordController;
@@ -126,7 +127,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::post('/two-factor-challenge', [TwoFactorAuthenticatedSessionController::class, 'store'])
-            ->middleware(['guest']);
+            ->middleware(['guest', EnsureLoginIsNotThrottled::class]);
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? ['auth', 'password.confirm']

--- a/src/Http/Responses/FailedTwoFactorLoginResponse.php
+++ b/src/Http/Responses/FailedTwoFactorLoginResponse.php
@@ -4,9 +4,28 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
+use Laravel\Fortify\LoginRateLimiter;
 
 class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContract
 {
+    /**
+     * The login rate limiter instance.
+     *
+     * @var \Laravel\Fortify\LoginRateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Laravel\Fortify\LoginRateLimiter|null  $limiter
+     * @return void
+     */
+    public function __construct(LoginRateLimiter $limiter = null)
+    {
+        $this->limiter = $limiter ?? app(LoginRateLimiter::class);
+    }
+
     /**
      * Create an HTTP response that represents the object.
      *
@@ -16,6 +35,8 @@ class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContra
     public function toResponse($request)
     {
         $message = __('The provided two factor authentication code was invalid.');
+
+        $this->limiter->increment($request);
 
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([


### PR DESCRIPTION
This is a partial fix for https://github.com/laravel/fortify/issues/171. At the moment the two factor challenge isn't rate limited, leaving it open to brute force attacks. 

I wasn't sure if the rate limit increment in the `FailedTwoFactorLoginResponse` is the correct location. @taylorotwell is this fine or do you think it's better placed somewhere else?