### PR TITLE
remove limiter from the registration view route

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -70,10 +70,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     if (Features::enabled(Features::registration())) {
         if ($enableViews) {
             Route::get(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'create'])
-                ->middleware(array_filter([
-                    'guest:'.config('fortify.guard'),
-                    $registrationLimiter ? 'throttle:'.$registrationLimiter : null,
-                ]))
+                ->middleware(['guest:'.config('fortify.guard')])
                 ->name('register');
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I notice that #460 is adding a rate limiter for registration. It shouldn't be applied to the registration view route, in many cases it might we as developers need to refresh the page multiple times for any reason. 

For example, I ran `php artisan optimize:clear` and vite trigger the reload many times here and it will reach the throttle limit.

<details><summary>Details</summary>
<p>

https://user-images.githubusercontent.com/46495960/233508826-1752c0bf-0444-416f-bb34-91f4344bfd4b.mp4

</p>
</details> 

