### PR TITLE
Remove repeated check that feature is enabled for 2fa confirmation 

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -298,8 +298,7 @@ class Fortify
      */
     public static function confirmsTwoFactorAuthentication()
     {
-        return Features::enabled(Features::twoFactorAuthentication()) &&
-               Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm');
+        return Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm');
     }
 
     /**


### PR DESCRIPTION
Minor refactoring

Removed repeated check if feature is enabled (`Feature::enabled()`) as it is present within `optionEnabled` [method](https://github.com/laravel/fortify/blob/1.x/src/Features.php#L25)
