### PR TITLE
Use `boolean` rather than `filled` for remember

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -52,7 +52,7 @@ class AttemptToAuthenticate
 
         if ($this->guard->attempt(
             $request->only(Fortify::username(), 'password'),
-            $request->filled('remember'))
+            $request->boolean('remember'))
         ) {
             return $next($request);
         }
@@ -77,7 +77,7 @@ class AttemptToAuthenticate
             return $this->throwFailedAuthenticationException($request);
         }
 
-        $this->guard->login($user, $request->filled('remember'));
+        $this->guard->login($user, $request->boolean('remember'));
 
         return $next($request);
     }


### PR DESCRIPTION
Right now, it's only checking if `remember` is filled. For AJAX-based requests (such as with Inertia), passing `remember: false` still remembers their auth session.

Using `boolean` on a non-existent property also resolves to `false`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
