### PR TITLE
Update route to name POST two factor challenge

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -130,11 +130,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->name('two-factor.login');
         }
 
-        Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
+        Route::post(RoutePath::for('two-factor.challenge', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
                 $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
-            ]));
+            ]))->name('two-factor.challenge');
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']


### PR DESCRIPTION
This pull request changes the POST route for two factor challenge to provide a name for it.  This route was previously un-named.  No change to the actual endpoint is made.  The purpose of this is to allow [Ziggy](https://github.com/tighten/ziggy) to publish this route to the front end.  See issue #468 (current workaround).  I do not think this would break any application as the route was previously un-named, and hence to use it, the actual endpoint would have had to have been referenced. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
