### PR TITLE
[develop] Adds L11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^8.16|^9.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request adds L11 support to fortify.

Also, drops:
- PHP 7.3, 7.4, 8.0.
- Laravel 8 and 9.