### PR TITLE
Fix Exception when sending empty 2FA confirmation code

### DIFF
--- a/src/Actions/ConfirmTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmTwoFactorAuthentication.php
@@ -35,7 +35,7 @@ class ConfirmTwoFactorAuthentication
      */
     public function __invoke($user, $code)
     {
-        if (empty($user->two_factor_secret) ||
+        if (empty($user->two_factor_secret) || empty($code) ||
             ! $this->provider->verify(decrypt($user->two_factor_secret), $code)) {
             throw ValidationException::withMessages([
                 'code' => [__('The provided two factor authentication code was invalid.')],

--- a/src/Actions/ConfirmTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmTwoFactorAuthentication.php
@@ -35,7 +35,8 @@ class ConfirmTwoFactorAuthentication
      */
     public function __invoke($user, $code)
     {
-        if (empty($user->two_factor_secret) || empty($code) ||
+        if (empty($user->two_factor_secret) || 
+            empty($code) ||
             ! $this->provider->verify(decrypt($user->two_factor_secret), $code)) {
             throw ValidationException::withMessages([
                 'code' => [__('The provided two factor authentication code was invalid.')],


### PR DESCRIPTION
This pull request prevents the user to send an empty confirm code and throw an exception to the code.

The following exception occurr if you try to confirm the two factor with an empty field:

![image](https://user-images.githubusercontent.com/35383529/155212677-2e645157-b8e8-497a-b55b-82a83d5b72b6.png)


