### PR TITLE
[1.x] Fix double error message for failed 2FA response

### DIFF
--- a/src/Http/Responses/FailedTwoFactorLoginResponse.php
+++ b/src/Http/Responses/FailedTwoFactorLoginResponse.php
@@ -23,9 +23,6 @@ class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContra
             ]);
         }
 
-        return redirect()->route('two-factor.login')->withErrors([
-            'code' => $message,
-            'email' => $message,
-        ]);
+        return redirect()->route('two-factor.login')->withErrors(['code' => $message]);
     }
 }


### PR DESCRIPTION
This PR solves an issue where a failed message was shown twice. This is technically a breaking change since we're removing the email key (the reason why we didn't in the related PR below). But the correct key is `code`.

See https://github.com/laravel/fortify/pull/360