### PR TITLE
[1.x] Fix two factor form without user

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,15 +8,15 @@ on:
 
 jobs:
   tests:
+    runs-on: ubuntu-18.04
 
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
         laravel: [^8.0]
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -33,11 +33,15 @@ class TwoFactorAuthenticatedSessionController extends Controller
     /**
      * Show the two factor authentication challenge view.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse
+     * @param  \Laravel\Fortify\Http\Requests\TwoFactorLoginRequest  $request
+     * @return \Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse|\Illuminate\Http\RedirectResponse
      */
-    public function create(Request $request): TwoFactorChallengeViewResponse
+    public function create(TwoFactorLoginRequest $request)
     {
+        if (! $request->hasChallengedUser()) {
+            return redirect()->route('login');
+        }
+
         return app(TwoFactorChallengeViewResponse::class);
     }
 

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -106,12 +106,12 @@ class TwoFactorLoginRequest extends FormRequest
     public function hasChallengedUser()
     {
         try {
-            $this->challengedUser();
+            $user = $this->challengedUser();
         } catch (HttpResponseException $e) {
             return false;
         }
 
-        return true;
+        return $user !== null;
     }
 
     /**

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -98,6 +98,23 @@ class TwoFactorLoginRequest extends FormRequest
         return $this->challengedUser = $user;
     }
 
+
+    /**
+     * Determine if there's a challenged user in the current session.
+     *
+     * @return bool
+     */
+    public function hasChallengedUser()
+    {
+        try {
+            $this->challengedUser();
+        } catch (HttpResponseException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Determine if the user wanted to be remembered after login.
      *

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -98,7 +98,6 @@ class TwoFactorLoginRequest extends FormRequest
         return $this->challengedUser = $user;
     }
 
-
     /**
      * Determine if there's a challenged user in the current session.
      *

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -240,6 +240,19 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $this->assertNull(Auth::getUser());
     }
 
+    public function test_two_factor_challenge_requires_a_challenged_user()
+    {
+        app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
+
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $response = $this->withSession([])->withoutExceptionHandling()->get('/two-factor-challenge');
+
+        $response->assertRedirect('/login');
+        $this->assertNull(Auth::getUser());
+    }
+
     protected function getPackageProviders($app)
     {
         return [FortifyServiceProvider::class];


### PR DESCRIPTION
This PR fixes an issue where the two factor form could still be displayed even though there's no user on session. This fix forces the controller to redirect to the login screen before the user can use the two factor view.

This PR unfortunately contains breaking changes to the method signature of the `create` method.

Fixes https://github.com/laravel/fortify/issues/231