### PR TITLE
[1.x] Fix Throttle Bypass Exploit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^2.0",
-        "illuminate/support": "^8.0|^9.0",
+        "illuminate/support": "^8.82|^9.0",
         "pragmarx/google2fa": "^7.0|^8.0"
     },
     "require-dev": {

--- a/src/LoginRateLimiter.php
+++ b/src/LoginRateLimiter.php
@@ -89,6 +89,6 @@ class LoginRateLimiter
      */
     protected function throttleKey(Request $request)
     {
-        return Str::lower($request->input(Fortify::username())).'|'.$request->ip();
+        return Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());
     }
 }

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Fortify\Tests;
 
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
@@ -141,6 +143,40 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
         $response->assertStatus(429);
         $response->assertJsonValidationErrors(['email']);
+    }
+
+    /**
+     * @dataProvider usernameProvider
+     */
+    public function test_cant_bypass_throttle_with_special_characters(string $username, string $expectedResult)
+    {
+        $loginRateLimiter = new LoginRateLimiter(
+            $this->mock(RateLimiter::class)
+        );
+
+        $reflection = new \ReflectionClass($loginRateLimiter);
+        $method = $reflection->getMethod('throttleKey');
+        $method->setAccessible(true);
+
+        $request = $this->mock(
+            Request::class,
+            static function ($mock) use ($username) {
+                $mock->shouldReceive('input')->andReturn($username);
+                $mock->shouldReceive('ip')->andReturn('192.168.0.1');
+            }
+        );
+
+        self::assertSame($expectedResult . '|192.168.0.1', $method->invoke($loginRateLimiter, $request));
+    }
+
+    public function usernameProvider(): array
+    {
+        return [
+            'lowercase special characters' => ['ⓣⓔⓢⓣ@ⓛⓐⓡⓐⓥⓔⓛ.ⓒⓞⓜ', 'test@laravel.com'],
+            'uppercase special characters' => ['ⓉⒺⓈⓉ@ⓁⒶⓇⒶⓋⒺⓁ.ⒸⓄⓂ', 'test@laravel.com'],
+            'special character numbers' =>['test⑩⓸③@laravel.com', 'test1043@laravel.com'],
+            'default email' => ['test@laravel.com', 'test@laravel.com'],
+        ];
     }
 
     public function test_the_user_can_logout_of_the_application()

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -166,7 +166,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             }
         );
 
-        self::assertSame($expectedResult . '|192.168.0.1', $method->invoke($loginRateLimiter, $request));
+        self::assertSame($expectedResult.'|192.168.0.1', $method->invoke($loginRateLimiter, $request));
     }
 
     public function usernameProvider(): array


### PR DESCRIPTION
Exploit was found in the UI package that could bypass login throttle by replacing username characters with special characters. 

The same is possible in this package.

For more context around the exploit: https://github.com/laravel/ui/pull/216