### PR TITLE
Feacher Redirect to custom URL in SuccessfulPasswordResetLinkRequestRespons

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -22,6 +22,7 @@ return [
         'password-confirmation' => null,
         'register' => null,
         'email-verification' => null,
+        'password-reset-link' => null,
         'password-reset' => null,
     ],
     'features' => [

--- a/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
@@ -36,6 +36,6 @@ class SuccessfulPasswordResetLinkRequestResponse implements SuccessfulPasswordRe
     {
         return $request->wantsJson()
                     ? new JsonResponse(['message' => trans($this->status)], 200)
-                    : redirect(Fortify::redirects('password-reset-link', back()))->with('status', trans($this->status));
+                    : redirect(Fortify::redirects('password-reset-link', route('password.request')))->with('status', trans($this->status));
     }
 }

--- a/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Fortify;
 
 class SuccessfulPasswordResetLinkRequestResponse implements SuccessfulPasswordResetLinkRequestResponseContract
 {
@@ -35,6 +36,6 @@ class SuccessfulPasswordResetLinkRequestResponse implements SuccessfulPasswordRe
     {
         return $request->wantsJson()
                     ? new JsonResponse(['message' => trans($this->status)], 200)
-                    : back()->with('status', trans($this->status));
+                    : redirect(Fortify::redirects('password-reset-link', back()))->with('status', trans($this->status));
     }
 }

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
+use Laravel\Fortify\Fortify;
 use Mockery;
 
 class PasswordResetLinkRequestControllerTest extends OrchestraTestCase

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -33,7 +33,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
                         ->post('/forgot-password', ['email' => 'taylor@laravel.com']);
 
         $response->assertStatus(302);
-        $response->assertRedirect(Fortify::redirects('password-reset-link', '/forgot-password'));
+        $response->assertRedirect(Fortify::redirects('password-reset-link', url('/forgot-password')));
         $response->assertSessionHasNoErrors();
         $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
     }
@@ -48,7 +48,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
                         ->post('/forgot-password', ['email' => 'taylor@laravel.com']);
 
         $response->assertStatus(302);
-        $response->assertRedirect(Fortify::redirects('password-reset-link', '/forgot-password'));
+        $response->assertRedirect(Fortify::redirects('password-reset-link', url('/forgot-password')));
         $response->assertSessionHasErrors('email');
     }
 
@@ -76,7 +76,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
             ->post('/forgot-password', ['emailAddress' => 'taylor@laravel.com']);
 
         $response->assertStatus(302);
-        $response->assertRedirect(Fortify::redirects('password-reset-link', '/forgot-password'));
+        $response->assertRedirect(Fortify::redirects('password-reset-link', url('/forgot-password')));
         $response->assertSessionHasNoErrors();
         $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
     }

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -32,7 +32,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
                         ->post('/forgot-password', ['email' => 'taylor@laravel.com']);
 
         $response->assertStatus(302);
-        $response->assertRedirect('/forgot-password');
+        $response->assertRedirect(Fortify::redirects('password-reset-link', '/forgot-password'));
         $response->assertSessionHasNoErrors();
         $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
     }
@@ -47,7 +47,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
                         ->post('/forgot-password', ['email' => 'taylor@laravel.com']);
 
         $response->assertStatus(302);
-        $response->assertRedirect('/forgot-password');
+        $response->assertRedirect(Fortify::redirects('password-reset-link', '/forgot-password'));
         $response->assertSessionHasErrors('email');
     }
 
@@ -75,7 +75,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
             ->post('/forgot-password', ['emailAddress' => 'taylor@laravel.com']);
 
         $response->assertStatus(302);
-        $response->assertRedirect('/forgot-password');
+        $response->assertRedirect(Fortify::redirects('password-reset-link', '/forgot-password'));
         $response->assertSessionHasNoErrors();
         $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
     }


### PR DESCRIPTION
I would like to redirect to a custom URL after sending a link by email in the flow when forgot password, so I would like to request an update.