### PR TITLE
Fixed codestyle

### DIFF
--- a/stubs/UpdateUserPassword.php
+++ b/stubs/UpdateUserPassword.php
@@ -24,7 +24,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
             'password' => $this->passwordRules(),
         ])->after(function ($validator) use ($user, $input) {
             if (! isset($input['current_password']) || ! Hash::check($input['current_password'], $user->password)) {
-                $validator->errors()->add('current_password', __('The provided password does not match your current password.'));
+                $validator->errors()->add(
+                    'current_password',
+                     __('The provided password does not match your current password.')
+                );
             }
         })->validateWithBag('updatePassword');
 


### PR DESCRIPTION
When running PHP CodeSniffer with PSR2 standard it will throw a warning like this:

FILE: /my-app/app/Actions/Fortify/UpdateUserPassword.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 27 | WARNING | Line exceeds 120 characters; contains 129 characters
----------------------------------------------------------------------

This commit solves the issue.