### PR TITLE
Remove forgot-password route name for POST request

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -53,8 +53,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-            ->middleware(['guest'])
-            ->name('password.email');
+            ->middleware(['guest']);
 
         Route::post('/reset-password', [NewPasswordController::class, 'store'])
             ->middleware(['guest'])


### PR DESCRIPTION
Based on the Laravel convention, there is no need to name a POST request route while the same route for the GET request has already a name.

In routes file, forgot-password route on GET request has a name equal to password.request

GET|HEAD |   URI :  forgot-password   |  Name:  password.request      | Laravel\Fortify\Http\Controllers\PasswordResetLinkController@create

I removed the route name of the POST request which was password.email

POST     | URI :   forgot-password  |  Name:  password.email   | Laravel\Fortify\Http\Controllers\PasswordResetLinkController@store


Breaking Points:

For the applications that are made on top of the Fortify, this change will be breaking. 

Jetstream in 2 places in stubs directory uses this name and they must be corrected as well.

Case 1: laravel/jetstream/stubs/livewire/resources/views/auth/forgot-password.blade.php

Case 2: laravel/jetstream/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue

I've just sent a PR for changing these two cases in Jetstream repository https://github.com/laravel/jetstream/pull/719 .

Best Regards,

Hamed Panjeh,
panjeh at  gmail.com