### PR TITLE
[1.x] Add `twoFactorSetupKey` method

### DIFF
--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -81,7 +81,7 @@ trait TwoFactorAuthenticatable
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
             $this->{Fortify::username()},
-            $this->twoFactorSetupKey()
+            decrypt($this->two_factor_secret)
         );
     }
 

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -81,7 +81,17 @@ trait TwoFactorAuthenticatable
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
             $this->{Fortify::username()},
-            decrypt($this->two_factor_secret)
+            $this->twoFactorSetupKey()
         );
+    }
+
+    /**
+     * Get the two factor authentication setup key.
+     *
+     * @return string
+     */
+    public function twoFactorSetupKey()
+    {
+        return decrypt($this->two_factor_secret);
     }
 }


### PR DESCRIPTION
This adds a method to access the user's two-factor setup key. This could make a Blade view for setting up 2FA easier to read compared to decrypting the ```two_factor_secret``` field directly in the view.

**Breaking Changes**
I wasn't sure if it would be a breaking change to edit the ```twoFactorQrCodeUrl``` method to reference this new method; so, I undid that part of the PR on the chance that it would be.

**Tests**
I didn't include any tests; but I could add one if wanted.