### PR TITLE
Add default max length for passwords

### DIFF
--- a/stubs/PasswordValidationRules.php
+++ b/stubs/PasswordValidationRules.php
@@ -13,6 +13,6 @@ trait PasswordValidationRules
      */
     protected function passwordRules(): array
     {
-        return ['required', 'string', new Password, 'confirmed'];
+        return ['required', 'string', 'max:256', new Password, 'confirmed'];
     }
 }


### PR DESCRIPTION
Another approach to #451

~~Maybe it won't break the tests this time?~~ It didn't 🥳 

Won't break the translations like the previous PR

FYI: Our company just received a security vulnerability report about us not having max password length:

> Hashing large data can cause significant resource consumption on behalf of the server expose the app for a DOS attack.