### PR TITLE
[1.x] Naming 2FA routes for consistency

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -137,16 +137,19 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             : ['auth'];
 
         Route::post('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'store'])
-            ->middleware($twoFactorMiddleware);
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.toggle');
 
         Route::delete('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'destroy'])
             ->middleware($twoFactorMiddleware);
 
         Route::get('/user/two-factor-qr-code', [TwoFactorQrCodeController::class, 'show'])
-            ->middleware($twoFactorMiddleware);
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.qr-code');
 
         Route::get('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'index'])
-            ->middleware($twoFactorMiddleware);
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.recovery-codes');
 
         Route::post('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'store'])
             ->middleware($twoFactorMiddleware);

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -138,10 +138,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
         Route::post('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'store'])
             ->middleware($twoFactorMiddleware)
-            ->name('two-factor.toggle');
+            ->name('two-factor.enable');
 
         Route::delete('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'destroy'])
-            ->middleware($twoFactorMiddleware);
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.disable');
 
         Route::get('/user/two-factor-qr-code', [TwoFactorQrCodeController::class, 'show'])
             ->middleware($twoFactorMiddleware)


### PR DESCRIPTION
After I included Fortify in an old Laravel project (with laravel ui), I was forced myself to use the url() helper instead the route() helper because some routes had no names on it. I added names to the following routes:
/user/two-factor-authentication => two-factor.toggle
/user/two-factor-qr-code => two-factor.qr-code
/user/two-factor-recovery-codes => two-factor.recovery-codes

Now I can use:
```php
<form method="POST" action="{{ route('two-factor.toggle') }}">
  [...]
</form>
```
instead
```php
<form method="POST" action="{{ url('/user/two-factor-authentication') }}">
  [...]
</form>
```

like other routes of Fortify. I used toggle because it enables and disables the 2FA for the user. Maybe a better name is found for that.

The tests can be modified to use route() helper but I don't know if that is really necessary.