### PR TITLE
Add rate limiter for a registration

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -34,6 +34,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     $limiter = config('fortify.limiters.login');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
+    $registrationLimiter = config('fortify.limiters.registration');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
@@ -69,12 +70,18 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     if (Features::enabled(Features::registration())) {
         if ($enableViews) {
             Route::get(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
+                ->middleware(array_filter([
+                    'guest:'.config('fortify.guard'),
+                    $registrationLimiter ? 'throttle:'.$registrationLimiter : null,
+                ]))
                 ->name('register');
         }
 
         Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')]);
+            ->middleware(array_filter([
+                'guest:'.config('fortify.guard'),
+                $registrationLimiter ? 'throttle:'.$registrationLimiter : null,
+            ]));
     }
 
     // Email Verification...


### PR DESCRIPTION
I added a rate limiter for a registration endpoint. I was looking around how to throttle the registration endpoint but I couldn't find it. It is backward compatible and I think it would benefit people who want to rate limit registration by ip
