### PR TITLE
Use trans option in failed password confirmation response

### DIFF
--- a/src/Http/Responses/FailedPasswordConfirmationResponse.php
+++ b/src/Http/Responses/FailedPasswordConfirmationResponse.php
@@ -15,7 +15,7 @@ class FailedPasswordConfirmationResponse implements FailedPasswordConfirmationRe
      */
     public function toResponse($request)
     {
-        $message = __('The provided password was incorrect.');
+        $message = __('auth.password');
 
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([


### PR DESCRIPTION
Currently, when using Laravel's translation feature in the password confirmation process, if you enter an invalid password, the translation is not applied, and it remains as an English message, rather than in the locale defined in the config/app.php file.

`Message displayed:`

<img width="425" alt="Captura de Tela 2023-10-10 às 22 23 10" src="https://github.com/laravel/fortify/assets/16225726/e7ec8778-801c-4556-8abc-363ecab7374d">

`Locale applied:`

<img width="634" alt="Captura de Tela 2023-10-10 às 22 24 05" src="https://github.com/laravel/fortify/assets/16225726/ac63426e-163f-4bc1-8540-5e2c5f4ab9b1">
