### PR TITLE
added publish fortify routes

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -137,6 +137,11 @@ class FortifyServiceProvider extends ServiceProvider
                 __DIR__.'/../stubs/UpdateUserPassword.php' => app_path('Actions/Fortify/UpdateUserPassword.php'),
             ], 'fortify-support');
 
+            $this->publishes([
+                __DIR__.'/../routes/routes.php' => base_path('routes/fortify.php'),
+            ], 'fortify-routes');
+
+
             $method = method_exists($this, 'publishesMigrations') ? 'publishesMigrations' : 'publishes';
 
             $this->{$method}([


### PR DESCRIPTION
Added publishing configuration for Fortify routes. Now, the routes defined in `routes/routes.php` will be published to `routes/fortify.php` using the 'fortify-routes' tag.
