### PR TITLE
Update PrepareAuthenticatedSession.php

### DIFF
--- a/src/Actions/PrepareAuthenticatedSession.php
+++ b/src/Actions/PrepareAuthenticatedSession.php
@@ -33,7 +33,9 @@ class PrepareAuthenticatedSession
      */
     public function handle($request, $next)
     {
-        $request->session()->regenerate();
+        if ($request->hasSession()) {
+            $request->session()->regenerate();
+        }
 
         $this->limiter->clear($request);
 


### PR DESCRIPTION
Hi,

I'm using Laravel Fortify in combination with Laravel Sanctum using API tokens.

Updated `fortify.php`:
```php
'middleware' => ['api'],
```

I'm overwriting the `authenticateUsing` method:
```php
Fortify::authenticateUsing(function (Request $request) {
            $request->validate([
                'email' => 'required|email',
                'password' => 'required',
                'device_name' => 'required',
            ]);

            $user = User::where('email', $request->email)->first();

            if (! $user || ! Hash::check($request->password, $user->password)) {
                throw ValidationException::withMessages([
                    'email' => ['The provided credentials are incorrect.'],
                ]);
            }

            return $user;
        });
```

However it fails on `PrepareAuthenticatedSession` because it expects a session.
Checking if a session is used, fixes the issue and I can successfully login.

Let me know your thoughts, maybe this is not the correct solution.