### PR TITLE
Add VerifyEmailResponse contract

### DIFF
--- a/src/Contracts/VerifyEmailResponse.php
+++ b/src/Contracts/VerifyEmailResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface VerifyEmailResponse extends Responsable
+{
+    //
+}

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -20,6 +20,7 @@ use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 use Laravel\Fortify\Http\Responses\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
@@ -33,6 +34,7 @@ use Laravel\Fortify\Http\Responses\PasswordUpdateResponse;
 use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
+use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -77,6 +79,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(PasswordUpdateResponseContract::class, PasswordUpdateResponse::class);
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(SuccessfulPasswordResetLinkRequestResponseContract::class, SuccessfulPasswordResetLinkRequestResponse::class);
+        $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
     }
 
     /**

--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -3,9 +3,7 @@
 namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Requests\VerifyEmailRequest;
 use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
 

--- a/src/Http/Controllers/VerifyEmailController.php
+++ b/src/Http/Controllers/VerifyEmailController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Requests\VerifyEmailRequest;
+use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
 
 class VerifyEmailController extends Controller
 {
@@ -14,22 +15,18 @@ class VerifyEmailController extends Controller
      * Mark the authenticated user's email address as verified.
      *
      * @param  \Laravel\Fortify\Http\Requests\VerifyEmailRequest  $request
-     * @return \Illuminate\Http\Response
+     * @return \Laravel\Fortify\Contracts\VerifyEmailResponse
      */
     public function __invoke(VerifyEmailRequest $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return $request->wantsJson()
-                ? new JsonResponse('', 204)
-                : redirect()->intended(Fortify::redirects('email-verification').'?verified=1');
+            return app(VerifyEmailResponse::class);
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return $request->wantsJson()
-            ? new JsonResponse('', 202)
-            : redirect()->intended(Fortify::redirects('email-verification').'?verified=1');
+        return app(VerifyEmailResponse::class);
     }
 }

--- a/src/Http/Responses/VerifyEmailResponse.php
+++ b/src/Http/Responses/VerifyEmailResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+use Laravel\Fortify\Fortify;
+
+class VerifyEmailResponse implements VerifyEmailResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $request->wantsJson()
+            ? new JsonResponse('', 204)
+            : redirect()->intended(Fortify::redirects('email-verification').'?verified=1');
+    }
+}


### PR DESCRIPTION
This PR adds a `VerifyEmailResponse` contract to let you modify the response returned after the email verification.

In some projects, you may need to change the default response. For example:

- to flash a success message in the session,
- or to have a dynamic redirection that depends on some user parameters.

