### PR TITLE
Include the otpauth url when retrieving the QR svg

### DIFF
--- a/src/Http/Controllers/TwoFactorQrCodeController.php
+++ b/src/Http/Controllers/TwoFactorQrCodeController.php
@@ -19,6 +19,6 @@ class TwoFactorQrCodeController extends Controller
             return [];
         }
 
-        return response()->json(['svg' => $request->user()->twoFactorQrCodeSvg()]);
+        return response()->json(['svg' => $request->user()->twoFactorQrCodeSvg(), 'url' => $request->user()->twoFactorQrCodeUrl()]);
     }
 }


### PR DESCRIPTION
This small change adds the otpauth:// url to the json output when retrieving the QR code svg image.

On some devices, notably iOS 15 and macOS Monterey, it is possible to add the 2 step verification code directly in the system keychain. This allows for autofilling the verification code, so no need for switch to another app. Note that the input for the verification code has to be marked with `autocomplete="one-time-token"`.

However, this nice feature is difficult if not impossible to use when only showing the QR code image, because the camera can not see it's own screen if you know what I mean 👀.
Adding the url makes it possible to show a button 'Add on this device', that simply is a link to the otpauth url. Clicking it will open the system dialog to confirm and add it to a specific account. I tested on both iOS and macOS and it works.

See also the [Apple documentation](https://developer.apple.com/documentation/authenticationservices/securing_logins_with_icloud_keychain_verification_codes), the mention an apple specific prefix, but it works also without the prefix.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
