### PR TITLE
Update comments to reflect redirect to login after password reset.

### DIFF
--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -73,8 +73,8 @@ class NewPasswordController extends Controller
         );
 
         // If the password was successfully reset, we will redirect the user back to
-        // the application's home authenticated view. If there is an error we can
-        // redirect them back to where they came from with their error message.
+        // the application's login view. If there is an error we can redirect them
+        // back to where they came from with their error message.
         return $status == Password::PASSWORD_RESET
                     ? app(PasswordResetResponse::class, ['status' => $status])
                     : app(FailedPasswordResetResponse::class, ['status' => $status]);

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -56,8 +56,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you may configure the path where users will get redirected during
-    | authentication or password reset when the operations are successful
-    | and the user is authenticated. You are free to change this value.
+    | authentication when the operation is successful and the user is
+    | authenticated. You are free to change this value.
     |
     */
 


### PR DESCRIPTION
This PR aims to fix minor comment discrepancies about the redirect location after a user resets their password. 

After successful password reset, the user will be redirected back to login not the application dashboard so I have updated comments in the stub and NewPasswordController. It looks like a couple of comments were missed after the implementation of the change in behaviour so this change will improve clarity for developers using Fortify. 

Documentation of the change in behaviour:
User redirects back to dashboard: https://laravel.com/docs/7.x/passwords#after-resetting-passwords
User redirects back to login: https://laravel.com/docs/8.x/fortify#handling-the-password-reset-response