### PR TITLE
Use provider methods instead of model for 2FA

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -73,9 +73,11 @@ class RedirectIfTwoFactorAuthenticatable
             });
         }
 
-        $model = $this->guard->getProvider()->getModel();
+        $user = $this->guard->getProvider()->retrieveByCredentials([
+            Fortify::username() => $request->{Fortify::username()},
+        ]);
 
-        return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use ($request) {
+        return tap($user, function ($user) use ($request) {
             if (! $user || ! Hash::check($request->password, $user->password)) {
                 $this->throwFailedAuthenticationException($request);
             }

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -86,10 +86,10 @@ class TwoFactorLoginRequest extends FormRequest
             return $this->challengedUser;
         }
 
-        $model = app(StatefulGuard::class)->getProvider()->getModel();
+        $provider = app(StatefulGuard::class)->getProvider();
 
         if (! $this->session()->has('login.id') ||
-            ! $user = $model::find($this->session()->pull('login.id'))) {
+            ! $user = $provider->retrieveById($this->session()->pull('login.id'))) {
             throw new HttpResponseException(
                 app(FailedTwoFactorLoginResponse::class)->toResponse($this)
             );


### PR DESCRIPTION
### Description:
Current 2FA validation ignores custom authentication providers. When there's a provider defined that extends `Illuminate\Auth\EloquentUserProvider` with a custom query in `newModelQuery` method, it is ignored and instead, user search is done by calling on models, so it bypasses  `newModelQuery` method.

### Steps To Reproduce:
1. Create a provider that extends `Illuminate\Auth\EloquentUserProvider`.
2. Overwrite `newModelQuery` method and add to query something that would certainly not return a user, like 
```php
    protected function newModelQuery($model = null)
    {
        return parent::newModelQuery($model)
            ->where('id', '=', -1);
    }
```
3. Try to log in with a gate that has the previously created provider.
4. `\Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable::validateCredentials` will still find the user and will try to validate credentials.