### PR TITLE
Add missing limiters to default fortify config

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -15,6 +15,9 @@ return [
     'domain' => null,
     'limiters' => [
         'login' => null,
+        'two-factor' => null,
+        'registration' => null,
+        'verification' => null,
     ],
     'paths' => [
         'login' => null,


### PR DESCRIPTION
The `config/fortify.php` has all config options listed initialized to null. However, the `limiters` array is missing default assignments for keys `two-factor`, `verification`, `registration` (#460). A user may not know there is rate limiting capabilities for these routes solely by looking at the config unless additionally looked at `routes.php`.

This PR adds default initialization for these limiters in `config/fortify.php` file.