### PR TITLE
Added config option for custom OTP window

### DIFF
--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -67,7 +67,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
      */
     public function verify($secret, $code)
     {
-        if(is_int($customWindow = config('fortify-options.two-factor-authentication.window'))) {
+        if (is_int($customWindow = config('fortify-options.two-factor-authentication.window'))) {
             $this->engine->setWindow($customWindow);
         }
 

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -67,6 +67,10 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
      */
     public function verify($secret, $code)
     {
+        if(is_int($customWindow = config('fortify-options.two-factor-authentication.window'))) {
+            $this->engine->setWindow($customWindow);
+        }
+
         $timestamp = $this->engine->verifyKeyNewer(
             $secret, $code, optional($this->cache)->get($key = 'fortify.2fa_codes.'.md5($code))
         );

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -140,6 +140,7 @@ return [
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,
+            // 'window' => 0,
         ]),
     ],
 

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -314,16 +314,16 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $previousOtp = $tfaEngine->oathTotp($userSecret, $currentTs - 1);
 
         $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
-                                                                        'name' => 'Taylor Otwell',
-                                                                        'email' => 'taylor@laravel.com',
-                                                                        'password' => bcrypt('secret'),
-                                                                        'two_factor_secret' => encrypt($userSecret),
-                                                                    ]);
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt($userSecret),
+        ]);
 
         $response = $this->withSession([
-                                           'login.id' => $user->id,
-                                           'login.remember' => false,
-                                       ])->withoutExceptionHandling()->post('/two-factor-challenge', [
+            'login.id' => $user->id,
+            'login.remember' => false,
+        ])->withoutExceptionHandling()->post('/two-factor-challenge', [
             'code' => $previousOtp,
         ]);
 

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -296,6 +296,41 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             ->assertSessionMissing('login.id');
     }
 
+    public function test_two_factor_challenge_fails_for_old_otp_and_zero_window()
+    {
+        app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
+
+        //Setting window to 0 should mean any old OTP is instantly invalid
+        app('config')->set('fortify.features', [
+            Features::twoFactorAuthentication(['window' => 0]),
+        ]);
+
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $tfaEngine = app(Google2FA::class);
+        $userSecret = $tfaEngine->generateSecretKey();
+        $currentTs = $tfaEngine->getTimestamp();
+        $previousOtp = $tfaEngine->oathTotp($userSecret, $currentTs - 1);
+
+        $user = TestTwoFactorAuthenticationSessionUser::forceCreate([
+                                                                        'name' => 'Taylor Otwell',
+                                                                        'email' => 'taylor@laravel.com',
+                                                                        'password' => bcrypt('secret'),
+                                                                        'two_factor_secret' => encrypt($userSecret),
+                                                                    ]);
+
+        $response = $this->withSession([
+                                           'login.id' => $user->id,
+                                           'login.remember' => false,
+                                       ])->withoutExceptionHandling()->post('/two-factor-challenge', [
+            'code' => $previousOtp,
+        ]);
+
+        $response->assertRedirect('/two-factor-challenge')
+                 ->assertSessionHas('login.id');
+    }
+
     public function test_two_factor_challenge_can_be_passed_via_recovery_code()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);


### PR DESCRIPTION
This PR addresses https://github.com/laravel/fortify/issues/324 , https://github.com/laravel/fortify/issues/374 

The aim is to allow a custom "window" to be set, as per the underlying package documentation: https://github.com/antonioribeiro/google2fa#validation-window

A fortify user could now set a window to 0 to instantly invalidate any old OTPs, or they could increase the current default setting of 1 to allow for a more generous window (setting this to 2 would allow up to 1 minute old OTPs to still be valid).