### PR TITLE
Don't overwrite an already two factor secret unless force = true

### DIFF
--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -31,17 +31,22 @@ class EnableTwoFactorAuthentication
      * Enable two factor authentication for the user.
      *
      * @param  mixed  $user
+     * @param  bool   Should we overwrite the currently set secret if one exists.
      * @return void
      */
-    public function __invoke($user)
+    public function __invoke($user, $force = false)
     {
-        $user->forceFill([
-            'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
-            'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
-                return RecoveryCode::generate();
-            })->all())),
-        ])->save();
 
-        TwoFactorAuthenticationEnabled::dispatch($user);
+        if (empty($user->two_factor_secret) || $force === true) {
+        
+            $user->forceFill([
+                'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
+                'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
+                    return RecoveryCode::generate();
+                })->all())),
+            ])->save();
+
+            TwoFactorAuthenticationEnabled::dispatch($user);
+        }
     }
 }

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -31,7 +31,7 @@ class EnableTwoFactorAuthentication
      * Enable two factor authentication for the user.
      *
      * @param  mixed  $user
-     * @param  bool   Should we overwrite the currently set secret if one exists.
+     * @param  bool $force
      * @return void
      */
     public function __invoke($user, $force = false)

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -36,9 +36,7 @@ class EnableTwoFactorAuthentication
      */
     public function __invoke($user, $force = false)
     {
-
         if (empty($user->two_factor_secret) || $force === true) {
-        
             $user->forceFill([
                 'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
                 'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -20,7 +20,7 @@ class TwoFactorAuthenticationController extends Controller
      */
     public function store(Request $request, EnableTwoFactorAuthentication $enable)
     {
-        $enable($request->user(), $request->input('force', false));
+        $enable($request->user(), $request->boolean('force', false));
 
         return app(TwoFactorEnabledResponse::class);
     }

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -20,7 +20,7 @@ class TwoFactorAuthenticationController extends Controller
      */
     public function store(Request $request, EnableTwoFactorAuthentication $enable)
     {
-        $enable($request->user());
+        $enable($request->user(), $request->input('force', false));
 
         return app(TwoFactorEnabledResponse::class);
     }

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -46,7 +46,6 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertNotNull($user->twoFactorQrCodeSvg());
     }
 
-
     #[ResetRefreshDatabaseState]
     public function test_calling_two_factor_authentication_endpoint_will_not_overwrite_without_force_parameter()
     {
@@ -110,7 +109,7 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
 
         $old_value = $user->two_factor_secret;
 
-          $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
+        $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
             '/user/two-factor-authentication',
             [
                 'force' => true,
@@ -120,7 +119,6 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $response->assertStatus(200);
 
         $user = $user->fresh();
-
 
         $this->assertNotNull($user->two_factor_secret);
         $this->assertNotNull($user->two_factor_recovery_codes);

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -46,6 +46,81 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertNotNull($user->twoFactorQrCodeSvg());
     }
 
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    #[ResetRefreshDatabaseState]
+    public function test_calling_two_factor_authentication_endpoint_will_not_overwrite_without_force_parameter()
+    {
+        Event::fake();
+
+        $user = TestTwoFactorAuthenticationUser::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->assertNotNull($user->two_factor_secret);
+        $this->assertNotNull($user->two_factor_recovery_codes);
+        $this->assertNull($user->two_factor_confirmed_at);
+
+        $old_value = $user->two_factor_secret;
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
+            '/user/two-factor-authentication'
+        );
+
+        $response->assertStatus(200);
+
+        Event::assertDispatched(TwoFactorAuthenticationEnabled::class);
+
+        $user = $user->fresh();
+
+        $this->assertNotNull($user->two_factor_secret);
+        $this->assertNotNull($user->two_factor_recovery_codes);
+        $this->assertEquals($old_value, $user->fresh()->two_factor_secret);
+        $this->assertNull($user->two_factor_confirmed_at);
+        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
+        $this->assertNotNull($user->twoFactorQrCodeSvg());
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    #[ResetRefreshDatabaseState]
+    public function test_calling_two_factor_authentication_endpoint_will_overwrite_with_force_parameter()
+    {
+        Event::fake();
+
+        $user = TestTwoFactorAuthenticationUser::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->assertNotNull($user->two_factor_secret);
+        $this->assertNotNull($user->two_factor_recovery_codes);
+        $this->assertNull($user->two_factor_confirmed_at);
+
+        $old_value = $user->two_factor_secret;
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
+            '/user/two-factor-authentication',
+            [
+                'force' => true,
+            ]
+        );
+
+        $response->assertStatus(200);
+
+        Event::assertDispatched(TwoFactorAuthenticationEnabled::class);
+
+        $user = $user->fresh();
+
+        $this->assertNotNull($user->two_factor_secret);
+        $this->assertNotNull($user->two_factor_recovery_codes);
+        $this->assertNotEquals($old_value, $user->fresh()->two_factor_secret);
+        $this->assertNull($user->two_factor_confirmed_at);
+        $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
+        $this->assertNotNull($user->twoFactorQrCodeSvg());
+    }
+
     public function test_two_factor_authentication_secret_key_can_be_retrieved()
     {
         Event::fake();


### PR DESCRIPTION
Add a `force` parameter that only overwrites existing two factor secret keys and recovery codes in the database if present when calling the enable two factor authentication action.

## Why

If the secret has already been set, the QR code may have already been shown to the end user, and this endpoint is erroneously called again - through a page refresh or some JS issue, the secret is overridden, rendering the code the end user just scanned useless without informing them that anything has changed.

## Mitigation

When calling the `/user/two-factor-authentication` endpoint, the code now checks to see if the `two_factor_secret` is not `null` and assumes that it shouldn't overwrite it to prevent situations like this.

To force it to overwrite, you can pass the `force` parameter - which will fill out the two factor columns with new values as it did previously.

The note here is to focus on **intent** - a piece of code should only overwrite this through the intent of the user (maybe clicking a button that refreshes the QR code before scanning it) or through some app-level action like resetting a user's twoFA status.
