### PR TITLE
Password reset - allow success response on invalid user

### DIFF
--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -38,8 +38,10 @@ class PasswordResetLinkController extends Controller
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
-        $status = $this->broker()->sendResetLink(
-            $request->only(Fortify::email())
+        $status = $this->showSuccessOnInvalidUser(
+            $this->broker()->sendResetLink(
+                $request->only(Fortify::email())
+            )
         );
 
         return $status == Password::RESET_LINK_SENT
@@ -55,5 +57,15 @@ class PasswordResetLinkController extends Controller
     protected function broker(): PasswordBroker
     {
         return Password::broker(config('fortify.passwords'));
+    }
+
+    /**
+     * Update status to success if success on invalid user is allowed.
+     */
+    protected function showSuccessOnInvalidUser(string $status): string
+    {
+        return config('fortify.success_on_invalid_user') && $status === Password::INVALID_USER
+            ? Password::RESET_LINK_SENT
+            : $status;
     }
 }

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -150,8 +150,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | When an invalid email is entered on a forgot-password reset route,
-    | setting this to true will return a success response allowing you to hide
-    | the fact that the email doesn't exist preventing email enumeration.
+    | setting this to true will return a success response preventing an
+    | intruder from fishing for valid email addresses
     |
     */
     'success_on_invalid_user' => true,

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -144,4 +144,15 @@ return [
         ]),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Show Success on Invalid User
+    |--------------------------------------------------------------------------
+    |
+    | When an invalid email is entered on a forgot-password reset route,
+    | setting this to true will return a success response allowing you to hide
+    | the fact that the email doesn't exist preventing email enumeration.
+    |
+    */
+    'success_on_invalid_user' => true,
 ];

--- a/tests/PasswordResetLinkRequestControllerTest.php
+++ b/tests/PasswordResetLinkRequestControllerTest.php
@@ -51,6 +51,22 @@ class PasswordResetLinkRequestControllerTest extends OrchestraTestCase
         $response->assertSessionHasErrors('email');
     }
 
+    public function test_reset_link_request_return_success_on_invalid_user_if_configured()
+    {
+        Config::set('fortify.success_on_invalid_user', true);
+        Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
+
+        $broker->shouldReceive('sendResetLink')->andReturn(Password::INVALID_USER);
+
+        $response = $this->from(url('/forgot-password'))
+            ->post('/forgot-password', ['email' => 'taylor@laravel.com']);
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/forgot-password');
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('status', trans(Password::RESET_LINK_SENT));
+    }
+
     public function test_reset_link_request_can_fail_with_json()
     {
         Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));


### PR DESCRIPTION
### Small security feature:

Adding a config flag to allow for responses to appear as successful when invalid emails are submitted during password resets, preventing intruders from fishing for valid email addresses

When used in combination with laravel, I would suggest just updating the reset success message to be more verbose in `resources/lang/en/passwords.php` : `sent`

Something like this:
`An email has been sent to the address provided, if it exists in our system. Please check your inbox for further instructions on how to reset your account. If you don't receive an email within a few minutes, please ensure that the email address entered is correct and try again. For security reasons, we do not confirm the existence of email addresses in our system.`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
