### PR TITLE
2FA setup key

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -17,6 +17,7 @@ use Laravel\Fortify\Http\Controllers\RegisteredUserController;
 use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController;
 use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
+use Laravel\Fortify\Http\Controllers\TwoFactorSetupKeyController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
@@ -153,6 +154,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::get('/user/two-factor-qr-code', [TwoFactorQrCodeController::class, 'show'])
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.qr-code');
+
+        Route::get('/user/two-factor-setup-key', [TwoFactorSetupKeyController::class, 'show'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.setup-key');
 
         Route::get('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'index'])
             ->middleware($twoFactorMiddleware)

--- a/src/Http/Controllers/TwoFactorSetupKeyController.php
+++ b/src/Http/Controllers/TwoFactorSetupKeyController.php
@@ -20,7 +20,7 @@ class TwoFactorSetupKeyController extends Controller
         }
 
         return response()->json([
-            'key' => decrypt($request->user()->two_factor_secret),
+            'setupKey' => decrypt($request->user()->two_factor_secret),
         ]);
     }
 }

--- a/src/Http/Controllers/TwoFactorSetupKeyController.php
+++ b/src/Http/Controllers/TwoFactorSetupKeyController.php
@@ -8,7 +8,7 @@ use Illuminate\Routing\Controller;
 class TwoFactorSetupKeyController extends Controller
 {
     /**
-     * Get the setup key for the user's two factor authentication.
+     * Get the current user's two factor authentication setup key.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Symfony\Component\HttpFoundation\Response
@@ -20,7 +20,7 @@ class TwoFactorSetupKeyController extends Controller
         }
 
         return response()->json([
-            'setupKey' => decrypt($request->user()->two_factor_secret),
+            'key' => decrypt($request->user()->two_factor_secret),
         ]);
     }
 }

--- a/src/Http/Controllers/TwoFactorSetupKeyController.php
+++ b/src/Http/Controllers/TwoFactorSetupKeyController.php
@@ -16,7 +16,7 @@ class TwoFactorSetupKeyController extends Controller
     public function show(Request $request)
     {
         if (is_null($request->user()->two_factor_secret)) {
-            return [];
+            abort(404, 'Two factor authentication has not been enabled.');
         }
 
         return response()->json([

--- a/src/Http/Controllers/TwoFactorSetupKeyController.php
+++ b/src/Http/Controllers/TwoFactorSetupKeyController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Fortify\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class TwoFactorSetupKeyController extends Controller
+{
+    /**
+     * Get the setup key for the user's two factor authentication.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function show(Request $request)
+    {
+        if (is_null($request->user()->two_factor_secret)) {
+            return [];
+        }
+
+        return response()->json([
+            'setupKey' => decrypt($request->user()->two_factor_secret),
+        ]);
+    }
+}


### PR DESCRIPTION
* Added new route & controller to allow users to use setup key when enabling 2FA

This is necessary for jetstream to be able to support showing the setup key when using inertia

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
