### PR TITLE
[1.x] Add registerThrough Callback to add custom Middlewares to Registration Route

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -32,6 +32,13 @@ class Fortify
     public static $authenticateUsingCallback;
 
     /**
+     * The callback that is responsible for building the registration pipeline array, if applicable.
+     *
+     * @var callable|null
+     */
+    public static $registerThroughCallback;
+
+    /**
      * The callback that is responsible for confirming user passwords.
      *
      * @var callable|null
@@ -234,6 +241,17 @@ class Fortify
     public static function authenticateUsing(callable $callback)
     {
         static::$authenticateUsingCallback = $callback;
+    }
+
+    /**
+     * Register a callback that is responsible for building the registration pipeline array.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function registerThrough(callable $callback)
+    {
+        static::$registerThroughCallback = $callback;
     }
 
     /**

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -48,10 +48,10 @@ class RegisteredUserController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Fortify\Contracts\CreatesNewUsers  $creator
-     * @return \Laravel\Fortify\Contracts\RegisterResponse
+     * @return mixed
      */
     public function store(Request $request,
-                          CreatesNewUsers $creator): RegisterResponse
+                          CreatesNewUsers $creator)
     {
         return $this->registerPipeline($request)->then(function ($request) use ($creator) {
             event(new Registered($user = $creator->create($request->all())));

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -59,7 +59,8 @@ class RegisteredUserControllerTest extends OrchestraTestCase
     {
         Fortify::registerThrough(function (Request $request) {
             return [
-                new class () {
+                new class ()
+                {
                     public function handle($request, $next)
                     {
                         return $next($request);

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -4,8 +4,10 @@ namespace Laravel\Fortify\Tests;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\Request;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
+use Laravel\Fortify\Fortify;
 use Mockery;
 
 class RegisteredUserControllerTest extends OrchestraTestCase
@@ -39,6 +41,33 @@ class RegisteredUserControllerTest extends OrchestraTestCase
 
     public function test_users_can_be_created_and_redirected_to_intended_url()
     {
+        $this->mock(CreatesNewUsers::class)
+                    ->shouldReceive('create')
+                    ->andReturn(Mockery::mock(Authenticatable::class));
+
+        $this->mock(StatefulGuard::class)
+                    ->shouldReceive('login')
+                    ->once();
+
+        $response = $this->withSession(['url.intended' => 'http://foo.com/bar'])
+                        ->post('/register', []);
+
+        $response->assertRedirect('http://foo.com/bar');
+    }
+
+    public function test_request_is_sent_through_pipeline_and_users_can_be_created()
+    {
+        Fortify::registerThrough(function (Request $request) {
+            return [
+                new class () {
+                    public function handle($request, $next)
+                    {
+                        return $next($request);
+                    }
+                },
+            ];
+        });
+
         $this->mock(CreatesNewUsers::class)
                     ->shouldReceive('create')
                     ->andReturn(Mockery::mock(Authenticatable::class));

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -59,7 +59,7 @@ class RegisteredUserControllerTest extends OrchestraTestCase
     {
         Fortify::registerThrough(function (Request $request) {
             return [
-                new class ()
+                new class()
                 {
                     public function handle($request, $next)
                     {


### PR DESCRIPTION
In a project I want to use the [spatie/laravel-honeypot](https://github.com/spatie/laravel-honeypot) package to protect the app against spam sign ups.
However, there currently doesn't seem to be a way to configure the middlewares of the `POST /register`-route.

This PR adds a `registerThrough()`-method and `$registerThroughCallback`-property to `Fortify`, that works similar to the [`authenticateThrough()`-method](https://laravel.com/docs/10.x/fortify#customizing-the-authentication-pipeline).

User will be able to add middlewares for the registration route by adding the following code to their `FortifyServiceProvider`.

```php
Fortify::registerThrough(function (Request $request) {
    return [
        MyCustomMiddleware::class,
        \Spatie\Honeypot\ProtectAgainstSpam::class
    ];
});
```

> **Warning**
> I had to change the return type of the `store`-method from `Laravel\Fortify\Contracts\RegisterResponse` to `mixed` as my test threw a type error. Not sure why though; my knowledge of the Pipeline class is quite limited.

More than happy to make a PR to the docs repo too, if this get's accepted.

---

After sleeping over this PR, I think it might be overkill to add this to Fortify.
To modify the middlewares for the `/register`-route, all I needed to do was copy & paste the route definition to my user-land routes file.

```php
Route::post('/register', [RegisteredUserController::class, 'store'])
    ->middleware([
        'guest:'.config('fortify.guard'), 
        \Spatie\Honeypot\ProtectAgainstSpam::class
    ]);

// other routes of my app
```

Proposing this pull request anyway, as this might be something you want to see in Fortify anway.