### PR TITLE
[1.x] Return a Responsable instance on profile update (#388)

### DIFF
--- a/src/Contracts/UpdateProfileResponse.php
+++ b/src/Contracts/UpdateProfileResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface UpdateProfileResponse extends Responsable
+{
+    //
+}

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -22,6 +22,7 @@ use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as Succ
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+use Laravel\Fortify\Contracts\UpdateProfileResponse as UpdateProfileResponseContract;
 use Laravel\Fortify\Http\Responses\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
@@ -36,6 +37,7 @@ use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
 use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
+use Laravel\Fortify\Http\Responses\UpdateProfileResponse;
 use PragmaRX\Google2FA\Google2FA;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -84,6 +86,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(SuccessfulPasswordResetLinkRequestResponseContract::class, SuccessfulPasswordResetLinkRequestResponse::class);
         $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
+        $this->app->singleton(UpdateProfileResponseContract::class, UpdateProfileResponse::class);
     }
 
     /**

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -21,8 +21,8 @@ use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
-use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 use Laravel\Fortify\Contracts\UpdateProfileResponse as UpdateProfileResponseContract;
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 use Laravel\Fortify\Http\Responses\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
@@ -36,8 +36,8 @@ use Laravel\Fortify\Http\Responses\PasswordUpdateResponse;
 use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
-use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
 use Laravel\Fortify\Http\Responses\UpdateProfileResponse;
+use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
 use PragmaRX\Google2FA\Google2FA;
 
 class FortifyServiceProvider extends ServiceProvider

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Fortify\Contracts\UpdateProfileResponse;

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Contracts\UpdateProfileResponse;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class ProfileInformationController extends Controller
@@ -21,8 +22,6 @@ class ProfileInformationController extends Controller
     {
         $updater->update($request->user(), $request->all());
 
-        return $request->wantsJson()
-                    ? new JsonResponse('', 200)
-                    : back()->with('status', 'profile-information-updated');
+        return app(UpdateProfileResponse::class);
     }
 }

--- a/src/Http/Responses/UpdateProfileResponse.php
+++ b/src/Http/Responses/UpdateProfileResponse.php
@@ -4,7 +4,6 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\UpdateProfileResponse as UpdateProfileResponseContract;
-use Laravel\Fortify\Fortify;
 
 class UpdateProfileResponse implements UpdateProfileResponseContract
 {

--- a/src/Http/Responses/UpdateProfileResponse.php
+++ b/src/Http/Responses/UpdateProfileResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\UpdateProfileResponse as UpdateProfileResponseContract;
+use Laravel\Fortify\Fortify;
+
+class UpdateProfileResponse implements UpdateProfileResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $request->wantsJson()
+            ? new JsonResponse('', 200)
+            : back()->with('status', 'profile-information-updated');
+    }
+}


### PR DESCRIPTION
Allows developers to customize response on update profile action via IoC like it was done in other user experience flows (e.g. Register). 

This PR doesn't bring backward incompatibility because `\Laravel\Fortify\Http\Responses\UpdateProfileResponse` class implements the previous testable behavior. 