### PR TITLE
[1.x] Ensure logout route is authenticated

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -42,6 +42,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         ]));
 
     Route::post(RoutePath::for('logout', '/logout'), [AuthenticatedSessionController::class, 'destroy'])
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
         ->name('logout');
 
     // Password Reset...

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -423,11 +423,6 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
 
     public function test_must_be_authenticated_to_logout(): void
     {
-        $user = TestAuthenticationSessionUser::forceCreate([
-            'name' => 'Taylor Otwell',
-            'email' => 'taylor@laravel.com',
-            'password' => bcrypt('secret'),
-        ]);
         Event::fake([Logout::class]);
 
         $response = $this->post('/logout');

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -412,18 +412,13 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
         ]);
-
-        $loggedOutUser = null;
-        Event::listen(function (Logout $event) use (&$loggedOutUser) {
-            $loggedOutUser = $event->user;
-        });
+        Event::fake([Logout::class]);
 
         $response = $this->actingAs($user)->post('/logout');
 
-        $this->assertNotNull($loggedOutUser);
-        $this->assertTrue($loggedOutUser->is($user));
         $response->assertRedirect();
         $this->assertGuest();
+        Event::assertDispatched(fn (Logout $logout) => $logout->user->is($user));
     }
 
     public function test_must_be_authenticated_to_logout(): void
@@ -433,16 +428,13 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
         ]);
-        $loggedOut = false;
-        Event::listen(function (Logout $event) use (&$loggedOut) {
-            $loggedOut = true;
-        });
+        Event::fake([Logout::class]);
 
         $response = $this->post('/logout');
 
-        $this->assertFalse($loggedOut);
         $response->assertRedirect();
         $this->assertGuest();
+        Event::assertNotDispatched(Logout::class);
     }
 
     protected function defineEnvironment($app)


### PR DESCRIPTION
It is currently possible to hit the `/logout` route as a guest. This means that the auth system "logs out" a `null` user.

This can occur in the real world when you:

1. Login to an app
2. Open the app in two tabs
3. Logout of one tab
4. Logout of the second tab

The framework will now logout a `null` user.

```php
Event::listen(fn (Logout $event) => assert($event->user === null));
```

I believe this is a good fix because:

1. Guests should not be able to visit the logout route. It is explicitly for authenticated users – just like the login route is explicitly for guests.
2. If you are listening for the logout event you are expecting a user.
3. The event is also typed (docblock) to require a user object.
4. Lastly, `laravel/breeze` does this, so it creates consistency for Jetstream and Fortify.

This issue was raised because 2 users have run into this in Pulse when using Jetstream (https://github.com/laravel/pulse/issues/364) and Laravel UI (https://github.com/laravel/pulse/issues/324). Although we will also handle this better in Pulse, I believe this is a good fix to include in Fortify.

- `laravel/ui` fix: https://github.com/laravel/ui/pull/269