### PR TITLE
create custom redirect to

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -4,7 +4,9 @@ namespace Laravel\Fortify;
 
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
+use Laravel\Fortify\Contracts\LoginResponse;
 use Laravel\Fortify\Contracts\LoginViewResponse;
+use Laravel\Fortify\Contracts\RegisterResponse;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
@@ -237,6 +239,17 @@ class Fortify
     public static function createUsersUsing(string $callback)
     {
         return app()->singleton(CreatesNewUsers::class, $callback);
+    }
+
+    /**
+     * Register a callback that should be used to redirect user after login.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function redirectAfterLoginUsing(callable $callback)
+    {
+        return app()->singleton(LoginResponse::class, $callback);
     }
 
     /**

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -253,6 +253,17 @@ class Fortify
     }
 
     /**
+     * Register a callback that should be used to redirect user after registered.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function redirectAfterRegisterUsing(callable $callback)
+    {
+        return app()->singleton(RegisterResponse::class, $callback);
+    }
+
+    /**
      * Register a class / callback that should be used to update user profile information.
      *
      * @param  string  $callback

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -49,7 +49,7 @@ class RegisteredUserController extends Controller
      * @return \Laravel\Fortify\Contracts\RegisterResponse
      */
     public function store(Request $request,
-                          CreatesNewUsers $creator): RegisterResponse
+                          CreatesNewUsers $creator)
     {
         event(new Registered($user = $creator->create($request->all())));
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end-users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR produces `Fortify::redirectAfterLoginUsing($callback)` and `Fortify::redirectAfterRegisterUsing($callback)` callbacks, the idea is based on ( #77 ). it gives developer **more options to customize** their redirect using callback or create another implementation of `Fortify\Http\Responses`