### PR TITLE
Update Fortify Password Validation Rule

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fortify Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the Fortify validator classes. Feel free to tweak each of these messages
+    | here.
+    |
+    */
+    'password' => [
+        'length' => 'The :attribute must be at least :length characters.',
+        'numeric' => 'The :attribute must contain at least one number.',
+        'special_character' => 'The :attribute must contain at least one special character.',
+        'uppercase' => 'The :attribute must contain at least one uppercase character.'
+    ],
+
+];

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -113,6 +113,7 @@ class FortifyServiceProvider extends ServiceProvider
     {
         $this->configurePublishing();
         $this->configureRoutes();
+        $this->configureTranslations();
     }
 
     /**
@@ -139,6 +140,10 @@ class FortifyServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
+
+            $this->publishes([
+                __DIR__.'/../lang' => lang_path('vendor/fortify'),
+            ], 'fortify-translations');
         }
     }
 
@@ -158,5 +163,16 @@ class FortifyServiceProvider extends ServiceProvider
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });
         }
+    }
+
+
+    /**
+     * Configure the translations offered by the package.
+     *
+     * @return void
+     */
+    protected function configureTranslations()
+    {
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'fortify');
     }
 }

--- a/src/Rules/HasNumeric.php
+++ b/src/Rules/HasNumeric.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class HasNumeric implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param $attribute
+     * @param $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return preg_match('/[0-9]/', $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array|string
+     */
+    public function message()
+    {
+        return __('fortify::validation.password.numeric');
+    }
+}

--- a/src/Rules/HasSpecialCharacter.php
+++ b/src/Rules/HasSpecialCharacter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class HasSpecialCharacter implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param $attribute
+     * @param $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return preg_match('/[\W_]/', $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array|string
+     */
+    public function message()
+    {
+        return __('fortify::validation.password.special_character');
+    }
+}

--- a/src/Rules/HasUppercase.php
+++ b/src/Rules/HasUppercase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class HasUppercase implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param $attribute
+     * @param $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return preg_match('/[A-Z]/', $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array|string
+     */
+    public function message()
+    {
+        return __('fortify::validation.password.uppercase');
+    }
+}

--- a/src/Rules/Length.php
+++ b/src/Rules/Length.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Fortify\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class Length implements Rule
+{
+    /**
+     * The length required.
+     *
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * Length validation rule constructor.
+     *
+     * @param  int  $length
+     */
+    public function __construct(int $length)
+    {
+        $this->length = $length;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param $attribute
+     * @param $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return mb_strlen($value) >= $this->length;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array|string
+     */
+    public function message()
+    {
+        return __('fortify::validation.password.length', ['length' => $this->length]);
+    }
+}

--- a/tests/PasswordRuleTest.php
+++ b/tests/PasswordRuleTest.php
@@ -2,69 +2,184 @@
 
 namespace Laravel\Fortify\Tests;
 
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Validation\Validator;
 use Laravel\Fortify\Rules\Password;
 
 class PasswordRuleTest extends OrchestraTestCase
 {
-    public function test_password_rule()
+    /**
+     * The Password validation rule instance.
+     *
+     * @var \Laravel\Fortify\Rules\Password
+     */
+    protected $rule;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
     {
-        $rule = new Password;
+        parent::setUp();
 
-        $this->assertTrue($rule->passes('password', 'password'));
-        $this->assertTrue($rule->passes('password', 234234234));
-        $this->assertFalse($rule->passes('password', ['foo' => 'bar']));
-        $this->assertFalse($rule->passes('password', 'secret'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));
-
-        $rule->length(10);
-
-        $this->assertFalse($rule->passes('password', 'password'));
-        $this->assertTrue($rule->passes('password', 'password11'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 10 characters'));
-
-        $rule->length(8)->requireUppercase();
-
-        $this->assertFalse($rule->passes('password', 'password'));
-        $this->assertTrue($rule->passes('password', 'Password'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character'));
-
-        $rule->length(8)->requireNumeric();
-
-        $this->assertFalse($rule->passes('password', 'Password'));
-        $this->assertFalse($rule->passes('password', 'password1'));
-        $this->assertTrue($rule->passes('password', 'Password1'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'characters and contain at least one uppercase character and one number'));
+        $this->rule = new Password();
     }
 
-    public function test_password_rule_can_require_special_characters()
+    /**
+     * Data provider containing valid numeric passwords.
+     *
+     * @return array[]
+     */
+    public function provideNumericPasswords(): array
     {
-        $rule = new Password;
-
-        $rule->length(8)->requireSpecialCharacter();
-
-        $this->assertTrue($rule->passes('password', 'password!'));
-        $this->assertFalse($rule->passes('password', 'password'));
-
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 8 characters'));
-        $this->assertTrue(Str::contains($rule->message(), 'special character'));
+        return [
+            ['p4ssw0rd'],
+            [1234567890],
+        ];
     }
 
-    public function test_password_rule_can_require_numeric_and_special_characters()
+    /**
+     * Data provider containing valid passwords with special characters.
+     *
+     * @return array[]
+     */
+    public function provideSpecialCharacterPasswords(): array
     {
-        $rule = new Password;
+        return [
+            ['pa$$word'],
+            ['p+sw-ord'],
+        ];
+    }
 
-        $rule->length(10)->requireNumeric()->requireSpecialCharacter();
+    /**
+     * Data provider containing valid uppercase passwords.
+     *
+     * @return array[]
+     */
+    public function provideUppercasePasswords(): array
+    {
+        return [
+            ['Password'],
+            ['passWord'],
+        ];
+    }
 
-        $this->assertTrue($rule->passes('password', 'password5%'));
-        $this->assertFalse($rule->passes('password', 'my-password'));
+    /**
+     * Create a new Validator instance using the "Password" validation rule
+     * and a given password string.
+     *
+     * @param  string  $password
+     * @return \Illuminate\Validation\Validator
+     */
+    public function validator(string $password): Validator
+    {
+        return ValidatorFacade::make(['password' => $password], ['password' => $this->rule]);
+    }
 
-        $this->assertTrue(Str::contains($rule->message(), 'must be at least 10 characters'));
-        $this->assertTrue(Str::contains($rule->message(), 'contain at least one special character'));
-        $this->assertTrue(Str::contains($rule->message(), 'and one number'));
+    /**
+     * Test if the "Password" rule can require numeric characters.
+     *
+     * @dataProvider provideNumericPasswords
+     * @return void
+     */
+    public function test_password_rule_can_require_numeric_characters($password)
+    {
+        $this->rule->requireNumeric();
+
+        $this->assertTrue($this->validator($password)->passes());
+    }
+
+    /**
+     * Test if the "Password" rule can require special characters.
+     *
+     * @dataProvider provideSpecialCharacterPasswords
+     * @return void
+     */
+    public function test_password_rule_can_require_special_characters($password)
+    {
+        $this->rule->requireSpecialCharacter();
+
+        $this->assertTrue($this->validator($password)->passes());
+    }
+
+    /**
+     * Test if the "Password" rule can require numeric characters.
+     *
+     * @dataProvider provideUppercasePasswords
+     * @return void
+     */
+    public function test_password_rule_can_require_uppercase_characters($password)
+    {
+        $this->rule->requireUppercase();
+
+        $this->assertTrue($this->validator($password)->passes());
+    }
+
+    /**
+     * Test if the "Password" rule can require a minimum length.
+     *
+     * @return void
+     */
+    public function test_password_rule_can_require_minimum_length()
+    {
+        $this->rule->length(6);
+        $this->assertTrue($this->validator('admin')->fails());
+
+        $this->rule->length(8);
+        $this->assertTrue($this->validator(1234567)->fails());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when
+     * it requires a numeric character.
+     *
+     * @return void
+     */
+    public function test_numeric_rule_can_return_error_message()
+    {
+        $this->rule->requireNumeric();
+
+        $this->assertStringContainsString('one number', $this->validator('password')->errors()->first());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when it
+     * requires a special character.
+     *
+     * @return void
+     */
+    public function test_special_character_rule_can_return_error_message()
+    {
+        $this->rule->requireSpecialCharacter();
+
+        $this->assertStringContainsString('one special character', $this->validator('password')->errors()->first());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when it
+     * requires an uppercase character.
+     *
+     * @return void
+     */
+    public function test_uppercase_rule_can_return_error_message()
+    {
+        $this->rule->requireUppercase();
+
+        $this->assertStringContainsString('one uppercase character', $this->validator('password')->errors()->first());
+    }
+
+    /**
+     * Test if the "Password" rule can return an error message when it
+     * requires a minimum length.
+     *
+     * @return void
+     */
+    public function test_length_rule_can_return_error_message()
+    {
+        $this->rule->length(10);
+
+        $this->assertStringContainsString('must be at least 10 characters', $this->validator('password')->errors()->first());
     }
 }


### PR DESCRIPTION
The intention of this pull request is to refactor the Fortify "Password" validation class to:

1. Splits the validation logic for each password requirement into separate validation rule classes.
2. Provide the user with a mechanism to customize error messages through the Laravel translation system. Translations can be published using the command: ```php artisan vendor:publish --tag=fortify-translations```

This pull request is a similar version of pull request [#503](https://github.com/laravel/fortify/pull/503) but compatible with the 1.x branch of Fortify.