### PR TITLE
Migration after() method missing callback parameter

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -15,19 +15,14 @@ return new class extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->text('two_factor_secret')
-                    ->after('password')
-                    ->nullable();
+            $table->after('password', function (Blueprint $table) {
+                $table->string('two_factor_secret')->nullable();
+                $table->string('two_factor_recovery_codes')->nullable();
 
-            $table->text('two_factor_recovery_codes')
-                    ->after('two_factor_secret')
-                    ->nullable();
-
-            if (Fortify::confirmsTwoFactorAuthentication()) {
-                $table->timestamp('two_factor_confirmed_at')
-                        ->after('two_factor_recovery_codes')
-                        ->nullable();
-            }
+                if (Fortify::confirmsTwoFactorAuthentication()) {
+                    $table->timestamp('two_factor_confirmed_at')->nullable();
+                }
+            });
         });
     }
 


### PR DESCRIPTION
An error occurs when you run `php artisan migrate` on this file because the `after()` method needs a callback function as the second parameter.

In this fix, `after()` is called first, while the new columns are created within the callback function.