### PR TITLE
Added a callback for RedirectIfTwoFactorAuthenticatable

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -66,8 +66,10 @@ class RedirectIfTwoFactorAuthenticatable
      */
     protected function validateCredentials($request)
     {
-        if (Fortify::$authenticateUsingCallback) {
-            return tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request) {
+        $callback = Fortify::$authenticateTwoFactorUsingCallback ?? Fortify::$authenticateUsingCallback;
+
+        if ($callback) {
+            return tap(call_user_func($callback, $request), function ($user) use ($request) {
                 if (! $user) {
                     $this->fireFailedEvent($request);
 

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -32,6 +32,13 @@ class Fortify
     public static $authenticateUsingCallback;
 
     /**
+     * The callback that is responsible for validating authentication credentials at two factor authentication class,
+     * if applicable.
+     * @var callable|null
+     */
+    public static $authenticateTwoFactorUsingCallback;
+
+    /**
      * The callback that is responsible for confirming user passwords.
      *
      * @var callable|null
@@ -215,6 +222,10 @@ class Fortify
     public static function authenticateUsing(callable $callback)
     {
         static::$authenticateUsingCallback = $callback;
+    }
+
+    public static function authenticateTwoFactorUsing(callable $callback){
+        static::$authenticateTwoFactorUsingCallback = $callback;
     }
 
     /**


### PR DESCRIPTION
Fully backward compatible, if no specific callback is set the normal callback will be used if it applies.

Inspired in my usecase where I had to delete a token at search but the callback is called twice so the second callback misses and fails, therefore instead of declaring a custom pipeline and creating a new extra class, just to do a separated step for deleting or any one time step that needs to be done while querying the credentials.

#161 