### PR TITLE
Allow specifying a prefix for route names

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -13,6 +13,7 @@ return [
     'home' => '/home',
     'prefix' => '',
     'domain' => null,
+    'name_prefix' => null,
     'lowercase_usernames' => false,
     'limiters' => [
         'login' => null,

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -21,150 +21,148 @@ use Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 use Laravel\Fortify\RoutePath;
 
-Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
-    $enableViews = config('fortify.views', true);
+$enableViews = config('fortify.views', true);
 
-    // Authentication...
+// Authentication...
+if ($enableViews) {
+    Route::get(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'create'])
+        ->middleware(['guest:'.config('fortify.guard')])
+        ->name('login');
+}
+
+$limiter = config('fortify.limiters.login');
+$twoFactorLimiter = config('fortify.limiters.two-factor');
+$verificationLimiter = config('fortify.limiters.verification', '6,1');
+
+Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
+    ->middleware(array_filter([
+        'guest:'.config('fortify.guard'),
+        $limiter ? 'throttle:'.$limiter : null,
+    ]));
+
+Route::post(RoutePath::for('logout', '/logout'), [AuthenticatedSessionController::class, 'destroy'])
+    ->name('logout');
+
+// Password Reset...
+if (Features::enabled(Features::resetPasswords())) {
     if ($enableViews) {
-        Route::get(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'create'])
+        Route::get(RoutePath::for('password.request', '/forgot-password'), [PasswordResetLinkController::class, 'create'])
             ->middleware(['guest:'.config('fortify.guard')])
-            ->name('login');
+            ->name('password.request');
+
+        Route::get(RoutePath::for('password.reset', '/reset-password/{token}'), [NewPasswordController::class, 'create'])
+            ->middleware(['guest:'.config('fortify.guard')])
+            ->name('password.reset');
     }
 
-    $limiter = config('fortify.limiters.login');
-    $twoFactorLimiter = config('fortify.limiters.two-factor');
-    $verificationLimiter = config('fortify.limiters.verification', '6,1');
+    Route::post(RoutePath::for('password.email', '/forgot-password'), [PasswordResetLinkController::class, 'store'])
+        ->middleware(['guest:'.config('fortify.guard')])
+        ->name('password.email');
 
-    Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
+    Route::post(RoutePath::for('password.update', '/reset-password'), [NewPasswordController::class, 'store'])
+        ->middleware(['guest:'.config('fortify.guard')])
+        ->name('password.update');
+}
+
+// Registration...
+if (Features::enabled(Features::registration())) {
+    if ($enableViews) {
+        Route::get(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'create'])
+            ->middleware(['guest:'.config('fortify.guard')])
+            ->name('register');
+    }
+
+    Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
+        ->middleware(['guest:'.config('fortify.guard')]);
+}
+
+// Email Verification...
+if (Features::enabled(Features::emailVerification())) {
+    if ($enableViews) {
+        Route::get(RoutePath::for('verification.notice', '/email/verify'), [EmailVerificationPromptController::class, '__invoke'])
+            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+            ->name('verification.notice');
+    }
+
+    Route::get(RoutePath::for('verification.verify', '/email/verify/{id}/{hash}'), [VerifyEmailController::class, '__invoke'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'signed', 'throttle:'.$verificationLimiter])
+        ->name('verification.verify');
+
+    Route::post(RoutePath::for('verification.send', '/email/verification-notification'), [EmailVerificationNotificationController::class, 'store'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'throttle:'.$verificationLimiter])
+        ->name('verification.send');
+}
+
+// Profile Information...
+if (Features::enabled(Features::updateProfileInformation())) {
+    Route::put(RoutePath::for('user-profile-information.update', '/user/profile-information'), [ProfileInformationController::class, 'update'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+        ->name('user-profile-information.update');
+}
+
+// Passwords...
+if (Features::enabled(Features::updatePasswords())) {
+    Route::put(RoutePath::for('user-password.update', '/user/password'), [PasswordController::class, 'update'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+        ->name('user-password.update');
+}
+
+// Password Confirmation...
+if ($enableViews) {
+    Route::get(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'show'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
+}
+
+Route::get(RoutePath::for('password.confirmation', '/user/confirmed-password-status'), [ConfirmedPasswordStatusController::class, 'show'])
+    ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+    ->name('password.confirmation');
+
+Route::post(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'store'])
+    ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+    ->name('password.confirm');
+
+// Two Factor Authentication...
+if (Features::enabled(Features::twoFactorAuthentication())) {
+    if ($enableViews) {
+        Route::get(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'create'])
+            ->middleware(['guest:'.config('fortify.guard')])
+            ->name('two-factor.login');
+    }
+
+    Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
             'guest:'.config('fortify.guard'),
-            $limiter ? 'throttle:'.$limiter : null,
+            $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
         ]));
 
-    Route::post(RoutePath::for('logout', '/logout'), [AuthenticatedSessionController::class, 'destroy'])
-        ->name('logout');
+    $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
+        ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']
+        : [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
 
-    // Password Reset...
-    if (Features::enabled(Features::resetPasswords())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('password.request', '/forgot-password'), [PasswordResetLinkController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('password.request');
+    Route::post(RoutePath::for('two-factor.enable', '/user/two-factor-authentication'), [TwoFactorAuthenticationController::class, 'store'])
+        ->middleware($twoFactorMiddleware)
+        ->name('two-factor.enable');
 
-            Route::get(RoutePath::for('password.reset', '/reset-password/{token}'), [NewPasswordController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('password.reset');
-        }
+    Route::post(RoutePath::for('two-factor.confirm', '/user/confirmed-two-factor-authentication'), [ConfirmedTwoFactorAuthenticationController::class, 'store'])
+        ->middleware($twoFactorMiddleware)
+        ->name('two-factor.confirm');
 
-        Route::post(RoutePath::for('password.email', '/forgot-password'), [PasswordResetLinkController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('password.email');
+    Route::delete(RoutePath::for('two-factor.disable', '/user/two-factor-authentication'), [TwoFactorAuthenticationController::class, 'destroy'])
+        ->middleware($twoFactorMiddleware)
+        ->name('two-factor.disable');
 
-        Route::post(RoutePath::for('password.update', '/reset-password'), [NewPasswordController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('password.update');
-    }
+    Route::get(RoutePath::for('two-factor.qr-code', '/user/two-factor-qr-code'), [TwoFactorQrCodeController::class, 'show'])
+        ->middleware($twoFactorMiddleware)
+        ->name('two-factor.qr-code');
 
-    // Registration...
-    if (Features::enabled(Features::registration())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('register');
-        }
+    Route::get(RoutePath::for('two-factor.secret-key', '/user/two-factor-secret-key'), [TwoFactorSecretKeyController::class, 'show'])
+        ->middleware($twoFactorMiddleware)
+        ->name('two-factor.secret-key');
 
-        Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')]);
-    }
+    Route::get(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'index'])
+        ->middleware($twoFactorMiddleware)
+        ->name('two-factor.recovery-codes');
 
-    // Email Verification...
-    if (Features::enabled(Features::emailVerification())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('verification.notice', '/email/verify'), [EmailVerificationPromptController::class, '__invoke'])
-                ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-                ->name('verification.notice');
-        }
-
-        Route::get(RoutePath::for('verification.verify', '/email/verify/{id}/{hash}'), [VerifyEmailController::class, '__invoke'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'signed', 'throttle:'.$verificationLimiter])
-            ->name('verification.verify');
-
-        Route::post(RoutePath::for('verification.send', '/email/verification-notification'), [EmailVerificationNotificationController::class, 'store'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'throttle:'.$verificationLimiter])
-            ->name('verification.send');
-    }
-
-    // Profile Information...
-    if (Features::enabled(Features::updateProfileInformation())) {
-        Route::put(RoutePath::for('user-profile-information.update', '/user/profile-information'), [ProfileInformationController::class, 'update'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('user-profile-information.update');
-    }
-
-    // Passwords...
-    if (Features::enabled(Features::updatePasswords())) {
-        Route::put(RoutePath::for('user-password.update', '/user/password'), [PasswordController::class, 'update'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('user-password.update');
-    }
-
-    // Password Confirmation...
-    if ($enableViews) {
-        Route::get(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'show'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
-    }
-
-    Route::get(RoutePath::for('password.confirmation', '/user/confirmed-password-status'), [ConfirmedPasswordStatusController::class, 'show'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-        ->name('password.confirmation');
-
-    Route::post(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'store'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-        ->name('password.confirm');
-
-    // Two Factor Authentication...
-    if (Features::enabled(Features::twoFactorAuthentication())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('two-factor.login');
-        }
-
-        Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
-            ->middleware(array_filter([
-                'guest:'.config('fortify.guard'),
-                $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
-            ]));
-
-        $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
-            ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']
-            : [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
-
-        Route::post(RoutePath::for('two-factor.enable', '/user/two-factor-authentication'), [TwoFactorAuthenticationController::class, 'store'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.enable');
-
-        Route::post(RoutePath::for('two-factor.confirm', '/user/confirmed-two-factor-authentication'), [ConfirmedTwoFactorAuthenticationController::class, 'store'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.confirm');
-
-        Route::delete(RoutePath::for('two-factor.disable', '/user/two-factor-authentication'), [TwoFactorAuthenticationController::class, 'destroy'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.disable');
-
-        Route::get(RoutePath::for('two-factor.qr-code', '/user/two-factor-qr-code'), [TwoFactorQrCodeController::class, 'show'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.qr-code');
-
-        Route::get(RoutePath::for('two-factor.secret-key', '/user/two-factor-secret-key'), [TwoFactorSecretKeyController::class, 'show'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.secret-key');
-
-        Route::get(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'index'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.recovery-codes');
-
-        Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
-            ->middleware($twoFactorMiddleware);
-    }
-});
+    Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
+        ->middleware($twoFactorMiddleware);
+}

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -154,6 +154,7 @@ class FortifyServiceProvider extends ServiceProvider
                 'namespace' => 'Laravel\Fortify\Http\Controllers',
                 'domain' => config('fortify.domain', null),
                 'prefix' => config('fortify.prefix'),
+                'middleware' => config('fortify.middleware', ['web']),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -154,6 +154,7 @@ class FortifyServiceProvider extends ServiceProvider
                 'namespace' => 'Laravel\Fortify\Http\Controllers',
                 'domain' => config('fortify.domain', null),
                 'prefix' => config('fortify.prefix'),
+                'as' => config('fortify.name_prefix') ? config('fortify.name_prefix').'.' : null ,
                 'middleware' => config('fortify.middleware', ['web']),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -91,6 +91,8 @@ return [
 
     'domain' => null,
 
+    'name_prefix' => null,
+
     /*
     |--------------------------------------------------------------------------
     | Fortify Routes Middleware


### PR DESCRIPTION
The PR introduces a way of setting a prefix on the name of the routes. 

The reason of the PR is if you are building an admin panel and you want to use fortify, it makes sense all the route names to be 'admin.' such as 'admin.login', 'admin.logout'. Especially when you have a frontend where it has it's own Authentication and you need to separate the routes

A new option has been added the config file which by default it keeps the existing behaviour.