### PR TITLE
[1.x] Fix password rule

### DIFF
--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -51,6 +51,8 @@ class Password implements Rule
      */
     public function passes($attribute, $value)
     {
+        $value = is_array($value) ? '' : (string) $value;
+
         if ($this->requireUppercase && Str::lower($value) === $value) {
             return false;
         }

--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -51,7 +51,7 @@ class Password implements Rule
      */
     public function passes($attribute, $value)
     {
-        $value = is_array($value) ? '' : (string) $value;
+        $value = is_scalar($value) ? (string) $value : '';
 
         if ($this->requireUppercase && Str::lower($value) === $value) {
             return false;

--- a/tests/PasswordRuleTest.php
+++ b/tests/PasswordRuleTest.php
@@ -12,6 +12,8 @@ class PasswordRuleTest extends OrchestraTestCase
         $rule = new Password;
 
         $this->assertTrue($rule->passes('password', 'password'));
+        $this->assertTrue($rule->passes('password', 234234234));
+        $this->assertFalse($rule->passes('password', ['foo' => 'bar']));
         $this->assertFalse($rule->passes('password', 'secret'));
 
         $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));


### PR DESCRIPTION
This fixes a bug when a non-string value is password as input for a password. For example, as an array through an API request from a third party.

https://github.com/laravel/fortify/issues/209