### PR TITLE
Name all routes in Fortify

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -36,7 +36,8 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         ->middleware(array_filter([
             'guest:'.config('fortify.guard'),
             $limiter ? 'throttle:'.$limiter : null,
-        ]));
+        ]))
+        ->name('login.store');
 
     Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');
@@ -71,7 +72,8 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::post('/register', [RegisteredUserController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')]);
+            ->middleware(['guest:'.config('fortify.guard')])
+            ->name('login.store');
     }
 
     // Email Verification...
@@ -117,7 +119,8 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         ->name('password.confirmation');
 
     Route::post('/user/confirm-password', [ConfirmablePasswordController::class, 'store'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+        ->name('password.confirmation.store');
 
     // Two Factor Authentication...
     if (Features::enabled(Features::twoFactorAuthentication())) {
@@ -131,7 +134,8 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
                 $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
-            ]));
+            ]))
+            ->name('two-factor.login.store');
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']
@@ -154,6 +158,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             ->name('two-factor.recovery-codes');
 
         Route::post('/user/two-factor-recovery-codes', [RecoveryCodeController::class, 'store'])
-            ->middleware($twoFactorMiddleware);
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.recovery-code.store');
     }
 });


### PR DESCRIPTION
This Pull Request proposed added names to all Fortify routes such that they can be consistently used by name with Ziggy in a frontend when Fortify's enableViews is set to false.

It uses new names for the unnamed routes such that there is no breaking change and no competition for eg `login`. Rather than assigning the name `login` to the create action when `enableViews` is true and to the store action when `enableViews` is false it seems clearer to just use two names, `login` and `login.store`.

This suffix `.store` is used consistently throughout for the new names because they're all store actions.

#498 provides more explanation. 