### PR TITLE
Confirmable 2FA

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -22,7 +22,9 @@ return new class extends Migration
                     ->after('two_factor_secret')
                     ->nullable();
 
-            $table->boolean('two_factor_confirmed')->default(false);
+            $table->boolean('two_factor_confirmed')
+                    ->after('two_factor_recovery_codes')
+                    ->default(false);
         });
     }
 

--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -21,6 +21,8 @@ return new class extends Migration
             $table->text('two_factor_recovery_codes')
                     ->after('two_factor_secret')
                     ->nullable();
+
+            $table->boolean('two_factor_confirmed')->default(false);
         });
     }
 
@@ -32,7 +34,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('two_factor_secret', 'two_factor_recovery_codes');
+            $table->dropColumn('two_factor_secret', 'two_factor_recovery_codes', 'two_factor_confirmed');
         });
     }
 };

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -141,6 +141,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.enable');
 
+        Route::post('/user/confirmed-two-factor-authentication', [ConfirmedTwoFactorAuthenticationController::class, 'store'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.confirm');
+
         Route::delete('/user/two-factor-authentication', [TwoFactorAuthenticationController::class, 'destroy'])
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.disable');

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -5,6 +5,7 @@ use Laravel\Fortify\Features;
 use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
 use Laravel\Fortify\Http\Controllers\ConfirmablePasswordController;
 use Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController;
+use Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationPromptController;
 use Laravel\Fortify\Http\Controllers\NewPasswordController;

--- a/src/Actions/ConfirmTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmTwoFactorAuthentication.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\Fortify\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+
+class ConfirmTwoFactorAuthentication
+{
+    /**
+     * The two factor authentication provider.
+     *
+     * @var \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider
+     */
+    protected $provider;
+
+    /**
+     * Create a new action instance.
+     *
+     * @param  \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider  $provider
+     * @return void
+     */
+    public function __construct(TwoFactorAuthenticationProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Confirm the two factor authentication configuration for the user.
+     *
+     * @param  mixed  $user
+     * @param  string  $code
+     * @return void
+     */
+    public function __invoke($user, $code)
+    {
+        if (empty($user->two_factor_secret) ||
+            ! $this->provider->verify(decrypt($user->two_factor_secret), $code)) {
+            throw ValidationException::withMessages([
+                'code' => [__('The provided two factor authentication code was invalid.')],
+            ])->errorBag('confirmTwoFactorAuthentication');
+        }
+
+        $user->forceFill([
+            'two_factor_confirmed' => true,
+        ])->save();
+
+        TwoFactorAuthenticationConfirmed::dispatch($user);
+    }
+}

--- a/src/Actions/ConfirmTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmTwoFactorAuthentication.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Actions;
 
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
 
 class ConfirmTwoFactorAuthentication
 {

--- a/src/Actions/DisableTwoFactorAuthentication.php
+++ b/src/Actions/DisableTwoFactorAuthentication.php
@@ -17,6 +17,7 @@ class DisableTwoFactorAuthentication
         $user->forceFill([
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
+            'two_factor_confirmed' => false,
         ])->save();
 
         TwoFactorAuthenticationDisabled::dispatch($user);

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -51,9 +51,17 @@ class RedirectIfTwoFactorAuthenticatable
     {
         $user = $this->validateCredentials($request);
 
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
+            if (optional($user)->two_factor_secret &&
+                optional($user)->two_factor_confirmed &&
+                in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
+                return $this->twoFactorChallengeResponse($request, $user);
+            } else {
+                return $next($request);
+            }
+        }
+
         if (optional($user)->two_factor_secret &&
-            ( ! Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') ||
-                optional($user)->two_factor_confirmed) &&
             in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
             return $this->twoFactorChallengeResponse($request, $user);
         }

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
+use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
 use Laravel\Fortify\LoginRateLimiter;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -51,6 +52,8 @@ class RedirectIfTwoFactorAuthenticatable
         $user = $this->validateCredentials($request);
 
         if (optional($user)->two_factor_secret &&
+            ( ! Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') ||
+                optional($user)->two_factor_confirmed) &&
             in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
             return $this->twoFactorChallengeResponse($request, $user);
         }

--- a/src/Events/TwoFactorAuthenticationConfirmed.php
+++ b/src/Events/TwoFactorAuthenticationConfirmed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Fortify\Events;
+
+class TwoFactorAuthenticationConfirmed extends TwoFactorAuthenticationEvent
+{
+    //
+}

--- a/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
@@ -18,7 +18,7 @@ class ConfirmedTwoFactorAuthenticationController extends Controller
      */
     public function store(Request $request, ConfirmTwoFactorAuthentication $confirm)
     {
-        $confirm($request->user());
+        $confirm($request->user(), $request->input('code'));
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)

--- a/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Fortify\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+
+class ConfirmedTwoFactorAuthenticationController extends Controller
+{
+    /**
+     * Enable two factor authentication for the user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function store(Request $request, ConfirmTwoFactorAuthentication $confirm)
+    {
+        $confirm($request->user());
+
+        return $request->wantsJson()
+                    ? new JsonResponse('', 200)
+                    : back()->with('status', 'two-factor-authentication-confirmed');
+    }
+}

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -79,6 +79,70 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         Event::assertDispatched(TwoFactorAuthenticationChallenged::class);
     }
 
+    public function test_user_is_not_redirected_to_challenge_when_using_two_factor_authentication_that_has_not_been_confirmed_and_confirmation_is_enabled()
+    {
+        Event::fake();
+
+        app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
+        app('config')->set('fortify.features', [
+            Features::registration(),
+            Features::twoFactorAuthentication(['confirm' => true]),
+        ]);
+
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+
+        Schema::table('users', function ($table) {
+            $table->text('two_factor_secret')->nullable();
+        });
+
+        TestTwoFactorAuthenticationSessionUser::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => 'test-secret',
+        ]);
+
+        $response = $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $response->assertRedirect('/home');
+    }
+
+    public function test_user_is_redirected_to_challenge_when_using_two_factor_authentication_that_has_been_confirmed_and_confirmation_is_enabled()
+    {
+        Event::fake();
+
+        app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
+        app('config')->set('fortify.features', [
+            Features::registration(),
+            Features::twoFactorAuthentication(['confirm' => true]),
+        ]);
+
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+
+        Schema::table('users', function ($table) {
+            $table->text('two_factor_secret')->nullable();
+            $table->boolean('two_factor_confirmed')->default(true);
+        });
+
+        TestTwoFactorAuthenticationSessionUser::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => 'test-secret',
+            'two_factor_confirmed' => true,
+        ]);
+
+        $response = $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $response->assertRedirect('/two-factor-challenge');
+    }
+
     public function test_user_can_authenticate_when_two_factor_challenge_is_disabled()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -4,7 +4,6 @@ namespace Laravel\Fortify\Tests;
 
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Schema;
 use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
 use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
 use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -32,10 +32,11 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
 
         Event::assertDispatched(TwoFactorAuthenticationEnabled::class);
 
-        $user->fresh();
+        $user = $user->fresh();
 
         $this->assertNotNull($user->two_factor_secret);
         $this->assertNotNull($user->two_factor_recovery_codes);
+        $this->assertEquals(0, $user->two_factor_confirmed);
         $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
         $this->assertNotNull($user->twoFactorQrCodeSvg());
     }


### PR DESCRIPTION
This PR allows 2FA to be configured to require confirmation before it is fully enabled via a new feature option. I don't *think* this PR is even breaking? But, sending to `master` for now.