### PR TITLE
[1.x] Return recovery errors under the `recovery_code` key

### DIFF
--- a/src/Http/Responses/FailedTwoFactorLoginResponse.php
+++ b/src/Http/Responses/FailedTwoFactorLoginResponse.php
@@ -15,14 +15,16 @@ class FailedTwoFactorLoginResponse implements FailedTwoFactorLoginResponseContra
      */
     public function toResponse($request)
     {
-        $message = __('The provided two factor authentication code was invalid.');
+        [$key, $message] = $request->has('recovery_code')
+            ? ['recovery_code', __('The provided two factor recovery code was invalid.')]
+            : ['code', __('The provided two factor authentication code was invalid.')];
 
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([
-                'code' => [$message],
+                $key => [$message],
             ]);
         }
 
-        return redirect()->route('two-factor.login')->withErrors(['code' => $message]);
+        return redirect()->route('two-factor.login')->withErrors([$key => $message]);
     }
 }

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -328,7 +328,8 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         ]);
 
         $response->assertRedirect('/two-factor-challenge')
-                 ->assertSessionHas('login.id');
+                 ->assertSessionHas('login.id')
+                 ->assertSessionHasErrors(['code']);
     }
 
     public function test_two_factor_challenge_can_be_passed_via_recovery_code()
@@ -380,7 +381,8 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         ]);
 
         $response->assertRedirect('/two-factor-challenge')
-            ->assertSessionHas('login.id');
+            ->assertSessionHas('login.id')
+            ->assertSessionHasErrors(['recovery_code']);
         $this->assertNull(Auth::getUser());
     }
 


### PR DESCRIPTION
_This might be considered a breaking change..._

Currently when the user sends a `recovery_code`, any basic validation errors will be returned under the `recovery_code` key. But if the provided recovery code is incorrect, then the error is returned under the `code` key instead.

It's not a big deal if all errors are displayed at the top of the page. But if the errors are displayed alongside the specific fields (like [this Jetstream PR](https://github.com/laravel/jetstream/pull/1115#discussion_r941912210)), then the developer really needs to look in two places for recovery code errors.

This PR returns all recovery code errors under the `recovery_code` key.

The only time this may be a problem is if the user has worked around this quirk by *only* checking the `code` key for `recovery_code` errors. If this is considered a breaking change, then I can target `master` instead.