### PR TITLE
[develop] Uses `publishesMigrations`

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -136,7 +136,9 @@ class FortifyServiceProvider extends ServiceProvider
                 __DIR__.'/../stubs/UpdateUserPassword.php' => app_path('Actions/Fortify/UpdateUserPassword.php'),
             ], 'fortify-support');
 
-            $this->publishes([
+            $method = method_exists($this, 'publishesMigrations') ? 'publishesMigrations' : 'publishes';
+
+            $this->{$method}([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'fortify-migrations');
         }


### PR DESCRIPTION
This pull request makes the develop branch, the upcoming version version of Fortify that supports Laravel 11, to use `publishesMigrations` method.