### PR TITLE
Fix second usage of 2FA code

### DIFF
--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -79,6 +79,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
             if ($timestamp === true) {
                 $timestamp = $this->engine->getTimestamp();
             }
+
             optional($this->cache)->put($key, $timestamp, ($this->engine->getWindow() ?: 1) * 60);
 
             return true;

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -76,6 +76,9 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
         );
 
         if ($timestamp !== false) {
+            if ($timestamp === true) {
+                $timestamp = $this->engine->getTimestamp();
+            }
             optional($this->cache)->put($key, $timestamp, ($this->engine->getWindow() ?: 1) * 60);
 
             return true;


### PR DESCRIPTION
Method `verifyKeyNewer` returns `true` when parameter `$oldTimestamp` is empty i.e. when there is no such code in cache. This allowed second usage of 2FA code:

#### First login with 2FA code:
`verifyKeyNewer` gets called with `null` as old timestamp, so it returns `true`. `true` is saved to cache as old timestamp.
#### Second login with same 2FA code:
`verifyKeyNewer` gets called with `true` as old timestamp, which later down the line gets converted to `1`. `verifyKeyNewer` uses current time and window value for creating starting timestamp and discards old timestamp, because it is smaller than created timestamp. So, if 2FA code is within the window, it gets accepted.

This pull request fixes this bug by creating new timestamp if `verifyKeyNewer` returned `true` and writing this new timestamp to cache.