### PR TITLE
Update logout to invalidate and regenerate session only if session is present

### DIFF
--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -99,9 +99,10 @@ class AuthenticatedSessionController extends Controller
     {
         $this->guard->logout();
 
-        $request->session()->invalidate();
-
-        $request->session()->regenerateToken();
+        if ($request->hasSession()) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
 
         return app(LogoutResponse::class);
     }


### PR DESCRIPTION
Added check in logout to invalidate and regenerate session only if request has session. This will allow logout to work when 'api' middleware is used with fortify.
