### PR TITLE
Customisable login validation rules

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -106,6 +106,7 @@ class FortifyServiceProvider extends ServiceProvider
                 __DIR__.'/../stubs/CreateNewUser.php' => app_path('Actions/Fortify/CreateNewUser.php'),
                 __DIR__.'/../stubs/FortifyServiceProvider.php' => app_path('Providers/FortifyServiceProvider.php'),
                 __DIR__.'/../stubs/PasswordValidationRules.php' => app_path('Actions/Fortify/PasswordValidationRules.php'),
+                __DIR__.'/../stubs/LoginValidationRules.php' => app_path('Actions/Fortify/LoginValidationRules.php'),
                 __DIR__.'/../stubs/ResetUserPassword.php' => app_path('Actions/Fortify/ResetUserPassword.php'),
                 __DIR__.'/../stubs/UpdateUserProfileInformation.php' => app_path('Actions/Fortify/UpdateUserProfileInformation.php'),
                 __DIR__.'/../stubs/UpdateUserPassword.php' => app_path('Actions/Fortify/UpdateUserPassword.php'),

--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -2,11 +2,13 @@
 
 namespace Laravel\Fortify\Http\Requests;
 
+use App\Actions\Fortify\LoginValidationRules;
 use Illuminate\Foundation\Http\FormRequest;
-use Laravel\Fortify\Fortify;
 
 class LoginRequest extends FormRequest
 {
+    use LoginValidationRules;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -24,9 +26,6 @@ class LoginRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            Fortify::username() => 'required|string',
-            'password' => 'required|string',
-        ];
+        return $this->loginRules();
     }
 }

--- a/stubs/LoginValidationRules.php
+++ b/stubs/LoginValidationRules.php
@@ -16,7 +16,7 @@ trait LoginValidationRules
     {
         return [
             Fortify::username() => ['required', 'string'],
-            'password' => ['required', 'string', new Password],
+            'password' => ['required', 'string'],
         ];
     }
 }

--- a/stubs/LoginValidationRules.php
+++ b/stubs/LoginValidationRules.php
@@ -15,7 +15,7 @@ trait LoginValidationRules
     protected function loginRules()
     {
         return [
-            Fortify::username() => 'required|string',
+            Fortify::username() => ['required', 'string'],
             'password' => ['required', 'string', new Password],
         ];
     }

--- a/stubs/LoginValidationRules.php
+++ b/stubs/LoginValidationRules.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use Laravel\Fortify\Fortify;
+use Laravel\Fortify\Rules\Password;
+
+trait LoginValidationRules
+{
+    /**
+     * Get the login validation rules.
+     *
+     * @return array
+     */
+    protected function loginRules()
+    {
+        return [
+            Fortify::username() => 'required|string',
+            'password' => ['required', 'string', new Password],
+        ];
+    }
+}

--- a/stubs/LoginValidationRules.php
+++ b/stubs/LoginValidationRules.php
@@ -3,7 +3,6 @@
 namespace App\Actions\Fortify;
 
 use Laravel\Fortify\Fortify;
-use Laravel\Fortify\Rules\Password;
 
 trait LoginValidationRules
 {

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -16,6 +16,8 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 use Mockery;
 use PragmaRX\Google2FA\Google2FA;
 
+require_once __DIR__.'/../stubs/LoginValidationRules.php';
+
 class AuthenticatedSessionControllerTest extends OrchestraTestCase
 {
     public function test_the_login_view_is_returned()
@@ -37,12 +39,12 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         TestAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
+            'password' => bcrypt('password'),
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'password' => 'password',
         ]);
 
         $response->assertRedirect('/home');
@@ -63,13 +65,13 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
+            'password' => bcrypt('password'),
             'two_factor_secret' => 'test-secret',
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'password' => 'password',
         ]);
 
         $response->assertRedirect('/two-factor-challenge');
@@ -96,13 +98,13 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
+            'password' => bcrypt('password'),
             'two_factor_secret' => 'test-secret',
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'password' => 'password',
         ]);
 
         $response->assertRedirect('/home');
@@ -136,7 +138,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
         $response = $this->postJson('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'password' => 'password',
         ]);
 
         $response->assertStatus(429);
@@ -181,7 +183,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
+            'password' => bcrypt('password'),
             'two_factor_secret' => encrypt($userSecret),
         ]);
 
@@ -205,7 +207,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
+            'password' => bcrypt('password'),
             'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code'])),
         ]);
 
@@ -231,7 +233,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
+            'password' => bcrypt('password'),
             'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code'])),
         ]);
 

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -39,12 +39,12 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         TestAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('secret'),
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'password',
+            'password' => 'secret',
         ]);
 
         $response->assertRedirect('/home');
@@ -65,13 +65,13 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('secret'),
             'two_factor_secret' => 'test-secret',
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'password',
+            'password' => 'secret',
         ]);
 
         $response->assertRedirect('/two-factor-challenge');
@@ -98,13 +98,13 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('secret'),
             'two_factor_secret' => 'test-secret',
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'password',
+            'password' => 'secret',
         ]);
 
         $response->assertRedirect('/home');
@@ -138,7 +138,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
         $response = $this->postJson('/login', [
             'email' => 'taylor@laravel.com',
-            'password' => 'password',
+            'password' => 'secret',
         ]);
 
         $response->assertStatus(429);
@@ -183,7 +183,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('secret'),
             'two_factor_secret' => encrypt($userSecret),
         ]);
 
@@ -207,7 +207,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code'])),
         ]);
 
@@ -233,7 +233,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['invalid-code', 'valid-code'])),
         ]);
 


### PR DESCRIPTION
This takes the currently password trait implementation and does the same again but for the login validation rules. There's not a whole lot to it as a PR, but it does increase the flexibility of people wanting to change the validation rules since the LoginRequest cannot be overridden.