### PR TITLE
Use remember property value vs. presence to determine if the user is remembered 

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -52,7 +52,7 @@ class AttemptToAuthenticate
 
         if ($this->guard->attempt(
             $request->only(Fortify::username(), 'password'),
-            $request->filled('remember'))
+            $request->boolean('remember'))
         ) {
             return $next($request);
         }
@@ -77,7 +77,7 @@ class AttemptToAuthenticate
             return $this->throwFailedAuthenticationException($request);
         }
 
-        $this->guard->login($user, $request->filled('remember'));
+        $this->guard->login($user, $request->boolean('remember'));
 
         return $next($request);
     }

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -129,7 +129,7 @@ class RedirectIfTwoFactorAuthenticatable
     {
         $request->session()->put([
             'login.id' => $user->getKey(),
-            'login.remember' => $request->filled('remember'),
+            'login.remember' => $request->boolean('remember'),
         ]);
 
         return $request->wantsJson()


### PR DESCRIPTION
When making a login request to Fortify, the user is still remembered when the `remember` property is set to a falsy value. This is because Fortify uses the `filled()` method to check for the remember property.

I think this can be confusing for users and when reading the [documentation](https://laravel.com/docs/8.x/fortify#authentication), it seems like a bug in the way it is worded.

> In addition, a boolean remember field may be provided to indicate that the user would like to use the "remember me" functionality provided by Laravel.

This PR just updates Fortify to utilize the `boolean()` method to check for the remember property just like Breeze does.