### PR TITLE
Add opt-in feature to confirm two factor setup

### DIFF
--- a/database/migrations/2021_06_01_145800_add_two_factor_enabled_column_to_users_table.php
+++ b/database/migrations/2021_06_01_145800_add_two_factor_enabled_column_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTwoFactorEnabledColumnToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('two_factor_enabled')
+                ->after('two_factor_enabled')
+                ->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('two_factor_enabled');
+        });
+    }
+}

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -140,6 +140,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.enable');
 
+        Route::post('/user/two-factor-authentication/confirm', [TwoFactorAuthenticationController::class, 'confirm'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.confirm');
+
         Route::delete('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'destroy'])
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.disable');

--- a/src/Actions/ConfirmEnableTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmEnableTwoFactorAuthentication.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Fortify\Actions;
+
+use Illuminate\Support\Collection;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\RecoveryCode;
+
+class ConfirmEnableTwoFactorAuthentication
+{
+    /**
+     * The two factor authentication provider.
+     *
+     * @var \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider
+     */
+    protected $provider;
+
+    /**
+     * Create a new action instance.
+     *
+     * @param  \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider  $provider
+     * @return void
+     */
+    public function __construct(TwoFactorAuthenticationProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Enable two factor authentication for the user.
+     *
+     * @param  \Illuminate\Foundation\Auth\User  $user
+     * @param  string  $code
+     * @return boolean
+     */
+    public function __invoke($user, $code)
+    {
+        if (!$this->provider->verify(decrypt($user->two_factor_secret), $code)) {
+            return false;
+        }
+
+        $user->two_factor_enabled = true;
+        $user->save();
+
+        return true;
+    }
+}

--- a/src/Actions/DisableTwoFactorAuthentication.php
+++ b/src/Actions/DisableTwoFactorAuthentication.php
@@ -13,6 +13,7 @@ class DisableTwoFactorAuthentication
     public function __invoke($user)
     {
         $user->forceFill([
+            'two_factor_enabled' => false,
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
         ])->save();

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -1,44 +1,11 @@
 <?php
 
+
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Support\Collection;
-use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
-use Laravel\Fortify\RecoveryCode;
-
-class EnableTwoFactorAuthentication
+/**
+ * @deprecated
+ */
+class EnableTwoFactorAuthentication extends GenerateTwoFactorAuthenticationSecret
 {
-    /**
-     * The two factor authentication provider.
-     *
-     * @var \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider
-     */
-    protected $provider;
-
-    /**
-     * Create a new action instance.
-     *
-     * @param  \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider  $provider
-     * @return void
-     */
-    public function __construct(TwoFactorAuthenticationProvider $provider)
-    {
-        $this->provider = $provider;
-    }
-
-    /**
-     * Enable two factor authentication for the user.
-     *
-     * @param  mixed  $user
-     * @return void
-     */
-    public function __invoke($user)
-    {
-        $user->forceFill([
-            'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
-            'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
-                return RecoveryCode::generate();
-            })->all())),
-        ])->save();
-    }
 }

--- a/src/Actions/GenerateTwoFactorAuthenticationSecret.php
+++ b/src/Actions/GenerateTwoFactorAuthenticationSecret.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Fortify\Actions;
+
+use Illuminate\Support\Collection;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\RecoveryCode;
+
+class GenerateTwoFactorAuthenticationSecret
+{
+    /**
+     * The two factor authentication provider.
+     *
+     * @var \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider
+     */
+    protected $provider;
+
+    /**
+     * Create a new action instance.
+     *
+     * @param  \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider  $provider
+     * @return void
+     */
+    public function __construct(TwoFactorAuthenticationProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Generate two factor authentication secret and recovery codes for the user.
+     *
+     * @param  mixed  $user
+     * @return void
+     */
+    public function __invoke($user)
+    {
+        $user->forceFill([
+            'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
+            'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
+                return RecoveryCode::generate();
+            })->all())),
+        ])->save();
+    }
+}

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -49,7 +49,7 @@ class RedirectIfTwoFactorAuthenticatable
     {
         $user = $this->validateCredentials($request);
 
-        if (optional($user)->two_factor_secret &&
+        if (optional($user)->two_factor_enabled &&
             in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
             return $this->twoFactorChallengeResponse($request, $user);
         }

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -49,7 +49,7 @@ class RedirectIfTwoFactorAuthenticatable
     {
         $user = $this->validateCredentials($request);
 
-        if (optional($user)->two_factor_enabled &&
+        if (optional($user)->isTwoFactorEnabled() &&
             in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
             return $this->twoFactorChallengeResponse($request, $user);
         }

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -5,8 +5,9 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Actions\GenerateTwoFactorAuthenticationSecret;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
-use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\ConfirmEnableTwoFactorAuthentication;
 
 class TwoFactorAuthenticationController extends Controller
 {
@@ -14,16 +15,36 @@ class TwoFactorAuthenticationController extends Controller
      * Enable two factor authentication for the user.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
+     * @param  \Laravel\Fortify\Actions\GenerateTwoFactorAuthenticationSecret  $enable
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function store(Request $request, EnableTwoFactorAuthentication $enable)
+    public function store(Request $request, GenerateTwoFactorAuthenticationSecret $generate)
     {
-        $enable($request->user());
+        $generate($request->user());
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)
                     : back()->with('status', 'two-factor-authentication-enabled');
+    }
+
+    /**
+     * Confirms activation of two-factor authentication by validating a TOTP code
+     * @param  \Illuminate\Http\Request  $request
+     * @param \Laravel\Fortify\Actions\ConfirmEnableTwoFactorAuthentication $confirm
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function confirm(Request $request, ConfirmEnableTwoFactorAuthentication $enable)
+    {
+        if (!$enable($request->user(), $request->code)) {
+            $error = __('The provided two factor authentication code was invalid.');
+            return $request->wantsJson()
+                ? new JsonResponse($error, 422)
+                : back()->withErrors($error);
+        }
+
+        return $request->wantsJson()
+            ? new JsonResponse('', 200)
+            : back();
     }
 
     /**

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -23,6 +23,20 @@ trait TwoFactorAuthenticatable
     }
 
     /**
+     * Check if two factor authentication is enabled for user.
+     *
+     * @return string|boolean
+     */
+    public function isTwoFactorEnabled()
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmTwoFactor')) {
+            return $this->two_factor_enabled;
+        }
+
+        return $this->two_factor_secret;
+    }
+
+    /**
      * Replace the given recovery code with a new one in the user's stored codes.
      *
      * @param  string  $code


### PR DESCRIPTION
As described in [#201](https://github.com/laravel/fortify/issues/201), the current 2FA solution can be activated without the user actually having done the proper configuration preventing them from logging in.

I added a new route and an action to confirm 2FA setup using a TOTP code.

I also moved the contents of the EnableTwoFactorAuthentication action to a new one called GenerateTwoFactorAuthenticationSecret but keep the original to avoid breaking changes.