### PR TITLE
[1.x] Add config to allow signed:relative in email verification

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -9,6 +9,7 @@ return [
     'username' => 'email',
     'email' => 'email',
     'views' => true,
+    'signed_relative' => false,
     'home' => '/home',
     'prefix' => '',
     'domain' => null,

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -20,6 +20,7 @@ use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
     $enableViews = config('fortify.views', true);
+    $signedMiddleware = config('fortify.signed_relative', false) ? 'signed:relative' : 'signed';
 
     // Authentication...
     if ($enableViews) {
@@ -82,7 +83,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::get('/email/verify/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-            ->middleware(['auth', 'signed', 'throttle:6,1'])
+            ->middleware(['auth', $signedMiddleware, 'throttle:6,1'])
             ->name('verification.verify');
 
         Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -122,6 +122,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Use Relative Signed Url In Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify if the signed middleware applied to the email
+    | verification verify route should use a relative url.
+    |
+    */
+
+    'signed_relative' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Features
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Hello 👋 

this PR enables the option to use the signed:relative middleware as described in [33137](https://github.com/laravel/framework/pull/33137). It defaults to false.

I used fortify with a separate frontend, and changed the email verification link through `createUrlUsing` setting the absolute parameter to false. This allowed me to prefix my frontend domain and send the verify request from there. For that to go through it is required to also set the `signed:relative` middleware.
