### PR TITLE
Use closure to add columns after an existing column

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -14,13 +14,10 @@ class AddTwoFactorColumnsToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->text('two_factor_secret')
-                    ->after('password')
-                    ->nullable();
-
-            $table->text('two_factor_recovery_codes')
-                    ->after('two_factor_secret')
-                    ->nullable();
+            $table->after('password', function ($table) {
+                $table->text('two_factor_secret')->nullable();
+                $table->text('two_factor_recovery_codes')->nullable();
+            });
         });
     }
 


### PR DESCRIPTION
To avoid  `ArgumentCountError`

```
  Too few arguments to function Illuminate\Database\Schema\Blueprint::after(), 1 passed in /var/www/html/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php on line 18 and exactly 2 expected
```

Laravel Framework 8.30.0

Ref https://github.com/laravel/framework/blob/81ef9850cc388f2f92b868fb35ffb76f0c9a0f46/src/Illuminate/Database/Schema/Blueprint.php#L1543