### PR TITLE
fix optional feature Two-Factor confirmation

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -23,11 +23,9 @@ return new class extends Migration
                     ->after('two_factor_secret')
                     ->nullable();
 
-            if (Fortify::confirmsTwoFactorAuthentication()) {
-                $table->timestamp('two_factor_confirmed_at')
-                        ->after('two_factor_recovery_codes')
-                        ->nullable();
-            }
+            $table->timestamp('two_factor_confirmed_at')
+                    ->after('two_factor_recovery_codes')
+                    ->nullable();
         });
     }
 
@@ -42,7 +40,6 @@ return new class extends Migration
             $table->dropColumn(array_merge([
                 'two_factor_secret',
                 'two_factor_recovery_codes',
-            ], Fortify::confirmsTwoFactorAuthentication() ? [
                 'two_factor_confirmed_at',
             ] : []));
         });

--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -41,7 +41,7 @@ return new class extends Migration
                 'two_factor_secret',
                 'two_factor_recovery_codes',
                 'two_factor_confirmed_at',
-            ] : []));
+            ]));
         });
     }
 };


### PR DESCRIPTION
install Jetstream and run `artisan migrate`, then go to /config/fortify.php -> features -> Features::twoFactorAuthentication -> uncomment the `confirm` option, it will break the TwoFA Disable button, since the necessary database column was not created, giving the following error:

Column not found: 1054 Unknown column 'two_factor_confirmed_at' in 'field list'

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
