### PR TITLE
Add two factor authentication successful event

### DIFF
--- a/src/Events/TwoFactorAuthenticationSuccessful.php
+++ b/src/Events/TwoFactorAuthenticationSuccessful.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Fortify\Events;
+
+class TwoFactorAuthenticationSuccessful extends TwoFactorAuthenticationEvent
+{
+    //
+}

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -9,6 +9,7 @@ use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Events\RecoveryCodeReplaced;
+use Laravel\Fortify\Events\TwoFactorAuthenticationSuccessful;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 
 class TwoFactorAuthenticatedSessionController extends Controller
@@ -63,6 +64,8 @@ class TwoFactorAuthenticatedSessionController extends Controller
         } elseif (! $request->hasValidCode()) {
             return app(FailedTwoFactorLoginResponse::class);
         }
+
+        TwoFactorAuthenticationSuccessful::dispatch($user);
 
         $this->guard->login($user, $request->remember());
 


### PR DESCRIPTION
This PR Adds a Two factor Authentication Success event,

This is useful if apps want to keep a record of the last time a two factor prompt was successful.
