### PR TITLE
This adds the route name two-factor.login to the POST route for /two-factor-challenge when views are not enabled

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -126,15 +126,21 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     if (Features::enabled(Features::twoFactorAuthentication())) {
         if ($enableViews) {
             Route::get(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('two-factor.login');
-        }
+            ->middleware(['guest:' . config('fortify.guard')])
+            ->name('two-factor.login');
 
-        Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
-            ->middleware(array_filter([
-                'guest:'.config('fortify.guard'),
-                $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
-            ]));
+            Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
+                ->middleware(array_filter([
+                    'guest:' . config('fortify.guard'),
+                    $twoFactorLimiter ? 'throttle:' . $twoFactorLimiter : null,
+                ]));
+        } else {
+            Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
+                ->middleware(array_filter([
+                    'guest:' . config('fortify.guard'),
+                    $twoFactorLimiter ? 'throttle:' . $twoFactorLimiter : null,
+                ]))->name('two-factor.login');
+        }
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']


### PR DESCRIPTION
This issue is discussed in #470 (my first attempt was incorrect).  This one adds an else statement to the `if ($enableViews)` logic for Two Factor routes.  Under the current route file, if views are _not enabled,_ the POST route for `/two-factor-challenge` (which is named `two-factor.login` if view _ARE_ enabled) is not named, and hence never published if you are using Ziggy.  This just adds the POST route in the else portion, and names it the same thing so ZIggy can pick it up.  

This will not break anyone's code - if views were enabled, the POST route was already named (and this pull request does not change anything for these users); if views were not enabled, a user would not have a named route to use in ZIggy - and would have had to have used a workaround.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
