### PR TITLE
Unsupported operand types on rollback migration

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -39,12 +39,12 @@ return new class extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn([
+            $table->dropColumn(array_merge([
                 'two_factor_secret',
                 'two_factor_recovery_codes',
-            ] + Fortify::confirmsTwoFactorAuthentication() ? [
+            ], Fortify::confirmsTwoFactorAuthentication() ? [
                 'two_factor_confirmed_at',
-            ] : []);
+            ] : []));
         });
     }
 };


### PR DESCRIPTION
When trying to rollback the migrations i got this error
TypeError 
Unsupported operand types: array + bool

This commit solves the issue.
