### PR TITLE
[1.x] fix: 🐛 Retrieve through UserProvider as possible

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -86,9 +86,11 @@ class RedirectIfTwoFactorAuthenticatable
             });
         }
 
-        $model = $this->guard->getProvider()->getModel();
+        $user = $this->guard->getProvider()->retrieveByCredentials([
+            Fortify::username() => $request->{Fortify::username()},
+        ]);
 
-        return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use ($request) {
+        return tap($user, function ($user) use ($request) {
             if (! $user || ! $this->guard->getProvider()->validateCredentials($user, ['password' => $request->password])) {
                 $this->fireFailedEvent($request, $user);
 

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -94,10 +94,8 @@ class TwoFactorLoginRequest extends FormRequest
             return true;
         }
 
-        $model = app(StatefulGuard::class)->getProvider()->getModel();
-
-        return $this->session()->has('login.id') &&
-            $model::find($this->session()->get('login.id'));
+        return $this->session()->has('login.id')
+            && app(StatefulGuard::class)->getProvider()->retrieveById($this->session()->get('login.id'));
     }
 
     /**
@@ -111,10 +109,8 @@ class TwoFactorLoginRequest extends FormRequest
             return $this->challengedUser;
         }
 
-        $model = app(StatefulGuard::class)->getProvider()->getModel();
-
         if (! $this->session()->has('login.id') ||
-            ! $user = $model::find($this->session()->get('login.id'))) {
+            ! $user = app(StatefulGuard::class)->getProvider()->retrieveById($this->session()->get('login.id'))) {
             throw new HttpResponseException(
                 app(FailedTwoFactorLoginResponse::class)->toResponse($this)
             );


### PR DESCRIPTION
## Overview

The related changes have been previously reverted, but we see no problem in merging these changes now.

- https://github.com/laravel/fortify/pull/189 by @driesvints (merged and reverted by @taylorotwell)
- https://github.com/laravel/fortify/pull/318 by @MaksTech (closed by @driesvints)

## Description

- The original PR #189 by @driesvints might have some bugs. I mentioned [here](https://github.com/laravel/fortify/pull/189#discussion_r906661504).
  > The verification might be not enough. `retrieveByCredentials()` does not expect password matches, only an email address does. Password hash validation is done by `validateCredentials()`, but its call was not included in the PR.
  > 
  > I think it is the cause of the PR reverted. 
  > 
  > @taylorotwell Is it right?
  
  Although no reason was given in the PR and commits, it might have lead to the revert.
- Re-created PR #318 by @MaksTech is looks good to me, but @driesvints appears to have closed it for unknown reasons.
- We've got stuck at https://github.com/mpyw/scoped-auth/issues/23 because of this, so I decided to re-re-create this PR with detailed explanations.