### PR TITLE
Removed direct invocation of `toResponse()` method

### DIFF
--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -61,7 +61,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
 
             event(new RecoveryCodeReplaced($user, $code));
         } elseif (! $request->hasValidCode()) {
-            return app(FailedTwoFactorLoginResponse::class)->toResponse($request);
+            return app(FailedTwoFactorLoginResponse::class);
         }
 
         $this->guard->login($user, $request->remember());

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -116,7 +116,7 @@ class TwoFactorLoginRequest extends FormRequest
         if (! $this->session()->has('login.id') ||
             ! $user = $model::find($this->session()->get('login.id'))) {
             throw new HttpResponseException(
-                app(FailedTwoFactorLoginResponse::class)->toResponse($this)
+                app(FailedTwoFactorLoginResponse::class)
             );
         }
 


### PR DESCRIPTION
The `toResponse()` method is called directly on the `FailedTwoFactorLoginResponse` class. However, since `FailedTwoFactorLoginResponse` implements the `Responsable` interface, the `toResponse()` method is automatically called when the response needs to be converted to an HTTP response.