### PR TITLE
Parameters order with hash_equals

### DIFF
--- a/src/Http/Requests/VerifyEmailRequest.php
+++ b/src/Http/Requests/VerifyEmailRequest.php
@@ -13,11 +13,11 @@ class VerifyEmailRequest extends FormRequest
      */
     public function authorize()
     {
-        if (! hash_equals((string) $this->route('id'), (string) $this->user()->getKey())) {
+        if (! hash_equals((string) $this->user()->getKey(), (string) $this->route('id'))) {
             return false;
         }
 
-        if (! hash_equals((string) $this->route('hash'), sha1($this->user()->getEmailForVerification()))) {
+        if (! hash_equals(sha1($this->user()->getEmailForVerification()), (string) $this->route('hash'))) {
             return false;
         }
 


### PR DESCRIPTION
There're 2 parameters in built-in function hash_equals, the first is "known_string" and second is "user_string".

[The notes in PHP manual of hash_equals](https://www.php.net/manual/en/function.hash-equals.php#refsect1-function.hash-equals-notes):
> It is important to provide the user-supplied string as the second parameter, rather than the first.

Otherwise, there's a question in stackoverflow.com about [Why is order of arguments in PHP's hash_equals() function important](https://stackoverflow.com/questions/27911597/why-is-order-of-arguments-in-phps-hash-equals-function-important)

In this commit, it changed parameter orders for hash_equals, because the "user_string" is provided by `$this->route('id')` and `$this->route('hash')`.

This commit will not break any existing features because it only change the order of `hash_equals()`. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
