### PR TITLE
Add at lest count number to password rule with backward compatibility

### DIFF
--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -22,6 +22,13 @@ class Password implements Rule
     protected $requireUppercase = false;
 
     /**
+     * minimum number of uppercase character in password.
+     *
+     * @var int
+     */
+    protected $atLestUppercaseCount = 1;
+
+    /**
      * Indicates if the password must contain one numeric digit.
      *
      * @var bool
@@ -29,11 +36,25 @@ class Password implements Rule
     protected $requireNumeric = false;
 
     /**
+     * minimum number of numeric digit in password.
+     *
+     * @var int
+     */
+    protected $atLestNumericCount = 1;
+
+    /**
      * Indicates if the password must contain one special character.
      *
      * @var bool
      */
     protected $requireSpecialCharacter = false;
+
+    /**
+     * minimum number of special character in password.
+     *
+     * @var int
+     */
+    protected $atLestSpecialCharacterCount = 1;
 
     /**
      * The message that should be used when validation fails.
@@ -53,15 +74,15 @@ class Password implements Rule
     {
         $value = is_scalar($value) ? (string) $value : '';
 
-        if ($this->requireUppercase && Str::lower($value) === $value) {
+        if ($this->requireUppercase && preg_match_all('/[\p{Lu}]/', $value) < $this->atLestUppercaseCount) {
             return false;
         }
 
-        if ($this->requireNumeric && ! preg_match('/[0-9]/', $value)) {
+        if ($this->requireNumeric && preg_match_all('/[0-9]/', $value) < $this->atLestNumericCount) {
             return false;
         }
 
-        if ($this->requireSpecialCharacter && ! preg_match('/[\W_]/', $value)) {
+        if ($this->requireSpecialCharacter && preg_match_all('/[\W_]/', $value) < $this->atLestSpecialCharacterCount) {
             return false;
         }
 
@@ -83,50 +104,62 @@ class Password implements Rule
             case $this->requireUppercase
                 && ! $this->requireNumeric
                 && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLeastUpperCaseCount uppercase character.', [
                     'length' => $this->length,
+                    'atLeastUpperCaseCount' => $this->atLestUppercaseCount,
                 ]);
 
             case $this->requireNumeric
                 && ! $this->requireUppercase
                 && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one number.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLestNumericCount number.', [
                     'length' => $this->length,
+                    'atLestNumericCount' => $this->atLestNumericCount,
                 ]);
 
             case $this->requireSpecialCharacter
                 && ! $this->requireUppercase
                 && ! $this->requireNumeric:
-                return __('The :attribute must be at least :length characters and contain at least one special character.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLestSpecialCharacter special character.', [
                     'length' => $this->length,
+                    'atLestSpecialCharacter' => $this->atLestSpecialCharacterCount,
                 ]);
 
             case $this->requireUppercase
                 && $this->requireNumeric
                 && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character and one number.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLeastUpperCaseCount uppercase character and :atLestNumericCount number.', [
                     'length' => $this->length,
+                    'atLeastUpperCaseCount' => $this->atLestUppercaseCount,
+                    'atLestNumericCount' => $this->atLestNumericCount,
                 ]);
 
             case $this->requireUppercase
                 && $this->requireSpecialCharacter
                 && ! $this->requireNumeric:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character and one special character.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLeastUpperCaseCount uppercase character and :atLestSpecialCharacter special character.', [
                     'length' => $this->length,
+                    'atLeastUpperCaseCount' => $this->atLestUppercaseCount,
+                    'atLestSpecialCharacter' => $this->atLestSpecialCharacterCount,
                 ]);
 
             case $this->requireUppercase
                 && $this->requireNumeric
                 && $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLeastUpperCaseCount uppercase character, :atLestNumericCount number, and :atLestSpecialCharacter special character.', [
                     'length' => $this->length,
+                    'atLeastUpperCaseCount' => $this->atLestUppercaseCount,
+                    'atLestNumericCount' => $this->atLestNumericCount,
+                    'atLestSpecialCharacter' => $this->atLestSpecialCharacterCount,
                 ]);
 
             case $this->requireNumeric
                 && $this->requireSpecialCharacter
                 && ! $this->requireUppercase:
-                return __('The :attribute must be at least :length characters and contain at least one special character and one number.', [
+                return __('The :attribute must be at least :length characters and contain at least :atLestSpecialCharacter special character and :atLestNumericCount number.', [
                     'length' => $this->length,
+                    'atLestNumericCount' => $this->atLestNumericCount,
+                    'atLestSpecialCharacter' => $this->atLestSpecialCharacterCount,
                 ]);
 
             default:
@@ -154,9 +187,10 @@ class Password implements Rule
      *
      * @return $this
      */
-    public function requireUppercase()
+    public function requireUppercase(int $atLestCount = 1)
     {
         $this->requireUppercase = true;
+        $this->atLestUppercaseCount = $atLestCount;
 
         return $this;
     }
@@ -166,9 +200,10 @@ class Password implements Rule
      *
      * @return $this
      */
-    public function requireNumeric()
+    public function requireNumeric(int $atLestCount = 1)
     {
         $this->requireNumeric = true;
+        $this->atLestNumericCount = $atLestCount;
 
         return $this;
     }
@@ -178,9 +213,10 @@ class Password implements Rule
      *
      * @return $this
      */
-    public function requireSpecialCharacter()
+    public function requireSpecialCharacter(int $atLestCount = 1)
     {
         $this->requireSpecialCharacter = true;
+        $this->atLestSpecialCharacterCount = $atLestCount;
 
         return $this;
     }

--- a/tests/PasswordRuleTest.php
+++ b/tests/PasswordRuleTest.php
@@ -30,7 +30,7 @@ class PasswordRuleTest extends OrchestraTestCase
         $this->assertFalse($rule->passes('password', 'password'));
         $this->assertTrue($rule->passes('password', 'Password'));
 
-        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character'));
+        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least 1 uppercase character'));
 
         $rule->length(8)->requireNumeric();
 
@@ -38,7 +38,16 @@ class PasswordRuleTest extends OrchestraTestCase
         $this->assertFalse($rule->passes('password', 'password1'));
         $this->assertTrue($rule->passes('password', 'Password1'));
 
-        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character and one number'));
+        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least 1 uppercase character and 1 number'));
+
+        $rule->length(8)->requireNumeric(4)->requireUppercase(8);
+
+        $this->assertFalse($rule->passes('password', 'password'));
+        $this->assertFalse($rule->passes('password', 'password1234'));
+        $this->assertFalse($rule->passes('password', 'PASSWORD'));
+        $this->assertTrue($rule->passes('password', 'PASSWORD1234'));
+
+        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least 8 uppercase character and 4 number'));
     }
 
     public function test_password_rule_can_require_special_characters()
@@ -51,7 +60,15 @@ class PasswordRuleTest extends OrchestraTestCase
         $this->assertFalse($rule->passes('password', 'password'));
 
         $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));
-        $this->assertTrue(Str::contains($rule->message(), 'special character'));
+        $this->assertTrue(Str::contains($rule->message(), 'at least 1 special character'));
+
+        $rule->length(8)->requireSpecialCharacter(2);
+
+        $this->assertTrue($rule->passes('password', 'password!#'));
+        $this->assertFalse($rule->passes('password', 'password'));
+
+        $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));
+        $this->assertTrue(Str::contains($rule->message(), 'at least 2 special character'));
     }
 
     public function test_password_rule_can_require_numeric_and_special_characters()
@@ -64,7 +81,16 @@ class PasswordRuleTest extends OrchestraTestCase
         $this->assertFalse($rule->passes('password', 'my-password'));
 
         $this->assertTrue(Str::contains($rule->message(), 'must be at least 10 characters'));
-        $this->assertTrue(Str::contains($rule->message(), 'contain at least one special character'));
-        $this->assertTrue(Str::contains($rule->message(), 'and one number'));
+        $this->assertTrue(Str::contains($rule->message(), 'contain at least 1 special character'));
+        $this->assertTrue(Str::contains($rule->message(), 'and 1 number'));
+
+        $rule->length(10)->requireNumeric(3)->requireSpecialCharacter(2);
+
+        $this->assertTrue($rule->passes('password', 'password532%!'));
+        $this->assertFalse($rule->passes('password', 'my-password'));
+
+        $this->assertTrue(Str::contains($rule->message(), 'must be at least 10 characters'));
+        $this->assertTrue(Str::contains($rule->message(), 'contain at least 2 special character'));
+        $this->assertTrue(Str::contains($rule->message(), 'and 3 number'));
     }
 }


### PR DESCRIPTION
Add at lest count to password rule with backward compatibility for version one

- atLestNumericCount => default is one
- atLestUpperCaseCount => default is one
- atLestSpecialCharacterCount => default is one