### PR TITLE
Add and use constants for session flashes

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -45,54 +45,13 @@ class Fortify
      */
     public static $registersRoutes = true;
 
-    /**
-     * Constant representing a successfully updated password.
-     *
-     * @var string
-     */
     const PASSWORD_UPDATED = 'password-updated';
-
-    /**
-     * Constant representing a successfully sent verification reminder.
-     *
-     * @var string
-     */
-    const VERIFICATION_LINK_SENT = 'verification-link-sent';
-
-    /**
-     * Constant representing a successfully updated user.
-     *
-     * @var string
-     */
     const PROFILE_INFORMATION_UPDATED = 'profile-information-updated';
-
-    /**
-     * Constant representing the recovery codes generated response.
-     *
-     * @var string
-     */
     const RECOVERY_CODES_GENERATED = 'recovery-codes-generated';
-
-    /**
-     * Constant representing two factor authentication being enabled.
-     *
-     * @var string
-     */
-    const TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
-
-    /**
-     * Constant representing two factor authentication being disabled.
-     *
-     * @var string
-     */
-    const TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
-
-    /**
-     * Constant representing two factor authentication being confirmed.
-     *
-     * @var string
-     */
     const TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
+    const TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
+    const TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
+    const VERIFICATION_LINK_SENT = 'verification-link-sent';
 
     /**
      * Get the username used for authentication.

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -46,6 +46,55 @@ class Fortify
     public static $registersRoutes = true;
 
     /**
+     * Constant representing a successfully updated password.
+     *
+     * @var string
+     */
+    const PASSWORD_UPDATED = 'password-updated';
+
+    /**
+     * Constant representing a successfully sent verification reminder.
+     *
+     * @var string
+     */
+    const VERIFICATION_LINK_SENT = 'verification-link-sent';
+
+    /**
+     * Constant representing a successfully updated user.
+     *
+     * @var string
+     */
+    const PROFILE_INFORMATION_UPDATED = 'profile-information-updated';
+
+    /**
+     * Constant representing the recovery codes generated response.
+     *
+     * @var string
+     */
+    const RECOVERY_CODES_GENERATED = 'recovery-codes-generated';
+
+    /**
+     * Constant representing two factor authentication being enabled.
+     *
+     * @var string
+     */
+    const TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
+
+    /**
+     * Constant representing two factor authentication being disabled.
+     *
+     * @var string
+     */
+    const TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
+
+    /**
+     * Constant representing two factor authentication being confirmed.
+     *
+     * @var string
+     */
+    const TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
+
+    /**
      * Get the username used for authentication.
      *
      * @return string

--- a/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
@@ -5,8 +5,8 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Fortify;
 
 class ConfirmedTwoFactorAuthenticationController extends Controller
 {

--- a/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
 
 class ConfirmedTwoFactorAuthenticationController extends Controller
@@ -22,6 +23,6 @@ class ConfirmedTwoFactorAuthenticationController extends Controller
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)
-                    : back()->with('status', 'two-factor-authentication-confirmed');
+                    : back()->with('status', Fortify::TWO_FACTOR_AUTHENTICATION_CONFIRMED);
     }
 }

--- a/src/Http/Controllers/EmailVerificationNotificationController.php
+++ b/src/Http/Controllers/EmailVerificationNotificationController.php
@@ -27,6 +27,6 @@ class EmailVerificationNotificationController extends Controller
 
         return $request->wantsJson()
                     ? new JsonResponse('', 202)
-                    : back()->with('status', 'verification-link-sent');
+                    : back()->with('status', Fortify::VERIFICATION_LINK_SENT);
     }
 }

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class ProfileInformationController extends Controller
@@ -23,6 +24,6 @@ class ProfileInformationController extends Controller
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)
-                    : back()->with('status', 'profile-information-updated');
+                    : back()->with('status', Fortify::PROFILE_INFORMATION_UPDATED);
     }
 }

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -5,8 +5,8 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+use Laravel\Fortify\Fortify;
 
 class ProfileInformationController extends Controller
 {

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 
 class RecoveryCodeController extends Controller
@@ -40,6 +41,6 @@ class RecoveryCodeController extends Controller
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)
-                    : back()->with('status', 'recovery-codes-generated');
+                    : back()->with('status', Fortify::RECOVERY_CODES_GENERATED);
     }
 }

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -5,8 +5,8 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
+use Laravel\Fortify\Fortify;
 
 class RecoveryCodeController extends Controller
 {

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -5,9 +5,9 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorAuthenticationController extends Controller
 {

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 
@@ -23,7 +24,7 @@ class TwoFactorAuthenticationController extends Controller
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)
-                    : back()->with('status', 'two-factor-authentication-enabled');
+                    : back()->with('status', Fortify::TWO_FACTOR_AUTHENTICATION_ENABLED);
     }
 
     /**
@@ -39,6 +40,6 @@ class TwoFactorAuthenticationController extends Controller
 
         return $request->wantsJson()
                     ? new JsonResponse('', 200)
-                    : back()->with('status', 'two-factor-authentication-disabled');
+                    : back()->with('status', Fortify::TWO_FACTOR_AUTHENTICATION_DISABLED);
     }
 }

--- a/src/Http/Responses/PasswordUpdateResponse.php
+++ b/src/Http/Responses/PasswordUpdateResponse.php
@@ -3,8 +3,8 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Contracts\PasswordUpdateResponse as PasswordUpdateResponseContract;
+use Laravel\Fortify\Fortify;
 
 class PasswordUpdateResponse implements PasswordUpdateResponseContract
 {

--- a/src/Http/Responses/PasswordUpdateResponse.php
+++ b/src/Http/Responses/PasswordUpdateResponse.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Contracts\PasswordUpdateResponse as PasswordUpdateResponseContract;
 
 class PasswordUpdateResponse implements PasswordUpdateResponseContract
@@ -17,6 +18,6 @@ class PasswordUpdateResponse implements PasswordUpdateResponseContract
     {
         return $request->wantsJson()
             ? new JsonResponse('', 200)
-            : back()->with('status', 'password-updated');
+            : back()->with('status', Fortify::PASSWORD_UPDATED);
     }
 }


### PR DESCRIPTION
This addresses what I brought up in #408 that it's a little awkward having to compare the `status` flash to hard-coded strings like `two-factor-authentication-enabled` to appropriately show the correct messaging to the user. This provides constants on `Laravel\Fortify\Fortify` which provides clarity in end-user code that the expectation is that these flash messages are a result of an interaction with Fortify.

I've intentionally adopted [similar naming to that used by the constants in Laravel's `PasswordBroker`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Contracts/Auth/PasswordBroker.php).