### PR TITLE
[1.x] Fix two-factor forgotten login id from session

### DIFF
--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -63,6 +63,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
 
         $this->guard->login($user, $request->remember());
 
+        $request->session()->forget('login.id');
         $request->session()->regenerate();
 
         return app(TwoFactorLoginResponse::class);

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -105,7 +105,7 @@ class TwoFactorLoginRequest extends FormRequest
         $model = app(StatefulGuard::class)->getProvider()->getModel();
 
         if (! $this->session()->has('login.id') ||
-            ! $user = $model::find($this->session()->pull('login.id'))) {
+            ! $user = $model::find($this->session()->get('login.id'))) {
             throw new HttpResponseException(
                 app(FailedTwoFactorLoginResponse::class)->toResponse($this)
             );


### PR DESCRIPTION
In [this PR](https://github.com/laravel/fortify/pull/233) @driesvints added the enhancement I requested for two factor login page to redirect to login page if user hasn't previously submitted his username and password. 

Because the newly added method `hasChallengedUser` calls `challengedUser` method which pulls `login.id` from session the user will never be able to login because there is no `login.id` on the next (POST) request.