### PR TITLE
[1.x] Fix two factor login check

### DIFF
--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -82,13 +82,10 @@ class TwoFactorLoginRequest extends FormRequest
      */
     public function hasChallengedUser()
     {
-        try {
-            $user = $this->challengedUser();
-        } catch (HttpResponseException $e) {
-            return false;
-        }
+        $model = app(StatefulGuard::class)->getProvider()->getModel();
 
-        return $user !== null;
+        return $this->session()->has('login.id') &&
+            $model::find($this->session()->get('login.id'));
     }
 
     /**


### PR DESCRIPTION
Alternative to https://github.com/laravel/fortify/pull/234

This fixes something I broke in https://github.com/laravel/fortify/pull/233 (unreleased). Apparently the user id gets pulled from the session when the form is submitted which makes sense. This means we cannot re-use the `challengedUser` method. I've instead opted to re-use some of the code from the `challengedUser` in the `hasChallengedUser` method. 

I tested this in an actual Jetstream app and it fixes the problem.

Thanks to @amiranagram for catching this.