### PR TITLE
[1.x] Cache 2FA token timestamp

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -35,6 +36,7 @@ use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
 use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
+use PragmaRX\Google2FA\Google2FA;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -49,10 +51,12 @@ class FortifyServiceProvider extends ServiceProvider
 
         $this->registerResponseBindings();
 
-        $this->app->singleton(
-            TwoFactorAuthenticationProviderContract::class,
-            TwoFactorAuthenticationProvider::class
-        );
+        $this->app->singleton(TwoFactorAuthenticationProviderContract::class, function ($app) {
+            return new TwoFactorAuthenticationProvider(
+                $app->make(Google2FA::class),
+                $app->make(Repository::class)
+            );
+        });
 
         $this->app->bind(StatefulGuard::class, function () {
             return Auth::guard(config('fortify.guard', null));

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -16,7 +16,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     protected $engine;
 
     /**
-     * The Cache repository instance.
+     * The cache repository implementation.
      *
      * @var \Illuminate\Contracts\Cache\Repository|null
      */
@@ -68,7 +68,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     public function verify($secret, $code)
     {
         $timestamp = $this->engine->verifyKeyNewer(
-            $secret, $code, optional($this->cache)->get($key = "fortify.2fa_codes.{$code}")
+            $secret, $code, optional($this->cache)->get($key = 'fortify.2fa_codes.'.sha1($code))
         );
 
         if ($timestamp !== false) {

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -68,7 +68,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     public function verify($secret, $code)
     {
         $timestamp = $this->engine->verifyKeyNewer(
-            $secret, $code, optional($this->cache)->get($key = 'fortify.2fa_codes.'.sha1($code))
+            $secret, $code, optional($this->cache)->get($key = 'fortify.2fa_codes.'.md5($code))
         );
 
         if ($timestamp !== false) {

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Fortify;
 
+use Illuminate\Contracts\Cache\Repository;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
 use PragmaRX\Google2FA\Google2FA;
 
@@ -15,14 +16,23 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     protected $engine;
 
     /**
+     * The Cache repository instance.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository|null
+     */
+    protected $cache;
+
+    /**
      * Create a new two factor authentication provider instance.
      *
      * @param  \PragmaRX\Google2FA\Google2FA  $engine
+     * @param  \Illuminate\Contracts\Cache\Repository|null  $cache
      * @return void
      */
-    public function __construct(Google2FA $engine)
+    public function __construct(Google2FA $engine, Repository $cache = null)
     {
         $this->engine = $engine;
+        $this->cache = $cache;
     }
 
     /**
@@ -57,6 +67,16 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
      */
     public function verify($secret, $code)
     {
-        return $this->engine->verifyKey($secret, $code);
+        $timestamp = $this->engine->verifyKeyNewer(
+            $secret, $code, optional($this->cache)->get($key = "fortify.2fa_codes.{$code}")
+        );
+
+        if ($timestamp !== false) {
+            optional($this->cache)->put($key, $timestamp, ($this->engine->getWindow() ?: 1) * 60);
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR allows to cache the 2FA timestamp of a token so it cannot be re-used during the time window of the 2FA engine. It's the solution detailed at https://github.com/antonioribeiro/google2fa#validation-window. 

Atm I'm storing the timestamp according with the token as its key in cache but the example from the link above associates it with the user. I don't see how that's important so I think the solution from this PR is probably fine. Happy to be proven otherwise if anyone has any objections.

The solution is backwards compatible because it introduces a new optional dependency for the `TwoFactorAuthenticationProvider` class.

Addresses concerns raised in https://github.com/laravel/fortify/issues/201