### PR TITLE
Use `boolean` rather than `filled` for remember

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -140,7 +140,7 @@ class RedirectIfTwoFactorAuthenticatable
     {
         $request->session()->put([
             'login.id' => $user->getKey(),
-            'login.remember' => $request->filled('remember'),
+            'login.remember' => $request->boolean('remember'),
         ]);
 
         TwoFactorAuthenticationChallenged::dispatch($user);


### PR DESCRIPTION
The pull request [#328](https://github.com/laravel/fortify/pull/328) changed the `remember` input value to accept a `boolean` instead of simply checking if the value was present and filled.

However the 2fa code wasn't updated to save the boolean value in the session, only if the value was filled. So that means a `false` value would not work if the user had 2fa enabled.