### PR TITLE
fix: TwoFactorDisabledResponse and TwoFactorEnabledResponse should implement their respective interfaces

### DIFF
--- a/src/Http/Responses/TwoFactorDisabledResponse.php
+++ b/src/Http/Responses/TwoFactorDisabledResponse.php
@@ -3,10 +3,10 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorDisabledResponse as TwoFactorDisabledResponseContract;
 use Laravel\Fortify\Fortify;
 
-class TwoFactorDisabledResponse implements TwoFactorLoginResponseContract
+class TwoFactorDisabledResponse implements TwoFactorDisabledResponseContract
 {
     /**
      * Create an HTTP response that represents the object.

--- a/src/Http/Responses/TwoFactorEnabledResponse.php
+++ b/src/Http/Responses/TwoFactorEnabledResponse.php
@@ -3,10 +3,10 @@
 namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
-use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorEnabledResponse as TwoFactorEnabledResponseContract;
 use Laravel\Fortify\Fortify;
 
-class TwoFactorEnabledResponse implements TwoFactorLoginResponseContract
+class TwoFactorEnabledResponse implements TwoFactorEnabledResponseContract
 {
     /**
      * Create an HTTP response that represents the object.


### PR DESCRIPTION
- This correction addresses the incorrect implementation of interfaces by TwoFactorDisabledResponse and TwoFactorEnabledResponse. Both classes currently implement the TwoFactorLoginResponse interface, but this fix introduces the appropriate implementations for their respective interfaces.
