### PR TITLE
Check if authenticated user has 2FA enabled

### DIFF
--- a/src/Http/Controllers/TwoFactorQrCodeController.php
+++ b/src/Http/Controllers/TwoFactorQrCodeController.php
@@ -15,6 +15,10 @@ class TwoFactorQrCodeController extends Controller
      */
     public function show(Request $request)
     {
+        if (is_null($request->user()->two_factor_secret)) {
+            return [];
+        }
+        
         return response()->json(['svg' => $request->user()->twoFactorQrCodeSvg()]);
     }
 }

--- a/src/Http/Controllers/TwoFactorQrCodeController.php
+++ b/src/Http/Controllers/TwoFactorQrCodeController.php
@@ -18,7 +18,7 @@ class TwoFactorQrCodeController extends Controller
         if (is_null($request->user()->two_factor_secret)) {
             return [];
         }
-        
+
         return response()->json(['svg' => $request->user()->twoFactorQrCodeSvg()]);
     }
 }


### PR DESCRIPTION
Even when a user does not have 2FA enabled access to ```/user/two-factor-qr-code``` is allowed which throw 
```
Illuminate\Contracts\Encryption\DecryptException
The payload is invalid.
``` 
Or in production:
```
500 | SERVER ERROR
``` 

This commit checks if the authenticated user has 2FA enabled before returning a response, in the case the user does not have 2FA enabled an empty array will return to the user (following the same logic from ```/user/two-factor-recovery-codes```).
