### PR TITLE
fix authenticateUsing getting called twice

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -69,7 +69,7 @@ class AttemptToAuthenticate
      */
     protected function handleUsingCustomCallback($request, $next)
     {
-        $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
+        $user = $request['authUser'] ?? call_user_func(Fortify::$authenticateUsingCallback, $request);
 
         if (! $user) {
             $this->fireFailedEvent($request);

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -48,7 +48,7 @@ class RedirectIfTwoFactorAuthenticatable
      */
     public function handle($request, $next)
     {
-        $user = $this->validateCredentials($request);
+        $user = $request['authUser'] ?? $this->validateCredentials($request);
 
         if (Fortify::confirmsTwoFactorAuthentication()) {
             if (optional($user)->two_factor_secret &&

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -82,6 +82,8 @@ class AuthenticatedSessionController extends Controller
             ));
         }
 
+        $request['authUser'] = call_user_func(Fortify::$authenticateUsingCallback, $request);
+
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
             config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This is to fix the issue of `authenticateUsing` getting called twice.

Fixes: [Issue 530](https://github.com/laravel/fortify/issues/530) & [Issue 339](https://github.com/laravel/fortify/issues/339)
