### PR TITLE
Remove 'guest' middleware from reset pwd routes

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -44,20 +44,16 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     if (Features::enabled(Features::resetPasswords())) {
         if ($enableViews) {
             Route::get('/forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->middleware(['guest'])
                 ->name('password.request');
 
             Route::get('/reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->middleware(['guest'])
                 ->name('password.reset');
         }
 
         Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-            ->middleware(['guest'])
             ->name('password.email');
 
         Route::post('/reset-password', [NewPasswordController::class, 'store'])
-            ->middleware(['guest'])
             ->name('password.update');
     }
 


### PR DESCRIPTION
This PR removes 'guest' middleware from reset password routes (same change as @driesvints did in https://github.com/laravel/laravel/pull/5129) so that users can reset their password while logged in.
