### PR TITLE
[1.x] Fix missing current password

### DIFF
--- a/stubs/UpdateUserPassword.php
+++ b/stubs/UpdateUserPassword.php
@@ -23,7 +23,7 @@ class UpdateUserPassword implements UpdatesUserPasswords
             'current_password' => ['required', 'string'],
             'password' => $this->passwordRules(),
         ])->after(function ($validator) use ($user, $input) {
-            if (! Hash::check($input['current_password'], $user->password)) {
+            if (! isset($input['current_password']) || ! Hash::check($input['current_password'], $user->password)) {
                 $validator->errors()->add('current_password', __('The provided password does not match your current password.'));
             }
         })->validateWithBag('updatePassword');

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Fortify\Tests;
 
+use App\Actions\Fortify\UpdateUserPassword;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Mockery;
 
@@ -26,5 +28,26 @@ class PasswordControllerTest extends OrchestraTestCase
         ]);
 
         $response->assertStatus(200);
+    }
+
+    public function test_passwords_cannot_be_updated_without_password_confirmation()
+    {
+        $user = Mockery::mock(Authenticatable::class);
+        $user->password = '';
+
+        require_once __DIR__ . '/../stubs/PasswordValidationRules.php';
+        require_once __DIR__ . '/../stubs/UpdateUserPassword.php';
+
+        try {
+            (new UpdateUserPassword())->update($user, [
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ]);
+        } catch (ValidationException $e) {
+            $this->assertTrue(in_array(
+                'The provided password does not match your current password.',
+                $e->errors()['current_password']
+            ));
+        }
     }
 }

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -35,8 +35,8 @@ class PasswordControllerTest extends OrchestraTestCase
         $user = Mockery::mock(Authenticatable::class);
         $user->password = '';
 
-        require_once __DIR__ . '/../stubs/PasswordValidationRules.php';
-        require_once __DIR__ . '/../stubs/UpdateUserPassword.php';
+        require_once __DIR__.'/../stubs/PasswordValidationRules.php';
+        require_once __DIR__.'/../stubs/UpdateUserPassword.php';
 
         try {
             (new UpdateUserPassword())->update($user, [


### PR DESCRIPTION
When no `current_password` key has been provided, the after callback of the validation of the request input throws an error exception instead of a proper validation exception. 

Fixes https://github.com/laravel/fortify/issues/174