### PR TITLE
[1.x] Allow controllers to be reused on applications that may require separate frontend and backend routes 

### DIFF
--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -58,7 +58,7 @@ class AuthenticatedSessionController extends Controller
     public function store(LoginRequest $request)
     {
         return $this->loginPipeline($request)->then(function ($request) {
-            return $this->handleLoginResponse($request);
+            return $this->sendLoginResponse($request);
         });
     }
 
@@ -110,12 +110,12 @@ class AuthenticatedSessionController extends Controller
     }
 
     /**
-     * Handle login response.
+     * Send the response after the user was authenticated.
      *
      * @param  \Laravel\Fortify\Http\Requests\LoginRequest  $request
      * @return mixed
      */
-    protected function handleLoginResponse(LoginRequest $request)
+    protected function sendLoginResponse(LoginRequest $request)
     {
         return app(LoginResponse::class);
     }

--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -58,7 +58,7 @@ class AuthenticatedSessionController extends Controller
     public function store(LoginRequest $request)
     {
         return $this->loginPipeline($request)->then(function ($request) {
-            return app(LoginResponse::class);
+            return $this->handleLoginResponse($request);
         });
     }
 
@@ -107,5 +107,16 @@ class AuthenticatedSessionController extends Controller
         }
 
         return app(LogoutResponse::class);
+    }
+
+    /**
+     * Handle login response.
+     *
+     * @param  \Laravel\Fortify\Http\Requests\LoginRequest  $request
+     * @return mixed
+     */
+    protected function handleLoginResponse(LoginRequest $request)
+    {
+        return app(LoginResponse::class);
     }
 }

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Closure;
-use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Support\Responsable;
@@ -91,7 +89,7 @@ class NewPasswordController extends Controller
      * Handle resetting the user's password.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Auth\Passwords\CanResetPassword  $user
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return void
      */
     protected function handleUserPasswordReset(Request $request, $user): void

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -111,7 +111,7 @@ class NewPasswordController extends Controller
      */
     protected function sendResetResponse(Request $request, string $status)
     {
-        return app(PasswordResetResponse::class, ['status' => $status])
+        return app(PasswordResetResponse::class, ['status' => $status]);
     }
 
     /**

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -102,7 +102,6 @@ class NewPasswordController extends Controller
         app(ResetsUserPasswords::class)->reset($user, $request->all());
     }
 
-
     /**
      * Get the response for a successful password reset.
      *

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -110,7 +110,7 @@ class NewPasswordController extends Controller
      * @param  string  $status
      * @return mixed
      */
-    protected function sendResetResponse(Request $request, $status)
+    protected function sendResetResponse(Request $request, string $status)
     {
         return app(PasswordResetResponse::class, ['status' => $status])
     }
@@ -122,7 +122,7 @@ class NewPasswordController extends Controller
      * @param  string  $status
      * @return mixed
      */
-    protected function sendResetFailedResponse(Request $request, $status)
+    protected function sendResetFailedResponse(Request $request, string $status)
     {
         return app(FailedPasswordResetResponse::class, ['status' => $status]);
     }


### PR DESCRIPTION
This includes usage such as Laravel Nova where applications may have an existing frontend authentication using Jetstream while backend authentication may be limited to just admins