### PR TITLE
Use Fortify username method on ConfirmPassword action

### DIFF
--- a/src/Actions/ConfirmPassword.php
+++ b/src/Actions/ConfirmPassword.php
@@ -17,7 +17,7 @@ class ConfirmPassword
      */
     public function __invoke(StatefulGuard $guard, $user, ?string $password = null)
     {
-        $username = config('fortify.username');
+        $username = Fortify::username();
 
         return is_null(Fortify::$confirmPasswordsUsingCallback) ? $guard->validate([
             $username => $user->{$username},


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This change updates the `ConfirmPassword` action to use the `username` method from the `Fortify` class, to be inline with how the `username` is retrieved in other action classes.
