### PR TITLE
returns json response

### DIFF
--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Http\Requests\VerifyEmailRequest;
+use Illuminate\Http\JsonResponse;
 
 class VerifyEmailController extends Controller
 {
@@ -15,16 +16,20 @@ class VerifyEmailController extends Controller
      * @param  \Laravel\Fortify\Http\Requests\VerifyEmailRequest  $request
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function __invoke(VerifyEmailRequest $request): RedirectResponse
+    public function __invoke(VerifyEmailRequest $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(config('fortify.home').'?verified=1');
+            return $request->wantsJson()
+                ? new JsonResponse('', 204)
+                : redirect()->intended(config('fortify.home').'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(config('fortify.home').'?verified=1');
+        return $request->wantsJson()
+            ? new JsonResponse('', 202)
+            : redirect()->intended(config('fortify.home').'?verified=1');
     }
 }


### PR DESCRIPTION
The VerifyEmailController only had support for returning a redirect to a page. But when using API to confirm a new user, a JSON reply is expected. Changed the code to support the functionality, that when required the response is in JSON format.

Had to remove the return type, to be able to support JSON reply.

If anything can be improved, please be my guest.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
