### PR TITLE
Fixed issue with login throttle condition and conflict with Laravel middleware

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -31,14 +31,14 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             ->name('login');
     }
 
-    $limiter = config('fortify.limiters.login');
-    $twoFactorLimiter = config('fortify.limiters.two-factor');
+    $limiterMiddleware = config('fortify.limiters.login-middleware');
+    $twoFactorLimiterMiddleware = config('fortify.limiters.two-factor-middleware');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
             'guest:'.config('fortify.guard'),
-            $limiter ? 'throttle:'.$limiter : null,
+            $limiterMiddleware ? 'throttle:'.$limiterMiddleware : null,
         ]));
 
     Route::post(RoutePath::for('logout', '/logout'), [AuthenticatedSessionController::class, 'destroy'])
@@ -134,7 +134,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
-                $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
+                $twoFactorLimiterMiddleware ? 'throttle:'.$twoFactorLimiterMiddleware : null,
             ]));
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -83,7 +83,7 @@ class AuthenticatedSessionController extends Controller
         }
 
         return (new Pipeline(app()))->send($request)->through(array_filter([
-            config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
+            config('fortify.limiters.login') ? EnsureLoginIsNotThrottled::class : null,
             config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,
             Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
             AttemptToAuthenticate::class,

--- a/src/LoginRateLimiter.php
+++ b/src/LoginRateLimiter.php
@@ -56,7 +56,7 @@ class LoginRateLimiter
      */
     public function increment(Request $request)
     {
-        $this->limiter->hit($this->throttleKey($request), 60);
+        $this->limiter->hit($this->throttleKey($request), config('fortify.limiters.decay-seconds', 60));
     }
 
     /**

--- a/src/LoginRateLimiter.php
+++ b/src/LoginRateLimiter.php
@@ -45,7 +45,7 @@ class LoginRateLimiter
      */
     public function tooManyAttempts(Request $request)
     {
-        return $this->limiter->tooManyAttempts($this->throttleKey($request), 5);
+        return $this->limiter->tooManyAttempts($this->throttleKey($request), config('fortify.limiters.login', 5));
     }
 
     /**

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -115,8 +115,10 @@ return [
     */
 
     'limiters' => [
-        'login' => 'login',
-        'two-factor' => 'two-factor',
+        'login' => 5,
+        'login-middleware' => 10, 
+        'two-factor' => 5,
+        'two-factor-middleware' => 10,
     ],
 
     /*

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -119,6 +119,7 @@ return [
         'login-middleware' => 10, 
         'two-factor' => 5,
         'two-factor-middleware' => 10,
+        'decay-seconds' => 60,
     ],
 
     /*


### PR DESCRIPTION
# Overview 

This change will fix an issue where the `EnsureLoginIsNotThrottled` verification is never reached if `fortify.limiters.login` has any value. The current ternary condition logic is inverted. 

Also, it solves the conflict of the Laravel throttle middleware cutting the flow to Fortify throttle's own handlers by adding more granular control over the rate limits for Fortify, Laravel middleware, and the decay in seconds. 

Finally, this solution will keep both throttle protections of Fortify's own handler and Laravel default middleware. If the configs proposed here are followed, the Fortify `EnsureLoginIsNotThrottled` will be triggered first returning a friendly message `Too many requests. Please try again in X seconds.` which plays nicely with InertiaJS and if the requests continue replicating a brute force behaviour, then Laravel kicks in.

## Steps to reproduce without this fix

1. Make sure to have the limiters defined in `config/fortify.php` as follows:
```
'limiters' => [
        'login' => 5,
        'two-factor' => 5,
    ],
```
2. Remove the throttle middleware from the `Route::post(RoutePath::for('login', '/login')` keeping everything else as is, see below: (Fortify has its own throttle error handlers, it shouldn't need to rely on Laravel defaults throttle middleware)
```
Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
        ->middleware(array_filter([
            'guest:'.config('fortify.guard')
        ]));
```
4. Now attempt multiple logins passing the limiter mark, you can try even 20 times. You'll never see the error "Too many login attempts. Please try again in X seconds.".
5. Now go to the default `AuthenticatedSessionController` in Fortify changing the line for the `EnsureLoginIsNotThrottled` below to `config('fortify.limiters.login') ? EnsureLoginIsNotThrottled::class : null`. Just invert it.
https://github.com/laravel/fortify/blob/a725684d17959c4750f3b441ff2e94ecde7793a1/src/Http/Controllers/AuthenticatedSessionController.php#L85-L87 
6. Now try to log in multiple times, at some point, you'll see the error "Too many requests. Please try again in X seconds.".

## Relevant issues found
- https://github.com/laravel/fortify/issues/336 
- https://github.com/laravel/fortify/issues/312
- https://github.com/laravel/fortify/issues/543