### PR TITLE
Update Fortify Password Validation Rule

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fortify Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the Fortify validator classes. Feel free to tweak each of these messages
+    | here.
+    |
+    */
+    'password' => [
+        'length' => 'The :attribute must be at least :length characters.',
+        'numeric' => 'The :attribute must contain at least one number.',
+        'special_character' => 'The :attribute must contain at least one special character.',
+        'uppercase' => 'The :attribute must contain at least one uppercase character.'
+    ]
+
+];

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -17,6 +17,6 @@ return [
         'numeric' => 'The :attribute must contain at least one number.',
         'special_character' => 'The :attribute must contain at least one special character.',
         'uppercase' => 'The :attribute must contain at least one uppercase character.'
-    ]
+    ],
 
 ];

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -113,6 +113,7 @@ class FortifyServiceProvider extends ServiceProvider
     {
         $this->configurePublishing();
         $this->configureRoutes();
+        $this->configureTranslations();
     }
 
     /**
@@ -139,6 +140,10 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
+
+            $this->publishes([
+                __DIR__.'/../lang' => lang_path('vendor/fortify'),
+            ], 'fortify-translations');
         }
     }
 
@@ -158,5 +163,15 @@ class FortifyServiceProvider extends ServiceProvider
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });
         }
+    }
+
+    /**
+     * Configure the translations offered by the package.
+     *
+     * @return void
+     */
+    protected function configureTranslations()
+    {
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'fortify');
     }
 }

--- a/src/Rules/HasNumeric.php
+++ b/src/Rules/HasNumeric.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class HasNumeric implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! preg_match('/[0-9]/', $value)) {
+            $fail(__('fortify::validation.password.numeric'));
+        }
+    }
+}

--- a/src/Rules/HasSpecialCharacter.php
+++ b/src/Rules/HasSpecialCharacter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class HasSpecialCharacter implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! preg_match('/[\W_]/', $value)) {
+            $fail(__('fortify::validation.password.special_character'));
+        }
+    }
+}

--- a/src/Rules/HasUppercase.php
+++ b/src/Rules/HasUppercase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class HasUppercase implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! preg_match('/[A-Z]/', $value)) {
+            $fail(__('fortify::validation.password.uppercase'));
+        }
+    }
+}

--- a/src/Rules/Length.php
+++ b/src/Rules/Length.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class Length implements ValidationRule
+{
+    /**
+     * The length required.
+     *
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * Length validation rule constructor.
+     *
+     * @param  int  $length
+     */
+    public function __construct(int $length)
+    {
+        $this->length = $length;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (mb_strlen($value) < $this->length) {
+            $fail(__('fortify::validation.password.length', ['length' => $this->length]));
+        }
+    }
+}

--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -2,138 +2,26 @@
 
 namespace Laravel\Fortify\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
-use Illuminate\Support\Str;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class Password implements Rule
+class Password implements ValidationRule
 {
     /**
-     * The minimum length of the password.
+     * The validation rules to apply.
      *
-     * @var int
+     * @var \Illuminate\Contracts\Validation\ValidationRule[]
      */
-    protected $length = 8;
+    protected $rules = [];
 
     /**
-     * Indicates if the password must contain one uppercase character.
+     * Initialize the validation rule and set the default password length.
      *
-     * @var bool
+     * @param  int  $length
      */
-    protected $requireUppercase = false;
-
-    /**
-     * Indicates if the password must contain one numeric digit.
-     *
-     * @var bool
-     */
-    protected $requireNumeric = false;
-
-    /**
-     * Indicates if the password must contain one special character.
-     *
-     * @var bool
-     */
-    protected $requireSpecialCharacter = false;
-
-    /**
-     * The message that should be used when validation fails.
-     *
-     * @var string
-     */
-    protected $message;
-
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
+    public function __construct(int $length = 8)
     {
-        $value = is_scalar($value) ? (string) $value : '';
-
-        if ($this->requireUppercase && Str::lower($value) === $value) {
-            return false;
-        }
-
-        if ($this->requireNumeric && ! preg_match('/[0-9]/', $value)) {
-            return false;
-        }
-
-        if ($this->requireSpecialCharacter && ! preg_match('/[\W_]/', $value)) {
-            return false;
-        }
-
-        return Str::length($value) >= $this->length;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        if ($this->message) {
-            return $this->message;
-        }
-
-        switch (true) {
-            case $this->requireUppercase
-            && ! $this->requireNumeric
-            && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character.', [
-                    'length' => $this->length,
-                ]);
-
-            case $this->requireNumeric
-            && ! $this->requireUppercase
-            && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one number.', [
-                    'length' => $this->length,
-                ]);
-
-            case $this->requireSpecialCharacter
-            && ! $this->requireUppercase
-            && ! $this->requireNumeric:
-                return __('The :attribute must be at least :length characters and contain at least one special character.', [
-                    'length' => $this->length,
-                ]);
-
-            case $this->requireUppercase
-            && $this->requireNumeric
-            && ! $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character and one number.', [
-                    'length' => $this->length,
-                ]);
-
-            case $this->requireUppercase
-            && $this->requireSpecialCharacter
-            && ! $this->requireNumeric:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character and one special character.', [
-                    'length' => $this->length,
-                ]);
-
-            case $this->requireUppercase
-            && $this->requireNumeric
-            && $this->requireSpecialCharacter:
-                return __('The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.', [
-                    'length' => $this->length,
-                ]);
-
-            case $this->requireNumeric
-            && $this->requireSpecialCharacter
-            && ! $this->requireUppercase:
-                return __('The :attribute must be at least :length characters and contain at least one special character and one number.', [
-                    'length' => $this->length,
-                ]);
-
-            default:
-                return __('The :attribute must be at least :length characters.', [
-                    'length' => $this->length,
-                ]);
-        }
+        $this->length($length);
     }
 
     /**
@@ -142,35 +30,19 @@ class Password implements Rule
      * @param  int  $length
      * @return $this
      */
-    public function length(int $length)
+    public function length(int $length): self
     {
-        $this->length = $length;
-
-        return $this;
+        return $this->upsertRule(new Length($length));
     }
 
     /**
-     * Indicate that at least one uppercase character is required.
+     * Indicate that at least one numeric character is required.
      *
      * @return $this
      */
-    public function requireUppercase()
+    public function requireNumeric(): self
     {
-        $this->requireUppercase = true;
-
-        return $this;
-    }
-
-    /**
-     * Indicate that at least one numeric digit is required.
-     *
-     * @return $this
-     */
-    public function requireNumeric()
-    {
-        $this->requireNumeric = true;
-
-        return $this;
+        return $this->upsertRule(new HasNumeric());
     }
 
     /**
@@ -178,22 +50,45 @@ class Password implements Rule
      *
      * @return $this
      */
-    public function requireSpecialCharacter()
+    public function requireSpecialCharacter(): self
     {
-        $this->requireSpecialCharacter = true;
-
-        return $this;
+        return $this->upsertRule(new HasSpecialCharacter());
     }
 
     /**
-     * Set the message that should be used when the rule fails.
+     * Indicate that at least one uppercase character is required.
      *
-     * @param  string  $message
      * @return $this
      */
-    public function withMessage(string $message)
+    public function requireUppercase(): self
     {
-        $this->message = $message;
+        return $this->upsertRule(new HasUppercase());
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        foreach ($this->rules as $rule) {
+            $rule->validate($attribute, $value, $fail);
+        }
+    }
+
+    /**
+     * Update or insert a rule in the validation rules to apply.
+     *
+     * @param  \Illuminate\Contracts\Validation\ValidationRule  $rule
+     * @return $this
+     */
+    private function upsertRule(ValidationRule $rule): self
+    {
+        $this->rules[$rule::class] = $rule;
 
         return $this;
     }

--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -88,7 +88,9 @@ class Password implements ValidationRule
      */
     private function upsertRule(ValidationRule $rule): self
     {
-        $this->rules[$rule::class] = $rule;
+        $key = get_class($rule);
+
+        $this->rules[$key] = $rule;
 
         return $this;
     }

--- a/tests/PasswordRuleTest.php
+++ b/tests/PasswordRuleTest.php
@@ -2,69 +2,184 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Validation\Validator;
 use Laravel\Fortify\Rules\Password;
 
 class PasswordRuleTest extends OrchestraTestCase
 {
-    public function test_password_rule()
+    /**
+     * The Password validation rule instance.
+     *
+     * @var \Laravel\Fortify\Rules\Password
+     */
+    protected $rule;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
     {
-        $rule = new Password;
+        parent::setUp();
 
-        $this->assertTrue($rule->passes('password', 'password'));
-        $this->assertTrue($rule->passes('password', 234234234));
-        $this->assertFalse($rule->passes('password', ['foo' => 'bar']));
-        $this->assertFalse($rule->passes('password', 'secret'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));
-
-        $rule->length(10);
-
-        $this->assertFalse($rule->passes('password', 'password'));
-        $this->assertTrue($rule->passes('password', 'password11'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 10 characters'));
-
-        $rule->length(8)->requireUppercase();
-
-        $this->assertFalse($rule->passes('password', 'password'));
-        $this->assertTrue($rule->passes('password', 'Password'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character'));
-
-        $rule->length(8)->requireNumeric();
-
-        $this->assertFalse($rule->passes('password', 'Password'));
-        $this->assertFalse($rule->passes('password', 'password1'));
-        $this->assertTrue($rule->passes('password', 'Password1'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character and one number'));
+        $this->rule = new Password();
     }
 
-    public function test_password_rule_can_require_special_characters()
+    /**
+     * Data provider containing valid numeric passwords.
+     *
+     * @return array[]
+     */
+    public function provideNumericPasswords(): array
     {
-        $rule = new Password;
-
-        $rule->length(8)->requireSpecialCharacter();
-
-        $this->assertTrue($rule->passes('password', 'password!'));
-        $this->assertFalse($rule->passes('password', 'password'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));
-        $this->assertTrue(Str::contains($rule->message(), 'special character'));
+        return [
+            ['p4ssw0rd'],
+            [1234567890],
+        ];
     }
 
-    public function test_password_rule_can_require_numeric_and_special_characters()
+    /**
+     * Data provider containing valid passwords with special characters.
+     *
+     * @return array[]
+     */
+    public function provideSpecialCharacterPasswords(): array
     {
-        $rule = new Password;
+        return [
+            ['pa$$word'],
+            ['p+sw-ord'],
+        ];
+    }
 
-        $rule->length(10)->requireNumeric()->requireSpecialCharacter();
+    /**
+     * Data provider containing valid uppercase passwords.
+     *
+     * @return array[]
+     */
+    public function provideUppercasePasswords(): array
+    {
+        return [
+            ['Password'],
+            ['passWord'],
+        ];
+    }
 
-        $this->assertTrue($rule->passes('password', 'password5%'));
-        $this->assertFalse($rule->passes('password', 'my-password'));
+    /**
+     * Create a new Validator instance using the "Password" validation rule
+     * and a given password string.
+     *
+     * @param  string  $password
+     * @return \Illuminate\Validation\Validator
+     */
+    public function validator(string $password): Validator
+    {
+        return ValidatorFacade::make(['password' => $password], ['password' => $this->rule]);
+    }
 
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 10 characters'));
-        $this->assertTrue(Str::contains($rule->message(), 'contain at least one special character'));
-        $this->assertTrue(Str::contains($rule->message(), 'and one number'));
+    /**
+     * Test if the "Password" rule can require numeric characters.
+     *
+     * @dataProvider provideNumericPasswords
+     * @return void
+     */
+    public function test_password_rule_can_require_numeric_characters($password)
+    {
+        $this->rule->requireNumeric();
+
+        $this->assertTrue($this->validator($password)->passes());
+    }
+
+    /**
+     * Test if the "Password" rule can require special characters.
+     *
+     * @dataProvider provideSpecialCharacterPasswords
+     * @return void
+     */
+    public function test_password_rule_can_require_special_characters($password)
+    {
+        $this->rule->requireSpecialCharacter();
+
+        $this->assertTrue($this->validator($password)->passes());
+    }
+
+    /**
+     * Test if the "Password" rule can require numeric characters.
+     *
+     * @dataProvider provideUppercasePasswords
+     * @return void
+     */
+    public function test_password_rule_can_require_uppercase_characters($password)
+    {
+        $this->rule->requireUppercase();
+
+        $this->assertTrue($this->validator($password)->passes());
+    }
+
+    /**
+     * Test if the "Password" rule can require a minimum length.
+     *
+     * @return void
+     */
+    public function test_password_rule_can_require_minimum_length()
+    {
+        $this->rule->length(6);
+        $this->assertTrue($this->validator('admin')->fails());
+
+        $this->rule->length(8);
+        $this->assertTrue($this->validator(1234567)->fails());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when
+     * it requires a numeric character.
+     *
+     * @return void
+     */
+    public function test_numeric_rule_can_return_error_message()
+    {
+        $this->rule->requireNumeric();
+
+        $this->assertStringContainsString('one number', $this->validator('password')->errors()->first());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when it
+     * requires a special character.
+     *
+     * @return void
+     */
+    public function test_special_character_rule_can_return_error_message()
+    {
+        $this->rule->requireSpecialCharacter();
+
+        $this->assertStringContainsString('one special character', $this->validator('password')->errors()->first());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when it
+     * requires an uppercase character.
+     *
+     * @return void
+     */
+    public function test_uppercase_rule_can_return_error_message()
+    {
+        $this->rule->requireUppercase();
+
+        $this->assertStringContainsString('one uppercase character', $this->validator('password')->errors()->first());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when it
+     * requires a minimum length.
+     *
+     * @return void
+     */
+    public function test_length_rule_can_return_error_message()
+    {
+        $this->rule->length(10);
+
+        $this->assertStringContainsString('must be at least 10 characters', $this->validator('password')->errors()->first());
     }
 }


### PR DESCRIPTION
The intention of this pull request is to refactor the Fortify "Password" validation class to:

1. Replace the obsolete [```Illuminate\Contracts\Validation\Rule```](https://github.com/laravel/fortify/blob/6d9e142667606a2c75728a660913d562486ea002/src/Rules/Password.php#L8C30-L8C30) interface and use the new ```Illuminate\Contracts\Validation\ValidationRule``` interface. 
2. Splits the validation logic for each password requirement into separate validation rule classes.
3. Provide the user with a mechanism to customize error messages through the Laravel translation system. Translations can be published using the command: ```php artisan vendor:publish --tag=fortify-translations```
