### PR TITLE
Action After Register User

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /vendor
 composer.lock
 /phpunit.xml

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -10,6 +10,7 @@ return [
     'email' => 'email',
     'views' => true,
     'home' => '/home',
+    'register' => '/home',
     'prefix' => '',
     'domain' => null,
     'limiters' => [

--- a/src/Contracts/RedirectAfterRegister.php
+++ b/src/Contracts/RedirectAfterRegister.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Laravel\Fortify\Contracts;
+
+
+interface RedirectAfterRegister
+{
+    /**
+     * Action after create user.
+     *
+     * @param  mixed $user
+     * @return mixed
+     */
+    public function afterRegister($guard, $user);
+
+}

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -14,6 +14,7 @@ use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
 use Laravel\Fortify\Http\Responses\SimpleViewResponse;
+use Laravel\Fortify\Contracts\RedirectAfterRegister;
 
 class Fortify
 {
@@ -270,6 +271,16 @@ class Fortify
     public static function resetUserPasswordsUsing(string $callback)
     {
         return app()->singleton(ResetsUserPasswords::class, $callback);
+    }
+
+    /**
+     * Redirect after to register user
+     *
+     * @param string $callback
+     * @return void
+     */
+    public static function redirectAfterRegisterUsing(string $callback){
+        return app()->singleton(RedirectAfterRegister::class, $callback);
     }
 
     /**

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -101,6 +101,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             $this->publishes([
                 __DIR__.'/../stubs/CreateNewUser.php' => app_path('Actions/Fortify/CreateNewUser.php'),
+                __DIR__.'/../stubs/RedirectAfterRegister.php' => app_path('Actions/Fortify/RedirectAfterRegister.php'),
                 __DIR__.'/../stubs/FortifyServiceProvider.php' => app_path('Providers/FortifyServiceProvider.php'),
                 __DIR__.'/../stubs/PasswordValidationRules.php' => app_path('Actions/Fortify/PasswordValidationRules.php'),
                 __DIR__.'/../stubs/ResetUserPassword.php' => app_path('Actions/Fortify/ResetUserPassword.php'),

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
+use Laravel\Fortify\Contracts\RedirectAfterRegister;
 use Laravel\Fortify\Contracts\RegisterResponse;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
 
@@ -46,14 +47,15 @@ class RegisteredUserController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Fortify\Contracts\CreatesNewUsers  $creator
+     * @param  \Laravel\Fortify\Contracts\RedirectAfterRegister  $redirect
      * @return \Laravel\Fortify\Contracts\RegisterResponse
      */
     public function store(Request $request,
-                          CreatesNewUsers $creator): RegisterResponse
+                          CreatesNewUsers $creator, RedirectAfterRegister $redirect): RegisterResponse
     {
         event(new Registered($user = $creator->create($request->all())));
 
-        $this->guard->login($user);
+        $redirect->afterRegister($this->guard, $user);
 
         return app(RegisterResponse::class);
     }

--- a/src/Http/Responses/RegisterResponse.php
+++ b/src/Http/Responses/RegisterResponse.php
@@ -18,6 +18,6 @@ class RegisterResponse implements RegisterResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 201)
-                    : redirect(config('fortify.home'));
+                    : redirect(config('fortify.register'));
     }
 }

--- a/stubs/FortifyServiceProvider.php
+++ b/stubs/FortifyServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\RedirectAfterRegister;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
@@ -35,6 +36,7 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
+        Fortify::redirectAfterRegisterUsing(RedirectAfterRegister::class);
 
         RateLimiter::for('login', function (Request $request) {
             return Limit::perMinute(5)->by($request->email.$request->ip());

--- a/stubs/RedirectAfterRegister.php
+++ b/stubs/RedirectAfterRegister.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use Laravel\Fortify\Contracts\RedirectAfterRegister as RedirectAfterRegisterInterface;
+
+class RedirectAfterRegister implements RedirectAfterRegisterInterface
+{
+    public function afterRegister($guard, $user){
+        $guard->login($user);
+    }
+}

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -63,6 +63,8 @@ return [
 
     'home' => RouteServiceProvider::HOME,
 
+    'register' => RouteServiceProvider::HOME,
+
     /*
     |--------------------------------------------------------------------------
     | Fortify Routes Prefix / Subdomain


### PR DESCRIPTION
Implemented the possibility of making a redirect or not performing the user login after registration.

Now just call **FortifyServiceProvider** within the boot method: 
**Fortify :: redirectAfterRegisterUsing (RedirectAfterRegister :: class);** and within **App / Actions / Fortify** the **RedirectAfterRegister** class in the **afterRegister** method manages the desired action, be it a login or a redirect

It would be a solution to the issue #77 

