### PR TITLE
Change users table for unique validation

### DIFF
--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -26,7 +26,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'string',
                 'email',
                 'max:255',
-                Rule::unique('users')->ignore($user->id),
+                Rule::unique(get_class($user))->ignore($user->id),
             ],
         ])->validateWithBag('updateProfileInformation');
 


### PR DESCRIPTION
In case you use another table name or model rather than the users table to store users, the unique validation fails because it searchs in a non existing table. Instead, using its classname in the validation the application will determine correctly the table name to use.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
