### PR TITLE
Allow translate sent message

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -51,7 +51,6 @@ class Fortify
     const TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
     const TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
     const TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
-    const VERIFICATION_LINK_SENT = 'verification-link-sent';
 
     /**
      * Get the username used for authentication.


### PR DESCRIPTION
Because the status message is sent in translated form, this constant is no longer needed.