### PR TITLE
add `as` route paramter

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -129,6 +129,7 @@ class FortifyServiceProvider extends ServiceProvider
                 'namespace' => 'Laravel\Fortify\Http\Controllers',
                 'domain' => config('fortify.domain', null),
                 'prefix' => config('fortify.prefix'),
+                'as'  => config('fortify.route_suffix', null),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -78,6 +78,7 @@ return [
 
     'domain' => null,
 
+    'route_suffix'  => null,
     /*
     |--------------------------------------------------------------------------
     | Fortify Routes Middleware


### PR DESCRIPTION
This PR is followed issue https://github.com/laravel/fortify/issues/314, I created before. And It contains the following:


### Description
When I'm working on a project using Jetstream and fortify for authentication scaffolding, I faced a situation to ignore the default routes and create custom routes just for adding suffix for the `route names`, I think it would be a better idea to add `as` option on the route configuration and set it to null as the `domain` option.

### Steps to Reproduce
Sometimes we need to check if the route belongs to the `authentication routes` or a normal route to make certain operations (such as hide the `navbar` or something). So, instead of let's say

```blade
@if(! request()->routeIs('login', 'register', '...')
   Show navbar
@endif
```

We can just do this

```blade
@if(! request()->routeIs('auth.*'))
   show navbar
@endif
```

### The Solution
The solution actually is pretty simple, we need to add the `as` option into `configureRoutes` inside `fortifyServiceProvider` & `fortify` config file.