### PR TITLE
Post-registration "no login" option

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -74,10 +74,14 @@ class Features
     /**
      * Enable the registration feature.
      *
+     * @param  array  $options
      * @return string
      */
-    public static function registration()
+    public static function registration(array $options = [])
     {
+        if (! empty($options)) {
+            config(['fortify-options.registration' => $options]);
+        }
         return 'registration';
     }
 

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -53,7 +53,9 @@ class RegisteredUserController extends Controller
     {
         event(new Registered($user = $creator->create($request->all())));
 
-        $this->guard->login($user);
+        if (config('fortify-options.registration.login', true)) {
+            $this->guard->login($user);
+        }
 
         return app(RegisterResponse::class);
     }


### PR DESCRIPTION
This PR adds the ability to register without login. This seems to be a pretty common need among users. The alternative being overriding the RegisteredController & route, this is a much more elegant solution.

Example usage:
```
// in config/fortify.php

    /*
    |--------------------------------------------------------------------------
    | Features
    |--------------------------------------------------------------------------
    |
    | Some of the Fortify features are optional. You may disable the features
    | by removing them from this array. You're free to only remove some of
    | these features or you can even remove all of these if you need to.
    |
    */

    'features' => [
        Features::registration([
            'login' => false,
        ]),
    ],

];
```