### PR TITLE
Fix the return type

### DIFF
--- a/src/Http/Controllers/ConfirmedPasswordStatusController.php
+++ b/src/Http/Controllers/ConfirmedPasswordStatusController.php
@@ -11,7 +11,7 @@ class ConfirmedPasswordStatusController extends Controller
      * Get the password confirmation status.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function show(Request $request)
     {


### PR DESCRIPTION
In a scenario where you may need to extend the `ConfirmedPasswordStatusController` to a custom controller and you need to call the `show()` method inside a function with a return type hint you will get the worning below: 

```
Return value is expected to be '\Illuminate\Http\JsonResponse', '\Illuminate\Http\Response' returned 
``` 

Example:

```php
<?php

declare(strict_types=1);

namespace App\Http\Controllers\Auth;

use Illuminate\Http\JsonResponse;
use Illuminate\Http\Request;

class ConfirmedPasswordStatusController extends \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController
{
    /**
     * Get the password confirmation status.
     *
     * @param \Illuminate\Http\Request $request
     *
     * @return \Illuminate\Http\JsonResponse
     */
    public function __invoke(Request $request): JsonResponse
    {
        return parent::show($request);
    }
```
