### PR TITLE
Merge query parameter with others instead of suffixing URL (VerifyEmailResponse)

### DIFF
--- a/src/Http/Responses/VerifyEmailResponse.php
+++ b/src/Http/Responses/VerifyEmailResponse.php
@@ -18,6 +18,6 @@ class VerifyEmailResponse implements VerifyEmailResponseContract
     {
         return $request->wantsJson()
             ? new JsonResponse('', 204)
-            : redirect()->intended(Fortify::redirects('email-verification').'?verified=1');
+            : redirect()->intended(Fortify::redirects('email-verification'))->with(['verified' => 1]);
     }
 }


### PR DESCRIPTION
The current syntax (`redirect()->intended(Fortify::redirects('email-verification').'?verified=1')`) doesn't support multiple query parameters. E.g. if the 'email-verification' returns an URL with a `?tenant=foo` parameter, `?verified=1` just gets appended to that url (resulting into `?tenant=foo?verified=1`).

This PR uses the `with(['verified' => 1])` method call to merge the 'verified' query parameter with already existing ones, instead of suffixing the generated URL with `?verified=1`.