### PR TITLE
[1.x] Allow validation rules to be overridden.

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -53,6 +53,13 @@ class Fortify
     public static $loginRules = null;
 
     /**
+     * The rules responsible for validating two-factor authentication requests.
+     *
+     * @var callable|array
+     */
+    public static $twoFactorAuthenticationRules = null;
+
+    /**
      * Get the username used for authentication.
      *
      * @return string
@@ -127,6 +134,36 @@ class Fortify
         return static::$loginRules ?? [
             static::username() => 'required|string',
             'password' => 'required|string',
+        ];
+    }
+
+    /**
+     * Specify the rules that should be used for validating login requests.
+     *
+     * @param  mixed  $rules
+     * @return void
+     */
+    public static function validateTwoFactorAuthenticationRequestsUsing($rules)
+    {
+        if (is_callable($rules) || is_array($rules)) {
+            static::$twoFactorAuthenticationRules = $rules;
+        }
+    }
+
+    /**
+     * Get the rules used for validating two-factor authentication requests.
+     *
+     * @return array
+     */
+    public static function twoFactorAuthenticationRules()
+    {
+        if (is_callable(static::$twoFactorAuthenticationRules)) {
+            return call_user_func(static::$twoFactorAuthenticationRules);
+        }
+
+        return static::$twoFactorAuthenticationRules ?? [
+            'code' => 'nullable|string',
+            'recovery_code' => 'nullable|string',
         ];
     }
 

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -46,6 +46,13 @@ class Fortify
     public static $registersRoutes = true;
 
     /**
+     * The rules responsible for validating login requests.
+     *
+     * @var callable|array
+     */
+    public static $loginRules = null;
+
+    /**
      * Get the username used for authentication.
      *
      * @return string
@@ -91,6 +98,36 @@ class Fortify
         static::resetPasswordView($prefix.'reset-password');
         static::verifyEmailView($prefix.'verify-email');
         static::confirmPasswordView($prefix.'confirm-password');
+    }
+
+    /**
+     * Specify the rules that should be used for validating login requests.
+     *
+     * @param  mixed  $rules
+     * @return void
+     */
+    public static function validateLoginRequestsUsing($rules)
+    {
+        if (is_callable($rules) || is_array($rules)) {
+            static::$loginRules = $rules;
+        }
+    }
+
+    /**
+     * Get the rules used for validating login requests.
+     *
+     * @return array
+     */
+    public static function loginRequestRules()
+    {
+        if (is_callable(static::$loginRules)) {
+            return call_user_func(static::$loginRules);
+        }
+
+        return static::$loginRules ?? [
+            static::username() => 'required|string',
+            'password' => 'required|string',
+        ];
     }
 
     /**

--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -24,9 +24,6 @@ class LoginRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            Fortify::username() => 'required|string',
-            'password' => 'required|string',
-        ];
+        return Fortify::loginRequestRules();
     }
 }

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorLoginRequest extends FormRequest
 {
@@ -41,10 +42,7 @@ class TwoFactorLoginRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'code' => 'nullable|string',
-            'recovery_code' => 'nullable|string',
-        ];
+        return Fortify::twoFactorAuthenticationRules();
     }
 
     /**


### PR DESCRIPTION
This PR is an attempt to allow developers to customise the rules used for authenticating login requests and two-factor authentication requests. It tries to avoid the breaking change that https://github.com/laravel/fortify/pull/198 presented.

Developers can override the rules by passing an array or a callback into the new methods in the `boot` method of the `FortifyServiceProvider`:

```php
/**
 * Bootstrap any application services.
 *
 * @return void
 */
public function boot()
{
    Fortify::validateLoginRequestsUsing([
        //
    ]);

    Fortify::validateLoginRequestsUsing(function () {
        return [
            //
        ];
    });

    Fortify::validateTwoFactorAuthenticationRequestsUsing([
        //
    ]);

    Fortify::validateTwoFactorAuthenticationRequestsUsing(function () {
        return [
            //
        ];
    });

    //...
}
```