### PR TITLE
Fix error while preparing PasswordResetResponse with views turned off

### DIFF
--- a/src/Http/Responses/PasswordResetResponse.php
+++ b/src/Http/Responses/PasswordResetResponse.php
@@ -36,6 +36,6 @@ class PasswordResetResponse implements PasswordResetResponseContract
     {
         return $request->wantsJson()
                     ? new JsonResponse(['message' => trans($this->status)], 200)
-                    : redirect(Fortify::redirects('password-reset', route('login')))->with('status', trans($this->status));
+                    : redirect(Fortify::redirects('password-reset', config('fortify.views', true) ? route('login') : null))->with('status', trans($this->status));
     }
 }


### PR DESCRIPTION
Fixing issue #432 

Added additional check to skip url generation from route('login') if we decide not to use view routes from configuration file.

This fix will help end users to achieve better customization with views turned off.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
