### PR TITLE
fix optional feature: Two-Factor confirmation

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -23,11 +23,9 @@ return new class extends Migration
                     ->after('two_factor_secret')
                     ->nullable();
 
-            if (Fortify::confirmsTwoFactorAuthentication()) {
-                $table->timestamp('two_factor_confirmed_at')
-                        ->after('two_factor_recovery_codes')
-                        ->nullable();
-            }
+            $table->timestamp('two_factor_confirmed_at')
+                    ->after('two_factor_recovery_codes')
+                    ->nullable();
         });
     }
 
@@ -42,9 +40,8 @@ return new class extends Migration
             $table->dropColumn(array_merge([
                 'two_factor_secret',
                 'two_factor_recovery_codes',
-            ], Fortify::confirmsTwoFactorAuthentication() ? [
                 'two_factor_confirmed_at',
-            ] : []));
+            ]));
         });
     }
 };


### PR DESCRIPTION
after installation completed, and once you run the `migrate` command, enabling the Two-Factor confirmation feature will break the Two-Factor "Disable" button at least.

Column not found: 1054 Unknown column 'two_factor_confirmed_at' in 'field list'

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
