### PR TITLE
[1.x] Retrieve user through provider

### DIFF
--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -86,10 +86,10 @@ class TwoFactorLoginRequest extends FormRequest
             return $this->challengedUser;
         }
 
-        $model = app(StatefulGuard::class)->getProvider()->getModel();
+        $provider = app(StatefulGuard::class)->getProvider();
 
         if (! $this->session()->has('login.id') ||
-            ! $user = $model::find($this->session()->pull('login.id'))) {
+            ! $user = $provider->retrieveById($this->session()->pull('login.id'))) {
             throw new HttpResponseException(
                 app(FailedTwoFactorLoginResponse::class)->toResponse($this)
             );


### PR DESCRIPTION
This is a partially fix for https://github.com/laravel/fortify/issues/171. Instead of relying on Eloquent to retrieve the user we make use of the user provider from the stateful guard and thus decouple the Two Factor implementation from Eloquent.