### PR TITLE
Redirect to intended URL after registration

### DIFF
--- a/src/Http/Responses/RegisterResponse.php
+++ b/src/Http/Responses/RegisterResponse.php
@@ -18,6 +18,6 @@ class RegisterResponse implements RegisterResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 201)
-                    : redirect(config('fortify.home'));
+                    : redirect()->intended(config('fortify.home'));
     }
 }

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -36,4 +36,20 @@ class RegisteredUserControllerTest extends OrchestraTestCase
 
         $response->assertRedirect('/home');
     }
+
+    public function test_users_can_be_created_and_redirected_to_intended_url()
+    {
+        $this->mock(CreatesNewUsers::class)
+                    ->shouldReceive('create')
+                    ->andReturn(Mockery::mock(Authenticatable::class));
+
+        $this->mock(StatefulGuard::class)
+                    ->shouldReceive('login')
+                    ->once();
+
+        $response = $this->withSession(['url.intended' => 'http://foo.com/bar'])
+                        ->post('/register', []);
+
+        $response->assertRedirect('http://foo.com/bar');
+    }
 }


### PR DESCRIPTION
This allows redirecting users to the intended URL after they've completed registration.