### PR TITLE
Deprecate the password rule and use illuminate password rule

### DIFF
--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -5,6 +5,9 @@ namespace Laravel\Fortify\Rules;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
 
+/**
+ * @deprecated Use \Illuminate\Validation\Rules\Password instead.
+ */
 class Password implements Rule
 {
     /**

--- a/stubs/PasswordValidationRules.php
+++ b/stubs/PasswordValidationRules.php
@@ -2,7 +2,7 @@
 
 namespace App\Actions\Fortify;
 
-use Laravel\Fortify\Rules\Password;
+use Illuminate\Validation\Rules\Password;
 
 trait PasswordValidationRules
 {
@@ -13,6 +13,6 @@ trait PasswordValidationRules
      */
     protected function passwordRules(): array
     {
-        return ['required', 'string', new Password, 'confirmed'];
+        return ['required', 'string', Password::default(), 'confirmed'];
     }
 }


### PR DESCRIPTION
Created a new PR with the feedback of Dries onto https://github.com/laravel/fortify/pull/510

This will deprecate the Fortify password rule and use the `Illuminate\Validation\Rules\Password` rule.

The `Illuminate\Validation\Rules\Password` rule has more functionality than the Fortify rule. For example this rule has mixed case and compromised check available.