### PR TITLE
Current password

### DIFF
--- a/stubs/UpdateUserPassword.php
+++ b/stubs/UpdateUserPassword.php
@@ -20,13 +20,11 @@ class UpdateUserPassword implements UpdatesUserPasswords
     public function update($user, array $input)
     {
         Validator::make($input, [
-            'current_password' => ['required', 'string'],
+            'current_password' => ['required', 'string', 'current_password:web'],
             'password' => $this->passwordRules(),
-        ])->after(function ($validator) use ($user, $input) {
-            if (! isset($input['current_password']) || ! Hash::check($input['current_password'], $user->password)) {
-                $validator->errors()->add('current_password', __('The provided password does not match your current password.'));
-            }
-        })->validateWithBag('updatePassword');
+        ], [
+            'current_password.current_password' => __('The provided password does not match your current password.'),
+        ])->validateWithBag('updatePassword');
 
         $user->forceFill([
             'password' => Hash::make($input['password']),

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -30,7 +30,7 @@ class PasswordControllerTest extends OrchestraTestCase
         $response->assertStatus(200);
     }
 
-    public function test_passwords_cannot_be_updated_without_password_confirmation()
+    public function test_passwords_cannot_be_updated_without_current_password()
     {
         $user = Mockery::mock(Authenticatable::class);
         $user->password = '';
@@ -40,6 +40,28 @@ class PasswordControllerTest extends OrchestraTestCase
 
         try {
             (new UpdateUserPassword())->update($user, [
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ]);
+        } catch (ValidationException $e) {
+            $this->assertTrue(in_array(
+                'The current password field is required.',
+                $e->errors()['current_password']
+            ));
+        }
+    }
+
+    public function test_passwords_cannot_be_updated_without_current_password_confirmation()
+    {
+        $user = Mockery::mock(Authenticatable::class);
+        $user->password = '';
+
+        require_once __DIR__.'/../stubs/PasswordValidationRules.php';
+        require_once __DIR__.'/../stubs/UpdateUserPassword.php';
+
+        try {
+            (new UpdateUserPassword())->update($user, [
+                'current_password' => 'invalid-password',
                 'password' => 'new-password',
                 'password_confirmation' => 'new-password',
             ]);


### PR DESCRIPTION
I noticed that what is implemented in the after callback is effectively the `current_password` rule, so it would be simpler to just use that rule.

The current implementation has to first check if `current_password` is set - we can skip that now by relying on `required`.

The only functional difference here is the error message is different when a value for `current_password` is not provided - the default Laravel error message: `The current password field is required.`.