### PR TITLE
[1.x] Ensures route password.confirm is defined when not using views

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -109,20 +109,16 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     // Password Confirmation...
     if ($enableViews) {
         Route::get('/user/confirm-password', [ConfirmablePasswordController::class, 'show'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('password.confirm');
-
-        Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
             ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
-    } else {
-        Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('password.confirm');
     }
 
     Route::get('/user/confirmed-password-status', [ConfirmedPasswordStatusController::class, 'show'])
         ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
         ->name('password.confirmation');
+
+    Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+        ->name('password.confirm');
 
     // Two Factor Authentication...
     if (Features::enabled(Features::twoFactorAuthentication())) {

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -111,14 +111,18 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::get('/user/confirm-password', [ConfirmablePasswordController::class, 'show'])
             ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
             ->name('password.confirm');
+ 
+        Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
+            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
+    } else {
+        Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
+            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+            ->name('password.confirm');
     }
 
     Route::get('/user/confirmed-password-status', [ConfirmedPasswordStatusController::class, 'show'])
         ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
         ->name('password.confirmation');
-
-    Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
 
     // Two Factor Authentication...
     if (Features::enabled(Features::twoFactorAuthentication())) {

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -111,7 +111,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::get('/user/confirm-password', [ConfirmablePasswordController::class, 'show'])
             ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
             ->name('password.confirm');
- 
+
         Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
             ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
     } else {


### PR DESCRIPTION
This fixes #367 

If you implement fortify without views, you have to hardcode the `password.confirm` route because no name is defined on the `post` route.

https://github.com/laravel/fortify/blob/b2de125809a742acf08bc6bcbe8f90f8ae92df29/routes/routes.php#L120-L121

If you have views enabled (`$enableViews = true`), you are saved because a `get` route is defined with the same route.

https://github.com/laravel/fortify/blob/b2de125809a742acf08bc6bcbe8f90f8ae92df29/routes/routes.php#L110-L114

Currently, this forces people using Fortify with a SPA/custom views (`$enableViews = false`), to hardcode the `password.confirm` route.

While this might not be the prettiest fix, it is a fix that will not cause breaking changes for those already using the package.