### PR TITLE
Specify return type array type

### DIFF
--- a/stubs/PasswordValidationRules.php
+++ b/stubs/PasswordValidationRules.php
@@ -9,7 +9,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate passwords.
      *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>
      */
     protected function passwordRules(): array
     {


### PR DESCRIPTION
After running larastan with the max level I get the error `:passwordRules() return type has no value type specified in iterable type array.`. It's because the return type of the `passwordRules` method contains an array, and we don't specify the type. So by adding the type it solves the issue. 

Note: I'm not sure if it should be `array<mixed>` or `array<string>`.

Here the link to check the error:
https://phpstan.org/r/8eaf0f10-579e-49f9-96bf-6a1b55769231