### PR TITLE
Add rate limiter for password update

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -34,6 +34,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     $limiter = config('fortify.limiters.login');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
+    $passwordUpdateLimiter = config('fortify.limiters.password-update');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
@@ -105,7 +106,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     // Passwords...
     if (Features::enabled(Features::updatePasswords())) {
         Route::put(RoutePath::for('user-password.update', '/user/password'), [PasswordController::class, 'update'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+            ->middleware(array_filter([
+                config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'),
+                $passwordUpdateLimiter ? 'throttle:'.$passwordUpdateLimiter : null,
+            ]))
             ->name('user-password.update');
     }
 


### PR DESCRIPTION
# Overview

A minor improvement that allows customizing the rate limiting of the `user-password.update` route. It would benefit those who want to rate limit the password update route for some reason (I will use it on my project since I like to be as strict as possible with rate limiting). There is no specific security concern here for the specific route other than the fact that it's nice to allow controlling the rate limiting of routes.

> Note: Change is backwards compatible.

# Testing

Add the line:
```
'password-update' => '1,1'
```
on `limiters` section of `fortify.php` file. Then, hit the password update endpoint twice. You will get a "Too Many Attempts" response for the 2nd request.

> Note: Sorry I didn't add a test, I couldn't set the config inside the test for some reason. I tested it manually by doing the above and messing with the `test_passwords_can_be_updated` test.