### PR TITLE
[1.x] Fix an issue with array to string conversion

### DIFF
--- a/stubs/FortifyServiceProvider.php
+++ b/stubs/FortifyServiceProvider.php
@@ -37,7 +37,9 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
         RateLimiter::for('login', function (Request $request) {
-            return Limit::perMinute(5)->by($request->email.$request->ip());
+            $email = (string) $request->email;
+
+            return Limit::perMinute(5)->by($email.$request->ip());
         });
 
         RateLimiter::for('two-factor', function (Request $request) {


### PR DESCRIPTION
If a different type than string (like an array) is posted for the login route then an array to string error can occur. Doing a simple string type cast prevents this.

Fixes https://github.com/laravel/fortify/issues/332