### PR TITLE
Added case-sensitivity option for usernames

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -13,7 +13,7 @@ return [
     'home' => '/home',
     'prefix' => '',
     'domain' => null,
-    'case_sensitive_usernames' => true,
+    'lowercase_usernames' => false,
     'limiters' => [
         'login' => null,
     ],

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -13,6 +13,7 @@ return [
     'home' => '/home',
     'prefix' => '',
     'domain' => null,
+    'case_sensitive_usernames' => true,
     'limiters' => [
         'login' => null,
     ],

--- a/src/Actions/CanonicalizeUsername.php
+++ b/src/Actions/CanonicalizeUsername.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of fortify, a Matchory application.
+ *
+ * Unauthorized copying of this file, via any medium, is strictly prohibited.
+ * Its contents are strictly confidential and proprietary.
+ *
+ * @copyright 2020–2023 Matchory GmbH · All rights reserved
+ * @author    Moritz Friedrich <moritz@matchory.com>
+ */
+
+declare(strict_types=1);
+
+namespace Laravel\Fortify\Actions;
+
+use Illuminate\Support\Str;
+use Laravel\Fortify\Fortify;
+
+class CanonicalizeUsername
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($request, $next)
+    {
+        $request->merge([
+            Fortify::username() => Str::lower($request->{Fortify::username()}),
+        ]);
+
+        return $next($request);
+    }
+}

--- a/src/Actions/CanonicalizeUsername.php
+++ b/src/Actions/CanonicalizeUsername.php
@@ -1,17 +1,5 @@
 <?php
 
-/**
- * This file is part of fortify, a Matchory application.
- *
- * Unauthorized copying of this file, via any medium, is strictly prohibited.
- * Its contents are strictly confidential and proprietary.
- *
- * @copyright 2020–2023 Matchory GmbH · All rights reserved
- * @author    Moritz Friedrich <moritz@matchory.com>
- */
-
-declare(strict_types=1);
-
 namespace Laravel\Fortify\Actions;
 
 use Illuminate\Support\Str;

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\Pipeline;
 use Laravel\Fortify\Actions\AttemptToAuthenticate;
+use Laravel\Fortify\Actions\CanonicalizeUsername;
 use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
 use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
@@ -83,6 +84,7 @@ class AuthenticatedSessionController extends Controller
 
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
+            config('fortify.case_sensitive_usernames') ? null : CanonicalizeUsername::class,
             Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
             AttemptToAuthenticate::class,
             PrepareAuthenticatedSession::class,

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -84,7 +84,7 @@ class AuthenticatedSessionController extends Controller
 
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
-            config('fortify.case_sensitive_usernames') ? null : CanonicalizeUsername::class,
+            config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,
             Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
             AttemptToAuthenticate::class,
             PrepareAuthenticatedSession::class,

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -4,8 +4,12 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+use Laravel\Fortify\Fortify;
+
+use function config;
 
 class ProfileInformationController extends Controller
 {
@@ -19,6 +23,12 @@ class ProfileInformationController extends Controller
     public function update(Request $request,
                            UpdatesUserProfileInformation $updater)
     {
+        if (! config('fortify.case_sensitive_usernames')) {
+            $request->merge([
+                Fortify::username() => Str::lower($request->{Fortify::username()}),
+            ]);
+        }
+
         $updater->update($request->user(), $request->all());
 
         return app(ProfileInformationUpdatedResponse::class);

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -21,7 +21,7 @@ class ProfileInformationController extends Controller
     public function update(Request $request,
                            UpdatesUserProfileInformation $updater)
     {
-        if (! config('fortify.case_sensitive_usernames')) {
+        if (config('fortify.lowercase_usernames')) {
             $request->merge([
                 Fortify::username() => Str::lower($request->{Fortify::username()}),
             ]);

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -9,8 +9,6 @@ use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Laravel\Fortify\Fortify;
 
-use function config;
-
 class ProfileInformationController extends Controller
 {
     /**

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -12,8 +12,6 @@ use Laravel\Fortify\Contracts\RegisterResponse;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
 use Laravel\Fortify\Fortify;
 
-use function config;
-
 class RegisteredUserController extends Controller
 {
     /**

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -6,9 +6,13 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\RegisterResponse;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
+use Laravel\Fortify\Fortify;
+
+use function config;
 
 class RegisteredUserController extends Controller
 {
@@ -51,6 +55,12 @@ class RegisteredUserController extends Controller
     public function store(Request $request,
                           CreatesNewUsers $creator): RegisterResponse
     {
+        if (! config('fortify.case_sensitive_usernames')) {
+            $request->merge([
+                Fortify::username() => Str::lower($request->{Fortify::username()}),
+            ]);
+        }
+
         event(new Registered($user = $creator->create($request->all())));
 
         $this->guard->login($user);

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -53,7 +53,7 @@ class RegisteredUserController extends Controller
     public function store(Request $request,
                           CreatesNewUsers $creator): RegisterResponse
     {
-        if (! config('fortify.case_sensitive_usernames')) {
+        if (config('fortify.lowercase_usernames')) {
             $request->merge([
                 Fortify::username() => Str::lower($request->{Fortify::username()}),
             ]);

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -52,18 +52,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Case Sensitive Usernames
+    | Lowercase Usernames
     |--------------------------------------------------------------------------
     |
-    | This value defines whether usernames should be considered as
-    | case-sensitive. If true, usernames will be written to and checked against
-    | the database as is. Otherwise, all usernames will be lower-cased.
-    |
-    | You should set this to true if you use the email field for usernames.
+    | This value defines whether usernames should be lowercased before saving
+    | them in the database, as some database system string fields are case
+    | sensitive. You may disable this for your application if necessary.
     |
     */
 
-    'case_sensitive_usernames' => true,
+    'lowercase_usernames' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -52,6 +52,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Case Sensitive Usernames
+    |--------------------------------------------------------------------------
+    |
+    | This value defines whether usernames should be considered as
+    | case-sensitive. If true, usernames will be written to and checked against
+    | the database as is. Otherwise, all usernames will be lower-cased.
+    |
+    | You should set this to true if you use the email field for usernames.
+    |
+    */
+
+    'case_sensitive_usernames' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Home Path
     |--------------------------------------------------------------------------
     |

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -428,6 +428,26 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $this->assertNull(Auth::getUser());
     }
 
+    public function test_case_insensitive_usernames_can_be_used()
+    {
+        app('config')->set('fortify.case_sensitive_usernames', false);
+
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+
+        TestAuthenticationSessionUser::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'TAYLOR@LARAVEL.COM',
+            'password' => 'secret',
+        ]);
+
+        $response->assertRedirect('/home');
+    }
+
     protected function getPackageProviders($app)
     {
         return [FortifyServiceProvider::class];

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -430,7 +430,7 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
     public function test_case_insensitive_usernames_can_be_used()
     {
-        app('config')->set('fortify.case_sensitive_usernames', false);
+        app('config')->set('fortify.lowercase_usernames', true);
 
         $this->loadLaravelMigrations(['--database' => 'testbench']);
 

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Mockery;
 
+use function app;
+
 class ProfileInformationControllerTest extends OrchestraTestCase
 {
     public function test_contact_information_can_be_updated()
@@ -19,6 +21,28 @@ class ProfileInformationControllerTest extends OrchestraTestCase
         $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/profile-information', [
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_email_address_will_be_updated_case_insensitive()
+    {
+        app('config')->set('fortify.case_sensitive_usernames', false);
+
+        $user = Mockery::mock(Authenticatable::class);
+
+        $this->mock(UpdatesUserProfileInformation::class)
+                    ->shouldReceive('update')
+                    ->with($user, [
+                        'name' => 'Taylor Otwell',
+                        'email' => 'taylor@laravel.com',
+                    ])
+                    ->once();
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/profile-information', [
+            'name' => 'Taylor Otwell',
+            'email' => 'TAYLOR@LARAVEL.COM',
         ]);
 
         $response->assertStatus(200);

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -6,8 +6,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Mockery;
 
-use function app;
-
 class ProfileInformationControllerTest extends OrchestraTestCase
 {
     public function test_contact_information_can_be_updated()

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -26,7 +26,7 @@ class ProfileInformationControllerTest extends OrchestraTestCase
 
     public function test_email_address_will_be_updated_case_insensitive()
     {
-        app('config')->set('fortify.case_sensitive_usernames', false);
+        app('config')->set('fortify.lowercase_usernames', true);
 
         $user = Mockery::mock(Authenticatable::class);
 

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -8,8 +8,6 @@ use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
 use Mockery;
 
-use function app;
-
 class RegisteredUserControllerTest extends OrchestraTestCase
 {
     public function test_the_register_view_is_returned()

--- a/tests/RegisteredUserControllerTest.php
+++ b/tests/RegisteredUserControllerTest.php
@@ -55,7 +55,7 @@ class RegisteredUserControllerTest extends OrchestraTestCase
 
     public function test_usernames_will_be_stored_case_insensitive()
     {
-        app('config')->set('fortify.case_sensitive_usernames', false);
+        app('config')->set('fortify.lowercase_usernames', true);
 
         $this->mock(CreatesNewUsers::class)
                     ->shouldReceive('create')


### PR DESCRIPTION
**Why**  
Using Postgres (and possibly other DBMS), comparisons are case-sensitive as opposed to MySQL.  
This causes issues where users would enter e.g. _**T**aylor<span>@</span>laravel.com_ on logging in but registered with _**t**aylor<span>@</span>laravel.com_, and receive a bad credentials error. This bites _every single installation of Fortify using Postgres_.

By storing the usernames in lowercase, and converting them before passing it to user-defined authentication logic, this problem just disappears.

**Backwards compatibility**  
I took care to not break BC anywhere:
 - The option defaults to `true` for now, meaning usernames are case-sensitive by default. That way, nothing breaks for existing applications, including those with custom workarounds. It should probably be set to `false` in the next major revision.
 - The case change happens before the input is passed to user-defined actions (e.g. `CreateNewUser`), so no changes to existing implementations are required.
 - The new `CanonicalizeUsername` action can just be dropped in existing users' pipelines, if desired.