### PR TITLE
[1.x] Allow vendor:publish routes

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -111,6 +111,10 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
+            
+            $this->publishes([
+                __DIR__.'/../routes/routes.php' => base_path('routes/fortify.php'),
+            ], 'fortify-routes');
         }
     }
 

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -111,7 +111,7 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
-            
+
             $this->publishes([
                 __DIR__.'/../routes/routes.php' => base_path('routes/fortify.php'),
             ], 'fortify-routes');


### PR DESCRIPTION
This will allow users to publish the Fortify routes via the ```vendor:publish``` artisan command.