### PR TITLE
Default Email Validation

### DIFF
--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -25,7 +25,7 @@ class LoginRequest extends FormRequest
     public function rules()
     {
         return [
-            Fortify::username() => 'required|string',
+            Fortify::username() => 'required|email:rfc',
             'password' => 'required|string',
         ];
     }


### PR DESCRIPTION
by default fortify uses the email as the username, but in the Request it uses a required|string, which is not a validation according to the username standard.