### PR TITLE
[1.x] Port security fixes to default login rate limiter

### DIFF
--- a/stubs/FortifyServiceProvider.php
+++ b/stubs/FortifyServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -33,9 +34,9 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
         RateLimiter::for('login', function (Request $request) {
-            $email = (string) $request->email;
+            $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());
 
-            return Limit::perMinute(5)->by($email.$request->ip());
+            return Limit::perMinute(5)->by($throttleKey);
         });
 
         RateLimiter::for('two-factor', function (Request $request) {


### PR DESCRIPTION
This PR ports two security fixes for MySQL/MariaDB from [`LoginRateLimiter`](https://github.com/laravel/fortify/blob/1.x/src/LoginRateLimiter.php#L92) to the service provider's rate limiter (that Fortify uses on a default installation):

- Protection against bypass attempts with different combinations of uppercase and lowercase characters (e.g. `uSer@example.com`): This fix has been included in `LoginRateLimiter` from the [beginning](https://github.com/laravel/fortify/commit/4f903075f01dddb46905a870f3a460fe17e1f461#diff-3cb814e6f9f9967e0516dda5c9fd4e8c3cb69394a03bad50bd7314156a8024c2R81) but not in the default rate limiter.
- Protection against bypass attempts with special characters (e.g. `uⓢer@example.com`): #354 fixed this in `LoginRateLimiter` but not in the default rate limiter.

I replaced `$request->email` with the more universal `$request->input(Fortify::username())` from `LoginRateLimiter`.

I also removed the string cast from #333 because it doesn't actually solve the issue it wanted to fix (#332). Passing an array still causes an "Array to string conversion" error.

There aren't any tests for the default rate limiter yet and I'm not sure about the bestway to test them.

The big issue with these vulnerabilities is that they don't get fixed in existing apps since the service provider is a stub file, but we can't really do anything about that.