### PR TITLE
Add redirect config after login, logout and registration

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -10,6 +10,11 @@ return [
     'email' => 'email',
     'views' => true,
     'home' => '/home',
+    'redirect' => [
+        'login' => '/home',
+        'registration' => '/home',
+        'logout' => '/login',
+    ],
     'prefix' => '',
     'domain' => null,
     'limiters' => [

--- a/src/Http/Responses/LoginResponse.php
+++ b/src/Http/Responses/LoginResponse.php
@@ -16,6 +16,6 @@ class LoginResponse implements LoginResponseContract
     {
         return $request->wantsJson()
                     ? response()->json(['two_factor' => false])
-                    : redirect()->intended(config('fortify.home'));
+                    : redirect()->intended(config('fortify.redirect.login'));
     }
 }

--- a/src/Http/Responses/LogoutResponse.php
+++ b/src/Http/Responses/LogoutResponse.php
@@ -17,6 +17,6 @@ class LogoutResponse implements LogoutResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 204)
-                    : redirect('/');
+                    : redirect()->intended(config('fortify.redirect.logout'));
     }
 }

--- a/src/Http/Responses/RegisterResponse.php
+++ b/src/Http/Responses/RegisterResponse.php
@@ -18,6 +18,6 @@ class RegisterResponse implements RegisterResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 201)
-                    : redirect()->intended(config('fortify.home'));
+                    : redirect()->intended(config('fortify.redirect.registration'));
     }
 }

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -65,6 +65,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Redirect Paths
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the path where users will get redirected after
+    | login, registration and logout
+    |
+    */
+
+    'redirect' => [
+        'login' => RouteServiceProvider::HOME,
+        'registration' => RouteServiceProvider::HOME,
+        'logout' => '/login',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Fortify Routes Prefix / Subdomain
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
In this PR I added posibility to set redirection route after logout, login and registration. Registration route can be set inside config/fortify.php