### PR TITLE
[1.x] Fix Two Factor prepare auth session

### DIFF
--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -29,7 +29,7 @@ class AuthenticatedSessionController extends Controller
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct(StatefulGuard $guard)

--- a/src/Http/Controllers/ConfirmablePasswordController.php
+++ b/src/Http/Controllers/ConfirmablePasswordController.php
@@ -22,7 +22,7 @@ class ConfirmablePasswordController extends Controller
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct(StatefulGuard $guard)

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -27,7 +27,7 @@ class NewPasswordController extends Controller
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct(StatefulGuard $guard)

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -22,7 +22,7 @@ class RegisteredUserController extends Controller
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct(StatefulGuard $guard)

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -20,13 +20,6 @@ class TwoFactorAuthenticatedSessionController extends Controller
     protected $guard;
 
     /**
-     * The login rate limiter instance.
-     *
-     * @var \Laravel\Fortify\LoginRateLimiter
-     */
-    protected $limiter;
-
-    /**
      * Create a new controller instance.
      *
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -9,7 +9,6 @@ use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
-use Laravel\Fortify\LoginRateLimiter;
 
 class TwoFactorAuthenticatedSessionController extends Controller
 {
@@ -31,13 +30,11 @@ class TwoFactorAuthenticatedSessionController extends Controller
      * Create a new controller instance.
      *
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
-     * @param  \Laravel\Fortify\LoginRateLimiter|null  $limiter
      * @return void
      */
-    public function __construct(StatefulGuard $guard, LoginRateLimiter $limiter = null)
+    public function __construct(StatefulGuard $guard)
     {
         $this->guard = $guard;
-        $this->limiter = $limiter ?? app(LoginRateLimiter::class);
     }
 
     /**
@@ -70,8 +67,6 @@ class TwoFactorAuthenticatedSessionController extends Controller
         $this->guard->login($user, $request->remember());
 
         $request->session()->regenerate();
-
-        $this->limiter->clear($request);
 
         return app(TwoFactorLoginResponse::class);
     }


### PR DESCRIPTION
This is a partial fix for https://github.com/laravel/fortify/issues/171. After a successful two factor auth, the `PrepareAuthenticatedSession` action is never reached and thus a new CSRF token is never generated nor is the rate limiter reset. This PR adds these calls manually to the `TwoFactorAuthenticatedSessionController`. Ideally the `PrepareAuthenticatedSession` action would handle this but it can never be reached because two factor is being done in a new request.

There's also a few minor DocBlock fixes I sneaked in.