### PR TITLE
Add environment variables to fortify config to allow overloading in env files

### DIFF
--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -16,7 +16,7 @@ return [
     |
     */
 
-    'guard' => 'web',
+    'guard' => env('FORTIFY_GUARD', 'web'),
 
     /*
     |--------------------------------------------------------------------------
@@ -29,7 +29,7 @@ return [
     |
     */
 
-    'passwords' => 'users',
+    'passwords' => env('FORTIFY_PASSWORDS', 'users'),
 
     /*
     |--------------------------------------------------------------------------
@@ -46,9 +46,9 @@ return [
     |
     */
 
-    'username' => 'email',
+    'username' => env('FORTIFY_USERNAME_FIELD', 'email'),
 
-    'email' => 'email',
+    'email' => env('FORTIFY_EMAIL_FIELD', 'email'),
 
     /*
     |--------------------------------------------------------------------------
@@ -61,7 +61,7 @@ return [
     |
     */
 
-    'home' => RouteServiceProvider::HOME,
+    'home' => env('FORTIFY_HOME', RouteServiceProvider::HOME),
 
     /*
     |--------------------------------------------------------------------------
@@ -74,9 +74,9 @@ return [
     |
     */
 
-    'prefix' => '',
+    'prefix' => env('FORTIFY_ROUTE_PREFIX', ''),
 
-    'domain' => null,
+    'domain' => env('FORTIFY_SUBDOMAIN', null),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This should make solving #77 simple, as all you need to do to change the default route is update your `.env` file. This is what I've done locally.

I also suggest this as it sticks to what we see in other config files that we work with on a daily basis, which allows us to have a standard location to make customizations to the framework, without modifying files, or requiring us to build entire classes to handle something as simple as a changed URL.

Which brings up the caveat to this: Anything beyond a basic URL change isn't handled this way, but I think that works fine. If you need more, there are other methods already available to account for that.