### PR TITLE
Always login same way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+/.idea

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -5,7 +5,6 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Routing\Pipeline;
 use Laravel\Fortify\Contracts\LoginResponse;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\LogoutResponse;

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -6,19 +6,14 @@ use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\Pipeline;
-use Laravel\Fortify\Actions\AttemptToAuthenticate;
-use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
-use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
-use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\LoginResponse;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\Contracts\LogoutResponse;
-use Laravel\Fortify\Features;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Requests\LoginRequest;
 
 class AuthenticatedSessionController extends Controller
 {
+    use AuthenticationPipeline;
     /**
      * The guard implementation.
      *
@@ -59,34 +54,6 @@ class AuthenticatedSessionController extends Controller
         return $this->loginPipeline($request)->then(function ($request) {
             return app(LoginResponse::class);
         });
-    }
-
-    /**
-     * Get the authentication pipeline instance.
-     *
-     * @param  \Laravel\Fortify\Http\Requests\LoginRequest  $request
-     * @return \Illuminate\Pipeline\Pipeline
-     */
-    protected function loginPipeline(LoginRequest $request)
-    {
-        if (Fortify::$authenticateThroughCallback) {
-            return (new Pipeline(app()))->send($request)->through(array_filter(
-                call_user_func(Fortify::$authenticateThroughCallback, $request)
-            ));
-        }
-
-        if (is_array(config('fortify.pipelines.login'))) {
-            return (new Pipeline(app()))->send($request)->through(array_filter(
-                config('fortify.pipelines.login')
-            ));
-        }
-
-        return (new Pipeline(app()))->send($request)->through(array_filter([
-            config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
-            Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
-            AttemptToAuthenticate::class,
-            PrepareAuthenticatedSession::class,
-        ]));
     }
 
     /**

--- a/src/Http/Controllers/AuthenticationPipeline.php
+++ b/src/Http/Controllers/AuthenticationPipeline.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Fortify\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Pipeline;
+use Laravel\Fortify\Actions\AttemptToAuthenticate;
+use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
+use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
+use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\Fortify;
+
+trait AuthenticationPipeline
+{
+    /**
+     * Get the authentication pipeline instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Pipeline\Pipeline
+     */
+    protected function loginPipeline(Request $request)
+    {
+        if (Fortify::$authenticateThroughCallback) {
+            return (new Pipeline(app()))->send($request)->through(array_filter(
+                call_user_func(Fortify::$authenticateThroughCallback, $request)
+            ));
+        }
+
+        if (is_array(config('fortify.pipelines.login'))) {
+            return (new Pipeline(app()))->send($request)->through(array_filter(
+                config('fortify.pipelines.login')
+            ));
+        }
+
+        return (new Pipeline(app()))->send($request)->through(array_filter([
+            config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
+            Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
+            AttemptToAuthenticate::class,
+            PrepareAuthenticatedSession::class,
+        ]));
+    }
+}

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -4,7 +4,6 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\CreatesNewUsers;

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -2,11 +2,9 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Foundation\Auth\User;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
-use Mockery;
 
 class RegisteredUserControllerTest extends OrchestraTestCase
 {
@@ -24,32 +22,62 @@ class RegisteredUserControllerTest extends OrchestraTestCase
 
     public function test_users_can_be_created()
     {
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+
         $this->mock(CreatesNewUsers::class)
                     ->shouldReceive('create')
-                    ->andReturn(Mockery::mock(Authenticatable::class));
+                    ->andReturn(TestRegisteredUser::forceCreate([
+                        'name' => 'Taylor Otwell',
+                        'email' => 'taylor@laravel.com',
+                        'password' => bcrypt('secret'),
+                    ]));
 
-        $this->mock(StatefulGuard::class)
-                    ->shouldReceive('login')
-                    ->once();
-
-        $response = $this->post('/register', []);
+        $response = $this->post('/register', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
 
         $response->assertRedirect('/home');
     }
 
     public function test_users_can_be_created_and_redirected_to_intended_url()
     {
-        $this->mock(CreatesNewUsers::class)
-                    ->shouldReceive('create')
-                    ->andReturn(Mockery::mock(Authenticatable::class));
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
 
-        $this->mock(StatefulGuard::class)
-                    ->shouldReceive('login')
-                    ->once();
+        $this->mock(CreatesNewUsers::class)
+            ->shouldReceive('create')
+            ->andReturn(TestRegisteredUser::forceCreate([
+                'name' => 'Taylor Otwell',
+                'email' => 'taylor@laravel.com',
+                'password' => bcrypt('secret'),
+            ]));
 
         $response = $this->withSession(['url.intended' => 'http://foo.com/bar'])
-                        ->post('/register', []);
+                        ->post('/register', [
+                            'email' => 'taylor@laravel.com',
+                            'password' => 'secret',
+                        ]);
 
         $response->assertRedirect('http://foo.com/bar');
     }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['migrator']->path(__DIR__.'/../database/migrations');
+
+        $app['config']->set('auth.providers.users.model', TestRegisteredUser::class);
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+}
+
+class TestRegisteredUser extends User
+{
+    protected $table = 'users';
 }


### PR DESCRIPTION
Currently when customizing the login with `Fortify::authenticateUsing` when creating the user he logs in ignoring this customization this feature is for logging in when creating a user using the same rule as in login.