### PR TITLE
Add ability to override the post-registration processes

### DIFF
--- a/src/Actions/AttemptToLogin.php
+++ b/src/Actions/AttemptToLogin.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Fortify\Actions;
+
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Laravel\Fortify\Fortify;
+
+class AttemptToLogin
+{
+    /**
+     * The guard implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected $guard;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @return void
+     */
+    public function __construct(StatefulGuard $guard)
+    {
+        $this->guard = $guard;
+    }
+
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($request, $next)
+    {
+        $this->guard->attempt($request->only(Fortify::username(), 'password'));
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
## Background
The class `Illuminate/Foundation/Auth/AuthenticatesUsers.php` which was responsible for user authentication in the Laravel framework, has been eliminated after version 7 of Laravel. 
Within that class, there is a method that provides the ability to customize the login and post-login processes, with access to the `$request` object.

```
    protected function authenticated(Request $request, $user)
    {
        //
    }
```

In Fortify, the task of authentication is handled by the class `AuthenticatedSessionController`. Although the `authenticated()` method no longer exists in this Fortify class, including `config('fortify.pipelines.login')` within the `loginPipeline()` method of this class serves as an appropriate replacement for the deprecated `authenticated()` method in the Laravel Framework.


Similarly, in the context of user registration, the class `Illuminate/Foundation/Auth/RegistersUsers.php` in the previous version of the Laravel framework was responsible for handling user registration. This class includes a method called `registered()` as follow:

```
    protected function registered(Request $request, $user)
    {
        //
    }
```

This method provides the ability to customize the registration and post-registration processes, with access to the `$request` object.

In Fortify, the class `RegisteredUserController` is responsible for user registration. However, unlike the login process where Fortify provides the ability to customize the process using `loginPipeline()`, this class does not offer the same customization options for the register and post-register processes.

## Issue
- I am working on a legacy Laravel application (predating the creation of Fortify) that relies on the post-login and post-register processes, utilizing the `$request` object  through deprecated `authenticated()` and `registered()` methods. This application even overrides the default logic of immediately logging in after registration with `$this->guard->login($user)`, following the traditional practice in Laravel. Instead, the login is made conditional under specific controlled circumstances. Recently, this application incorporated Fortify, but the incorporation was not implemented in a tidy and standardized manner. Since Fortify does not provide the option to customize the post-register process, a portion of the Fortify code was copied, implemented, and modified directly within the application. Consequently, any future updates to Fortify will need to be manually recognized and then applied to the application code, even after updating the package through Composer.

## Proposed Solution
- By incorporating the pipeline feature into the registration flow, one gains access to the `$request` object and gains the ability to fully customize and exert control over the registration process.
- While the proposed `registerPipeline()` method here follows by default the old Laravel custom of automatically logging in the registered user to ensure full backward compatibility, it also extends access to the `$request` object, allowing for greater control over the registration process.

Please review this PR for implementation and let me know if you have any feedback, suggested changes, or alternative solutions.

Thanks,

**Authored-by**: Hamed Panjeh <panjeh@gmail.com>