### PR TITLE
Fix authenticateUsing called twice

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -69,7 +69,7 @@ class AttemptToAuthenticate
      */
     protected function handleUsingCustomCallback($request, $next)
     {
-        $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
+        $user = $request['authUser'] ?? call_user_func(Fortify::$authenticateUsingCallback, $request);
 
         if (! $user) {
             $this->fireFailedEvent($request);

--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -69,7 +69,7 @@ class AttemptToAuthenticate
      */
     protected function handleUsingCustomCallback($request, $next)
     {
-        $user = $request['authUser'] ?? call_user_func(Fortify::$authenticateUsingCallback, $request);
+        $user = $request->get('user') ?? call_user_func(Fortify::$authenticateUsingCallback, $request);
 
         if (! $user) {
             $this->fireFailedEvent($request);

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -48,7 +48,7 @@ class RedirectIfTwoFactorAuthenticatable
      */
     public function handle($request, $next)
     {
-        $user = $this->validateCredentials($request);
+        $user = $request['authUser'] ?? $this->validateCredentials($request);
 
         if (Fortify::confirmsTwoFactorAuthentication()) {
             if (optional($user)->two_factor_secret &&

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -39,9 +39,6 @@ class RedirectIfTwoFactorAuthenticatable
         $this->limiter = $limiter;
     }
 
-
-    public $authUser;
-
     /**
      * Handle the incoming request.
      *

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -39,6 +39,9 @@ class RedirectIfTwoFactorAuthenticatable
         $this->limiter = $limiter;
     }
 
+
+    public $authUser;
+
     /**
      * Handle the incoming request.
      *
@@ -48,7 +51,11 @@ class RedirectIfTwoFactorAuthenticatable
      */
     public function handle($request, $next)
     {
-        $user = $request['authUser'] ?? $this->validateCredentials($request);
+        $user = $this->validateCredentials($request);
+
+        if ($user) {
+            $request->request->set('user', $user);
+        }
 
         if (Fortify::confirmsTwoFactorAuthentication()) {
             if (optional($user)->two_factor_secret &&

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -82,6 +82,8 @@ class AuthenticatedSessionController extends Controller
             ));
         }
 
+        $request['authUser'] = call_user_func(Fortify::$authenticateUsingCallback, $request);
+
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
             config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -82,15 +82,6 @@ class AuthenticatedSessionController extends Controller
             ));
         }
 
-        $request['authUser'] = tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request)
-		{
-			if (!$user) {
-				$this->fireFailedEvent($request);
-
-				$this->throwFailedAuthenticationException($request);
-			}
-		});
-
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
             config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -84,6 +84,10 @@ class AuthenticatedSessionController extends Controller
 
         $request['authUser'] = call_user_func(Fortify::$authenticateUsingCallback, $request);
 
+        $request->set(["key"=>"value"]);
+
+        $request->request->add(['variable' => 'value']); //add request
+
         return (new Pipeline(app()))->send($request)->through(array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
             config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This is to fix the issue of `authenticateUsing` getting called twice.

Fixes: [Issue 530](https://github.com/laravel/fortify/issues/530) & [Issue 339](https://github.com/laravel/fortify/issues/339)
