### PR TITLE
Add throttle middleware in reset password routes (POST)

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -34,6 +34,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     $limiter = config('fortify.limiters.login');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
+    $resetPasswordLimiter = config('fortify.limiters.reset-password', '6,1');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
@@ -57,11 +58,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::post(RoutePath::for('password.email', '/forgot-password'), [PasswordResetLinkController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
+            ->middleware(['guest:'.config('fortify.guard'), 'throttle:'.$resetPasswordLimiter])
             ->name('password.email');
 
         Route::post(RoutePath::for('password.update', '/reset-password'), [NewPasswordController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
+            ->middleware(['guest:'.config('fortify.guard'), 'throttle:'.$resetPasswordLimiter])
             ->name('password.update');
     }
 


### PR DESCRIPTION
Currently, in order for us to implement a security throttle on the `password reset` submission routes, we need to rewrite the routes in the routes/web.php file.

This PR aims to provide developers with the opportunity to configure a password reset throttle simply by creating it in the `FortifyServiceProvider` and adding this limiter in `config/fortify.php`.

Example:

`config/fortify.php`

<img width="405" alt="Captura de Tela 2023-09-29 às 14 38 28" src="https://github.com/laravel/fortify/assets/16225726/ddde458e-da97-4f38-afb4-a741d4ea692c">

`FortifyServiceProvider`

<img width="650" alt="Captura de Tela 2023-09-29 às 14 39 08" src="https://github.com/laravel/fortify/assets/16225726/8b58de02-7366-419d-819a-18a21625e829">



