### PR TITLE
[1.x] Prevent duplicate query using user from request

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -72,7 +72,7 @@ class AttemptToAuthenticate
         $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
 
         if (! $user) {
-            $this->fireFailedEvent($request, $user);
+            $this->fireFailedEvent($request);
 
             return $this->throwFailedAuthenticationException($request);
         }
@@ -103,12 +103,11 @@ class AttemptToAuthenticate
      * Fire the failed authentication attempt event with the given arguments.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return void
      */
-    protected function fireFailedEvent($request, $user = null)
+    protected function fireFailedEvent($request)
     {
-        event(new Failed(config('fortify.guard'), $user, [
+        event(new Failed(config('fortify.guard'), null, [
             Fortify::username() => $request->{Fortify::username()},
             'password' => $request->password,
         ]));

--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -50,7 +50,7 @@ class AttemptToAuthenticate
             return $this->handleUsingCustomCallback($request, $next);
         }
 
-        if ($this->guard->attempt(
+        if ($request->user() || $this->guard->attempt(
             $request->only(Fortify::username(), 'password'),
             $request->filled('remember'))
         ) {
@@ -72,7 +72,7 @@ class AttemptToAuthenticate
         $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
 
         if (! $user) {
-            $this->fireFailedEvent($request);
+            $this->fireFailedEvent($request, $user);
 
             return $this->throwFailedAuthenticationException($request);
         }
@@ -103,11 +103,12 @@ class AttemptToAuthenticate
      * Fire the failed authentication attempt event with the given arguments.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return void
      */
-    protected function fireFailedEvent($request)
+    protected function fireFailedEvent($request, $user = null)
     {
-        event(new Failed(config('fortify.guard'), null, [
+        event(new Failed(config('fortify.guard'), $user, [
             Fortify::username() => $request->{Fortify::username()},
             'password' => $request->password,
         ]));

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -79,7 +79,7 @@ class RedirectIfTwoFactorAuthenticatable
 
         $model = $this->guard->getProvider()->getModel();
 
-        return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use($request) {
+        return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use ($request) {
             if (! $user || ! $this->guard->getProvider()->validateCredentials($user, ['password' => $request->password])) {
                 $this->fireFailedEvent($request, $user);
 

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -68,7 +68,7 @@ class RedirectIfTwoFactorAuthenticatable
         if (Fortify::$authenticateUsingCallback) {
             return tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request) {
                 if (! $user) {
-                    $this->fireFailedEvent($request, $user);
+                    $this->fireFailedEvent($request);
 
                     return $this->throwFailedAuthenticationException($request);
                 }


### PR DESCRIPTION
Resolve #120

@driesvints Both classes have very similar parts, do you think it's valid to abstract to another class? Ex: `AbstractAuthenticate`
