### PR TITLE
feat: redirection customization

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -15,6 +15,13 @@ return [
     'limiters' => [
         'login' => null,
     ],
+    'redirects' => [
+        'login' => null,
+        'logout' => null,
+        'password-confirmed' => null,
+        'register' => null,
+        'email-verification' => null,
+    ],
     'features' => [
         Features::registration(),
         Features::resetPasswords(),

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -18,7 +18,7 @@ return [
     'redirects' => [
         'login' => null,
         'logout' => null,
-        'password-confirmed' => null,
+        'password-confirmation' => null,
         'register' => null,
         'email-verification' => null,
     ],

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -73,7 +73,7 @@ class Fortify
      */
     public static function redirects(string $redirect, $default = null)
     {
-        return config('fortify.redirects.'.$redirect, $default) ?? config('fortify.home');
+        return config('fortify.redirects.'.$redirect) ?? $default ?? config('fortify.home');
     }
 
     /**

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -66,6 +66,17 @@ class Fortify
     }
 
     /**
+     * Get the redirect path.
+     *
+     * @param  string  $redirect
+     * @return string
+     */
+    public static function redirects(string $redirect, $default = null)
+    {
+        return config('fortify.redirects.'.$redirect, $default) ?? config('fortify.home');
+    }
+
+    /**
      * Register the views for Fortify using conventional names under the given namespace.
      *
      * @param  string  $namespace

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -66,7 +66,7 @@ class Fortify
     }
 
     /**
-     * Get the redirect path.
+     * Get a completion redirect path for a specific feature.
      *
      * @param  string  $redirect
      * @return string

--- a/src/Http/Controllers/EmailVerificationNotificationController.php
+++ b/src/Http/Controllers/EmailVerificationNotificationController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Fortify;
 
 class EmailVerificationNotificationController extends Controller
 {
@@ -19,7 +20,7 @@ class EmailVerificationNotificationController extends Controller
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
                         ? new JsonResponse('', 204)
-                        : redirect()->intended(config('fortify.home'));
+                        : redirect()->intended(Fortify::redirects('email-verification'));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/src/Http/Controllers/EmailVerificationPromptController.php
+++ b/src/Http/Controllers/EmailVerificationPromptController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
+use Laravel\Fortify\Fortify;
 
 class EmailVerificationPromptController extends Controller
 {
@@ -17,7 +18,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request)
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(config('fortify.home'))
+                    ? redirect()->intended(Fortify::redirects('email-verification'))
                     : app(VerifyEmailViewResponse::class);
     }
 }

--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Requests\VerifyEmailRequest;
 
 class VerifyEmailController extends Controller
@@ -20,7 +21,7 @@ class VerifyEmailController extends Controller
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
                 ? new JsonResponse('', 204)
-                : redirect()->intended(config('fortify.home').'?verified=1');
+                : redirect()->intended(Fortify::redirects('email-verification').'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
@@ -29,6 +30,6 @@ class VerifyEmailController extends Controller
 
         return $request->wantsJson()
             ? new JsonResponse('', 202)
-            : redirect()->intended(config('fortify.home').'?verified=1');
+            : redirect()->intended(Fortify::redirects('email-verification').'?verified=1');
     }
 }

--- a/src/Http/Responses/FailedPasswordConfirmationResponse.php
+++ b/src/Http/Responses/FailedPasswordConfirmationResponse.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswordConfirmationResponseContract;
 
@@ -24,6 +23,6 @@ class FailedPasswordConfirmationResponse implements FailedPasswordConfirmationRe
             ]);
         }
 
-        return redirect()->back()->withErrors(['password' => $message]);
+        return back()->withErrors(['password' => $message]);
     }
 }

--- a/src/Http/Responses/FailedPasswordResetResponse.php
+++ b/src/Http/Responses/FailedPasswordResetResponse.php
@@ -39,8 +39,8 @@ class FailedPasswordResetResponse implements FailedPasswordResetResponseContract
             ]);
         }
 
-        return redirect()->back()
-                    ->withInput($request->only('email'))
-                    ->withErrors(['email' => trans($this->status)]);
+        return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => trans($this->status)]);
     }
 }

--- a/src/Http/Responses/LoginResponse.php
+++ b/src/Http/Responses/LoginResponse.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Fortify;
 
 class LoginResponse implements LoginResponseContract
 {
@@ -16,6 +17,6 @@ class LoginResponse implements LoginResponseContract
     {
         return $request->wantsJson()
                     ? response()->json(['two_factor' => false])
-                    : redirect()->intended(config('fortify.home'));
+                    : redirect()->intended(Fortify::redirects('login'));
     }
 }

--- a/src/Http/Responses/LogoutResponse.php
+++ b/src/Http/Responses/LogoutResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
+use Laravel\Fortify\Fortify;
 
 class LogoutResponse implements LogoutResponseContract
 {
@@ -17,6 +18,6 @@ class LogoutResponse implements LogoutResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 204)
-                    : redirect('/');
+                    : redirect(Fortify::redirects('logout', '/'));
     }
 }

--- a/src/Http/Responses/PasswordConfirmedResponse.php
+++ b/src/Http/Responses/PasswordConfirmedResponse.php
@@ -18,6 +18,6 @@ class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 201)
-                    : redirect()->intended(Fortify::redirects('password-confirmed'));
+                    : redirect()->intended(Fortify::redirects('password-confirmation'));
     }
 }

--- a/src/Http/Responses/PasswordConfirmedResponse.php
+++ b/src/Http/Responses/PasswordConfirmedResponse.php
@@ -3,8 +3,8 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
+use Laravel\Fortify\Fortify;
 
 class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
 {
@@ -18,6 +18,6 @@ class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 201)
-                    : redirect()->intended(config('fortify.home'));
+                    : redirect()->intended(Fortify::redirects('password-confirmed'));
     }
 }

--- a/src/Http/Responses/RegisterResponse.php
+++ b/src/Http/Responses/RegisterResponse.php
@@ -3,8 +3,8 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
+use Laravel\Fortify\Fortify;
 
 class RegisterResponse implements RegisterResponseContract
 {
@@ -18,6 +18,6 @@ class RegisterResponse implements RegisterResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 201)
-                    : redirect()->intended(config('fortify.home'));
+                    : redirect()->intended(Fortify::redirects('register'));
     }
 }

--- a/src/Http/Responses/TwoFactorLoginResponse.php
+++ b/src/Http/Responses/TwoFactorLoginResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
 {
@@ -17,6 +18,6 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse('', 204)
-                    : redirect()->intended(config('fortify.home'));
+                    : redirect()->intended(Fortify::redirects('login'));
     }
 }


### PR DESCRIPTION
Resolve #77 

Added `redirects` on Fortify configuration.

```php
'redirects' => [
    'login' => null,
    'logout' => null,
    'password-confirmed' => null,
    'register' => null,
    'email-verification' => null,
],
```

if not defined or null, `config('fortify.home')` will be used.