### PR TITLE
[1.x] Use available `$name` property from `SessionGuard` if the value exists

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -107,7 +107,7 @@ class AttemptToAuthenticate
      */
     protected function fireFailedEvent($request)
     {
-        event(new Failed(config('fortify.guard'), null, [
+        event(new Failed($this->guard?->name ?? config('fortify.guard'), null, [
             Fortify::username() => $request->{Fortify::username()},
             'password' => $request->password,
         ]));

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -123,7 +123,7 @@ class RedirectIfTwoFactorAuthenticatable
      */
     protected function fireFailedEvent($request, $user = null)
     {
-        event(new Failed(config('fortify.guard'), $user, [
+        event(new Failed($this->guard?->name ?? config('fortify.guard'), $user, [
             Fortify::username() => $request->{Fortify::username()},
             'password' => $request->password,
         ]));


### PR DESCRIPTION
Introduced in Laravel Framwork 10.0.0: https://github.com/laravel/framework/pull/43163

![CleanShot 2024-06-27 at 14 25 37](https://github.com/laravel/fortify/assets/172966/6e1e756e-188d-4ad2-bd51-5fcd3a84ac1b)

This avoids having to override the method on application that can have separate fortify routes (and user guard) for frontend and backend.
 
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
