### PR TITLE
[2FA] Entering an invalid 2FA code redirects back to re-enter the code

### DIFF
--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -63,7 +63,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
         } elseif (! $request->hasValidCode()) {
             $request->session()->put([
                 'login.id' => $user->getKey(),
-                'login.remember' => $request->filled('remember'),
+                'login.remember' => $request->remember(),
             ]);
 
             return app(FailedTwoFactorLoginResponse::class);

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -61,6 +61,11 @@ class TwoFactorAuthenticatedSessionController extends Controller
 
             event(new RecoveryCodeReplaced($user, $code));
         } elseif (! $request->hasValidCode()) {
+            $request->session()->put([
+                'login.id' => $user->getKey(),
+                'login.remember' => $request->filled('remember'),
+            ]);
+
             return app(FailedTwoFactorLoginResponse::class);
         }
 

--- a/src/Http/Responses/FailedTwoFactorLoginResponse.php
+++ b/src/Http/Responses/FailedTwoFactorLoginResponse.php
@@ -15,7 +15,11 @@ class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContra
      */
     public function toResponse($request)
     {
-        $message = __('The provided two factor authentication code was invalid.');
+        if ($request->filled('code')) {
+            $message = __('The provided two factor authentication code was invalid.');
+        } elseif ($request->filled('recovery_code')) {
+            $message = __('The provided recovery code was invalid.');
+        }
 
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([
@@ -23,6 +27,6 @@ class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContra
             ]);
         }
 
-        return redirect()->route('login')->withErrors(['code' => $message]);
+        return redirect()->route('two-factor.login')->withErrors(['code' => $message]);
     }
 }

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -242,7 +242,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'recovery_code' => 'missing-code',
         ]);
 
-        $response->assertRedirect('/login');
+        $response->assertRedirect('/two-factor-challenge');
         $this->assertNull(Auth::getUser());
     }
 


### PR DESCRIPTION
This PR solves #343 
#### Changes
- Entering an invalid 2FA code results in a redirect back to allow the user to re-enter the code
- More meaningful error message when a user enters an invalid recovery code vs 2FA code

The benefit to the end-users would be a better UX in my opinion as described previously in #343 
