### PR TITLE
[1.x] Require password and confirmation

### DIFF
--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -55,6 +55,8 @@ class NewPasswordController extends Controller
     public function store(Request $request): Responsable
     {
         $request->validate([
+            'password' => 'required|confirmed',
+            'password_confirmation' => 'required',
             'token' => 'required',
             Fortify::email() => 'required|email',
         ]);

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -55,10 +55,10 @@ class NewPasswordController extends Controller
     public function store(Request $request): Responsable
     {
         $request->validate([
-            'password' => 'required|confirmed',
-            'password_confirmation' => 'required',
             'token' => 'required',
             Fortify::email() => 'required|email',
+            'password' => 'required|confirmed',
+            'password_confirmation' => 'required',
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -61,9 +61,6 @@ class NewPasswordControllerTest extends OrchestraTestCase
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
-        $guard = $this->mock(StatefulGuard::class);
-        $user = Mockery::mock(Authenticatable::class);
-
         $broker->shouldReceive('reset')->andReturnUsing(function ($input, $callback) {
             return Password::INVALID_TOKEN;
         });
@@ -129,5 +126,16 @@ class NewPasswordControllerTest extends OrchestraTestCase
 
         $response->assertStatus(302);
         $response->assertRedirect('/login');
+    }
+
+    public function test_password_and_password_confirmation_are_required()
+    {
+        $response = $this->post('/reset-password', [
+            'token' => 'token',
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['password', 'password_confirmation']);
     }
 }


### PR DESCRIPTION
I'm not really sure why this wasn't done before? These field are obviously required in the next step for the password broker. 

Fixes https://github.com/laravel/fortify/issues/244