### PR TITLE
[1.x] Remove password confirmation requirement

### DIFF
--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -57,8 +57,7 @@ class NewPasswordController extends Controller
         $request->validate([
             'token' => 'required',
             Fortify::email() => 'required|email',
-            'password' => 'required|confirmed',
-            'password_confirmation' => 'required',
+            'password' => 'required',
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -128,7 +128,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertRedirect('/login');
     }
 
-    public function test_password_and_password_confirmation_are_required()
+    public function test_password_is_required()
     {
         $response = $this->post('/reset-password', [
             'token' => 'token',
@@ -136,6 +136,6 @@ class NewPasswordControllerTest extends OrchestraTestCase
         ]);
 
         $response->assertStatus(302);
-        $response->assertSessionHasErrors(['password', 'password_confirmation']);
+        $response->assertSessionHasErrors(['password']);
     }
 }


### PR DESCRIPTION
In some situations you don't need the password confirmation if this isn't part of the password reset flow.

See https://github.com/laravel/fortify/issues/253