### PR TITLE
[1.x] Prevent new login after failed 2FA

### DIFF
--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -54,9 +54,13 @@ class TwoFactorLoginRequest extends FormRequest
      */
     public function hasValidCode()
     {
-        return $this->code && app(TwoFactorAuthenticationProvider::class)->verify(
+        return $this->code && tap(app(TwoFactorAuthenticationProvider::class)->verify(
             decrypt($this->challengedUser()->two_factor_secret), $this->code
-        );
+        ), function ($result) {
+            if ($result) {
+                $this->session()->forget('login.id');
+            }
+        });
     }
 
     /**
@@ -70,8 +74,12 @@ class TwoFactorLoginRequest extends FormRequest
             return;
         }
 
-        return collect($this->challengedUser()->recoveryCodes())->first(function ($code) {
+        return tap(collect($this->challengedUser()->recoveryCodes())->first(function ($code) {
             return hash_equals($this->recovery_code, $code) ? $code : null;
+        }), function ($code) {
+            if ($code) {
+                $this->session()->forget('login.id');
+            }
         });
     }
 
@@ -102,7 +110,7 @@ class TwoFactorLoginRequest extends FormRequest
         $model = app(StatefulGuard::class)->getProvider()->getModel();
 
         if (! $this->session()->has('login.id') ||
-            ! $user = $model::find($this->session()->pull('login.id'))) {
+            ! $user = $model::find($this->session()->get('login.id'))) {
             throw new HttpResponseException(
                 app(FailedTwoFactorLoginResponse::class)->toResponse($this)
             );

--- a/src/Http/Responses/FailedTwoFactorLoginResponse.php
+++ b/src/Http/Responses/FailedTwoFactorLoginResponse.php
@@ -23,6 +23,6 @@ class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContra
             ]);
         }
 
-        return redirect()->route('login')->withErrors(['email' => $message]);
+        return redirect()->route('two-factor.login')->withErrors(['email' => $message]);
     }
 }

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -192,7 +192,8 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'code' => $validOtp,
         ]);
 
-        $response->assertRedirect('/home');
+        $response->assertRedirect('/home')
+            ->assertSessionMissing('login.id');
     }
 
     public function test_two_factor_challenge_can_be_passed_via_recovery_code()
@@ -216,7 +217,8 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'recovery_code' => 'valid-code',
         ]);
 
-        $response->assertRedirect('/home');
+        $response->assertRedirect('/home')
+            ->assertSessionMissing('login.id');
         $this->assertNotNull(Auth::getUser());
         $this->assertNotContains('valid-code', json_decode(decrypt($user->fresh()->two_factor_recovery_codes), true));
     }
@@ -242,7 +244,8 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'recovery_code' => 'missing-code',
         ]);
 
-        $response->assertRedirect('/login');
+        $response->assertRedirect('/two-factor-challenge')
+            ->assertSessionHas('login.id');
         $this->assertNull(Auth::getUser());
     }
 


### PR DESCRIPTION
At the moment, when a 2FA challenge is failed, the user is required to again provide its username and password. This, however, isn't standard behavior across most apps. Usually, you're not required to login again and are asked to again attempt a new 2FA code.

I've attempted a fix that keeps the `login.id` in session after a failed 2FA and the failed 2FA response now redirects to the 2FA form. The `login.id` key is only removed after a successful 2FA code. Together with the 2FA rate limiting I feel this should provide enough safety. I don't really see how asking the username/password again for every failed 2FA request is more safer.

If this is considered a breaking change then I can send this to master. 

See https://github.com/laravel/fortify/issues/351