### PR TITLE
Ensure all test methods are camelCased + add .idea folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+/.idea

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -20,7 +20,7 @@ use PragmaRX\Google2FA\Google2FA;
 
 class AuthenticatedSessionControllerTest extends OrchestraTestCase
 {
-    public function test_the_login_view_is_returned()
+    public function testTheLoginViewIsReturned()
     {
         $this->mock(LoginViewResponse::class)
                 ->shouldReceive('toResponse')
@@ -32,7 +32,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_user_can_authenticate()
+    public function testUserCanAuthenticate()
     {
         $this->loadLaravelMigrations(['--database' => 'testbench']);
 
@@ -50,7 +50,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertRedirect('/home');
     }
 
-    public function test_user_is_redirected_to_challenge_when_using_two_factor_authentication()
+    public function testUserIsRedirectedToChallengeWhenUsingTwoFactorAuthentication()
     {
         Event::fake();
 
@@ -79,7 +79,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         Event::assertDispatched(TwoFactorAuthenticationChallenged::class);
     }
 
-    public function test_user_is_not_redirected_to_challenge_when_using_two_factor_authentication_that_has_not_been_confirmed_and_confirmation_is_enabled()
+    public function testUserIsNotRedirectedToChallengeWhenUsingTwoFactorAuthenticationThatHasNotBeenConfirmedAndConfirmationIsEnabled()
     {
         Event::fake();
 
@@ -110,7 +110,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertRedirect('/home');
     }
 
-    public function test_user_is_redirected_to_challenge_when_using_two_factor_authentication_that_has_been_confirmed_and_confirmation_is_enabled()
+    public function testUserIsRedirectedToChallengeWhenUsingTwoFactorAuthenticationThatHasBeenConfirmedAndConfirmationIsEnabled()
     {
         Event::fake();
 
@@ -143,7 +143,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertRedirect('/two-factor-challenge');
     }
 
-    public function test_user_can_authenticate_when_two_factor_challenge_is_disabled()
+    public function testUserCanAuthenticateWhenTwoFactorChallengeIsDisabled()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
 
@@ -174,7 +174,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertRedirect('/home');
     }
 
-    public function test_validation_exception_returned_on_failure()
+    public function testValidationExceptionReturnedOnFailure()
     {
         $this->loadLaravelMigrations(['--database' => 'testbench']);
 
@@ -193,7 +193,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertSessionHasErrors(['email']);
     }
 
-    public function test_login_attempts_are_throttled()
+    public function testLoginAttemptsAreThrottled()
     {
         $this->mock(LoginRateLimiter::class, function ($mock) {
             $mock->shouldReceive('tooManyAttempts')->andReturn(true);
@@ -212,7 +212,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
     /**
      * @dataProvider usernameProvider
      */
-    public function test_cant_bypass_throttle_with_special_characters(string $username, string $expectedResult)
+    public function testCantBypassThrottleWithSpecialCharacters(string $username, string $expectedResult)
     {
         $loginRateLimiter = new LoginRateLimiter(
             $this->mock(RateLimiter::class)
@@ -243,7 +243,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         ];
     }
 
-    public function test_the_user_can_logout_of_the_application()
+    public function testTheUserCanLogoutOfTheApplication()
     {
         Auth::guard()->setUser(
             Mockery::mock(Authenticatable::class)->shouldIgnoreMissing()
@@ -255,7 +255,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $this->assertNull(Auth::guard()->getUser());
     }
 
-    public function test_the_user_can_logout_of_the_application_using_json_request()
+    public function testTheUserCanLogoutOfTheApplicationUsingJsonRequest()
     {
         Auth::guard()->setUser(
             Mockery::mock(Authenticatable::class)->shouldIgnoreMissing()
@@ -267,7 +267,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $this->assertNull(Auth::guard()->getUser());
     }
 
-    public function test_two_factor_challenge_can_be_passed_via_code()
+    public function testTwoFactorChallengeCanBePassedViaCode()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
 
@@ -296,7 +296,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             ->assertSessionMissing('login.id');
     }
 
-    public function test_two_factor_authentication_preserves_remember_me_selection(): void
+    public function testTwoFactorAuthenticationPreservesRememberMeSelection(): void
     {
         Event::fake();
 
@@ -325,7 +325,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             ->assertSessionHas('login.remember', false);
     }
 
-    public function test_two_factor_challenge_fails_for_old_otp_and_zero_window()
+    public function testTwoFactorChallengeFailsForOldOtpAndZeroWindow()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
 
@@ -361,7 +361,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
                  ->assertSessionHasErrors(['code']);
     }
 
-    public function test_two_factor_challenge_can_be_passed_via_recovery_code()
+    public function testTwoFactorChallengeCanBePassedViaRecoveryCode()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
 
@@ -388,7 +388,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $this->assertNotContains('valid-code', json_decode(decrypt($user->fresh()->two_factor_recovery_codes), true));
     }
 
-    public function test_two_factor_challenge_can_fail_via_recovery_code()
+    public function testTwoFactorChallengeCanFailViaRecoveryCode()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
 
@@ -415,7 +415,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $this->assertNull(Auth::getUser());
     }
 
-    public function test_two_factor_challenge_requires_a_challenged_user()
+    public function testTwoFactorChallengeRequiresAChallengedUser()
     {
         app('config')->set('auth.providers.users.model', TestTwoFactorAuthenticationSessionUser::class);
 

--- a/tests/ConfirmablePasswordControllerTest.php
+++ b/tests/ConfirmablePasswordControllerTest.php
@@ -25,7 +25,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         ]);
     }
 
-    public function test_the_confirm_password_view_is_returned()
+    public function testTheConfirmPasswordViewIsReturned()
     {
         $this->mock(ConfirmPasswordViewResponse::class)
             ->shouldReceive('toResponse')
@@ -39,7 +39,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_password_can_be_confirmed()
+    public function testPasswordCanBeConfirmed()
     {
         $response = $this->withoutExceptionHandling()
             ->actingAs($this->user)
@@ -53,7 +53,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         $response->assertRedirect('http://foo.com/bar');
     }
 
-    public function test_password_confirmation_can_fail_with_an_invalid_password()
+    public function testPasswordConfirmationCanFailWithAnInvalidPassword()
     {
         $response = $this->withoutExceptionHandling()
             ->actingAs($this->user)
@@ -69,7 +69,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         $this->assertNotEquals($response->getTargetUrl(), 'http://foo.com/bar');
     }
 
-    public function test_password_confirmation_can_fail_without_a_password()
+    public function testPasswordConfirmationCanFailWithoutAPassword()
     {
         $response = $this->withoutExceptionHandling()
             ->actingAs($this->user)
@@ -85,7 +85,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         $this->assertNotEquals($response->getTargetUrl(), 'http://foo.com/bar');
     }
 
-    public function test_password_confirmation_can_be_customized()
+    public function testPasswordConfirmationCanBeCustomized()
     {
         Fortify::$confirmPasswordsUsingCallback = function () {
             return true;
@@ -105,7 +105,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         Fortify::$confirmPasswordsUsingCallback = null;
     }
 
-    public function test_password_confirmation_can_be_customized_and_fail_without_password()
+    public function testPasswordConfirmationCanBeCustomizedAndFailWithoutPassword()
     {
         Fortify::$confirmPasswordsUsingCallback = function () {
             return true;
@@ -125,7 +125,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         Fortify::$confirmPasswordsUsingCallback = null;
     }
 
-    public function test_password_can_be_confirmed_with_json()
+    public function testPasswordCanBeConfirmedWithJson()
     {
         $response = $this->actingAs($this->user)
             ->postJson(
@@ -136,7 +136,7 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
         $response->assertStatus(201);
     }
 
-    public function test_password_confirmation_can_fail_with_json()
+    public function testPasswordConfirmationCanFailWithJson()
     {
         $response = $this->actingAs($this->user)
             ->postJson(

--- a/tests/EmailVerificationNotificationControllerTest.php
+++ b/tests/EmailVerificationNotificationControllerTest.php
@@ -7,7 +7,7 @@ use Mockery;
 
 class EmailVerificationNotificationControllerTest extends OrchestraTestCase
 {
-    public function test_email_verification_notification_can_be_sent()
+    public function testEmailVerificationNotificationCanBeSent()
     {
         $user = Mockery::mock(Authenticatable::class);
 
@@ -22,7 +22,7 @@ class EmailVerificationNotificationControllerTest extends OrchestraTestCase
         $response->assertRedirect('/email/verify');
     }
 
-    public function test_user_is_redirect_if_already_verified()
+    public function testUserIsRedirectIfAlreadyVerified()
     {
         $user = Mockery::mock(Authenticatable::class);
 
@@ -37,7 +37,7 @@ class EmailVerificationNotificationControllerTest extends OrchestraTestCase
         $response->assertRedirect('/home');
     }
 
-    public function test_user_is_redirect_to_intended_url_if_already_verified()
+    public function testUserIsRedirectToIntendedUrlIfAlreadyVerified()
     {
         $user = Mockery::mock(Authenticatable::class);
 

--- a/tests/EmailVerificationPromptControllerTest.php
+++ b/tests/EmailVerificationPromptControllerTest.php
@@ -8,7 +8,7 @@ use Mockery;
 
 class EmailVerificationPromptControllerTest extends OrchestraTestCase
 {
-    public function test_the_email_verification_prompt_view_is_returned()
+    public function testTheEmailVerificationPromptViewIsReturned()
     {
         $this->mock(VerifyEmailViewResponse::class)
                 ->shouldReceive('toResponse')
@@ -23,7 +23,7 @@ class EmailVerificationPromptControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_user_is_redirect_home_if_already_verified()
+    public function testUserIsRedirectHomeIfAlreadyVerified()
     {
         $this->mock(VerifyEmailViewResponse::class)
                 ->shouldReceive('toResponse')
@@ -37,7 +37,7 @@ class EmailVerificationPromptControllerTest extends OrchestraTestCase
         $response->assertRedirect('/home');
     }
 
-    public function test_user_is_redirect_to_intended_url_if_already_verified()
+    public function testUserIsRedirectToIntendedUrlIfAlreadyVerified()
     {
         $this->mock(VerifyEmailViewResponse::class)
                 ->shouldReceive('toResponse')

--- a/tests/FortifyServiceProviderTest.php
+++ b/tests/FortifyServiceProviderTest.php
@@ -8,7 +8,7 @@ use Laravel\Fortify\Fortify;
 
 class FortifyServiceProviderTest extends OrchestraTestCase
 {
-    public function test_views_can_be_customized()
+    public function testViewsCanBeCustomized()
     {
         Fortify::loginView(function () {
             return 'foo';
@@ -20,7 +20,7 @@ class FortifyServiceProviderTest extends OrchestraTestCase
         $this->assertSame('foo', $response->content());
     }
 
-    public function test_customized_views_can_return_their_own_responsable()
+    public function testCustomizedViewsCanReturnTheirOwnResponsible()
     {
         Fortify::loginView(function () {
             return new class implements Responsable

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -14,7 +14,7 @@ use Mockery;
 
 class NewPasswordControllerTest extends OrchestraTestCase
 {
-    public function test_the_new_password_view_is_returned()
+    public function testTheNewPasswordViewIsReturned()
     {
         $this->mock(ResetPasswordViewResponse::class)
                 ->shouldReceive('toResponse')
@@ -26,7 +26,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_password_can_be_reset()
+    public function testPasswordCanBeReset()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
@@ -58,7 +58,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertRedirect(Fortify::redirects('password-reset', route('login')));
     }
 
-    public function test_password_reset_can_fail()
+    public function testPasswordResetCanFail()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
@@ -77,7 +77,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertSessionHasErrors('email');
     }
 
-    public function test_password_reset_can_fail_with_json()
+    public function testPasswordResetCanFailWithJson()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
@@ -96,7 +96,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertJsonValidationErrors('email');
     }
 
-    public function test_password_can_be_reset_with_customized_email_address_field()
+    public function testPasswordCanBeResetWithCustomizedEmailAddressField()
     {
         Config::set('fortify.email', 'emailAddress');
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
@@ -129,7 +129,7 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertRedirect(Fortify::redirects('password-reset', route('login')));
     }
 
-    public function test_password_is_required()
+    public function testPasswordIsRequired()
     {
         $response = $this->post('/reset-password', [
             'token' => 'token',

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -10,7 +10,7 @@ use Mockery;
 
 class PasswordControllerTest extends OrchestraTestCase
 {
-    public function test_passwords_can_be_updated()
+    public function testPasswordsCanBeUpdated()
     {
         $user = Mockery::mock(User::class);
 
@@ -27,7 +27,7 @@ class PasswordControllerTest extends OrchestraTestCase
         $response->assertStatus(200);
     }
 
-    public function test_passwords_cannot_be_updated_without_current_password()
+    public function testPasswordsCannotBeUpdatedWithoutCurrentPassword()
     {
         $user = Mockery::mock(User::class);
 
@@ -47,7 +47,7 @@ class PasswordControllerTest extends OrchestraTestCase
         }
     }
 
-    public function test_passwords_cannot_be_updated_without_current_password_confirmation()
+    public function testPasswordsCannotBeUpdatedWithoutCurrentPasswordConfirmation()
     {
         $user = Mockery::mock(User::class);
 

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -10,7 +10,7 @@ use Mockery;
 
 class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
 {
-    public function test_the_reset_link_request_view_is_returned()
+    public function testTheResetLinkRequestViewIsReturned()
     {
         $this->mock(RequestPasswordResetLinkViewResponse::class)
                 ->shouldReceive('toResponse')
@@ -22,7 +22,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_reset_link_can_be_successfully_requested()
+    public function testResetLinkCanBeSuccessfullyRequested()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
@@ -37,7 +37,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
         $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
     }
 
-    public function test_reset_link_request_can_fail()
+    public function testResetLinkRequestCanFail()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
@@ -51,7 +51,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
         $response->assertSessionHasErrors('email');
     }
 
-    public function test_reset_link_request_can_fail_with_json()
+    public function testResetLinkRequestCanFailWithJson()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
 
@@ -64,7 +64,7 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
         $response->assertJsonValidationErrors('email');
     }
 
-    public function test_reset_link_can_be_successfully_requested_with_customized_email_field()
+    public function testResetLinkCanBeSuccessfullyRequestedWithCustomizedEmailField()
     {
         Config::set('fortify.email', 'emailAddress');
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));

--- a/tests/PasswordRuleTest.php
+++ b/tests/PasswordRuleTest.php
@@ -7,7 +7,7 @@ use Laravel\Fortify\Rules\Password;
 
 class PasswordRuleTest extends OrchestraTestCase
 {
-    public function test_password_rule()
+    public function testPasswordRule()
     {
         $rule = new Password;
 
@@ -41,7 +41,7 @@ class PasswordRuleTest extends OrchestraTestCase
         $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character and one number'));
     }
 
-    public function test_password_rule_can_require_special_characters()
+    public function testPasswordRuleCanRequireSpecialCharacters()
     {
         $rule = new Password;
 
@@ -54,7 +54,7 @@ class PasswordRuleTest extends OrchestraTestCase
         $this->assertTrue(Str::contains($rule->message(), 'special character'));
     }
 
-    public function test_password_rule_can_require_numeric_and_special_characters()
+    public function testPasswordRuleCanRequireNumericAndSpecialCharacters()
     {
         $rule = new Password;
 

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -8,7 +8,7 @@ use Mockery;
 
 class ProfileInformationControllerTest extends OrchestraTestCase
 {
-    public function test_contact_information_can_be_updated()
+    public function testContactInformationCanBeUpdated()
     {
         $user = Mockery::mock(Authenticatable::class);
 

--- a/tests/RecoveryCodeControllerTest.php
+++ b/tests/RecoveryCodeControllerTest.php
@@ -9,7 +9,7 @@ use Laravel\Fortify\FortifyServiceProvider;
 
 class RecoveryCodeControllerTest extends OrchestraTestCase
 {
-    public function test_new_recovery_codes_can_be_generated()
+    public function testNewRecoveryCodesCanBeGenerated()
     {
         Event::fake();
 

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -10,7 +10,7 @@ use Mockery;
 
 class RegisteredUserControllerTest extends OrchestraTestCase
 {
-    public function test_the_register_view_is_returned()
+    public function testTheRegisterViewIsReturned()
     {
         $this->mock(RegisterViewResponse::class)
                 ->shouldReceive('toResponse')
@@ -22,7 +22,7 @@ class RegisteredUserControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_users_can_be_created()
+    public function testUsersCanBeCreated()
     {
         $this->mock(CreatesNewUsers::class)
                     ->shouldReceive('create')
@@ -37,7 +37,7 @@ class RegisteredUserControllerTest extends OrchestraTestCase
         $response->assertRedirect('/home');
     }
 
-    public function test_users_can_be_created_and_redirected_to_intended_url()
+    public function testUsersCanBeCreatedAndRedirectedToIntendedUrl()
     {
         $this->mock(CreatesNewUsers::class)
                     ->shouldReceive('create')

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -14,7 +14,7 @@ use PragmaRX\Google2FA\Google2FA;
 
 class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
 {
-    public function test_two_factor_authentication_can_be_enabled()
+    public function testTwoFactorAuthenticationCanBeEnabled()
     {
         Event::fake();
 
@@ -44,7 +44,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertNotNull($user->twoFactorQrCodeSvg());
     }
 
-    public function test_two_factor_authentication_secret_key_can_be_retrieved()
+    public function testTwoFactorAuthenticationSecretKeyCanBeRetrieved()
     {
         Event::fake();
 
@@ -67,7 +67,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertEquals('foo', $response->original['secretKey']);
     }
 
-    public function test_two_factor_authentication_can_be_confirmed()
+    public function testTwoFactorAuthenticationCanBeConfirmed()
     {
         Event::fake();
 
@@ -109,7 +109,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertFalse($user->hasEnabledTwoFactorAuthentication());
     }
 
-    public function test_two_factor_authentication_can_not_be_confirmed_with_invalid_code()
+    public function testTwoFactorAuthenticationCanNotBeConfirmedWithInvalidCode()
     {
         Event::fake();
 
@@ -144,7 +144,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertNull($user->two_factor_confirmed_at);
     }
 
-    public function test_two_factor_authentication_can_be_disabled()
+    public function testTwoFactorAuthenticationCanBeDisabled()
     {
         Event::fake();
 

--- a/tests/VerifyEmailControllerTest.php
+++ b/tests/VerifyEmailControllerTest.php
@@ -8,7 +8,7 @@ use Mockery;
 
 class VerifyEmailControllerTest extends OrchestraTestCase
 {
-    public function test_the_email_can_be_verified()
+    public function testTheEmailCanBeVerified()
     {
         $url = URL::temporarySignedRoute(
             'verification.verify',
@@ -33,7 +33,7 @@ class VerifyEmailControllerTest extends OrchestraTestCase
         $response->assertRedirect('http://foo.com/bar');
     }
 
-    public function test_redirected_if_email_is_already_verified()
+    public function testRedirectedIfEmailIsAlreadyVerified()
     {
         $url = URL::temporarySignedRoute(
             'verification.verify',
@@ -56,7 +56,7 @@ class VerifyEmailControllerTest extends OrchestraTestCase
         $response->assertStatus(302);
     }
 
-    public function test_email_is_not_verified_if_id_does_not_match()
+    public function testEmailIsNotVerifiedIfIdDoesNotMatch()
     {
         $url = URL::temporarySignedRoute(
             'verification.verify',
@@ -77,7 +77,7 @@ class VerifyEmailControllerTest extends OrchestraTestCase
         $response->assertStatus(403);
     }
 
-    public function test_email_is_not_verified_if_email_does_not_match()
+    public function testEmailIsNotVerifiedIfEmailDoesNotMatch()
     {
         $url = URL::temporarySignedRoute(
             'verification.verify',


### PR DESCRIPTION
While reviewing Laravel code, I noticed that all the tests were written in camel case. However, upon examining the Fortify codebase, I found that it used snake case. So, I made the necessary updates and I think camel case is more readable than snake case and the majority of the languages use the camel case.

This is the same as this [PR](https://github.com/laravel/framework/pull/29508) by @lucasmichot