### PR TITLE
[1.x] Custom recovery codes

### DIFF
--- a/src/RecoveryCode.php
+++ b/src/RecoveryCode.php
@@ -7,12 +7,34 @@ use Illuminate\Support\Str;
 class RecoveryCode
 {
     /**
+     * The callback that should be used to generate a recovery code.
+     *
+     * @var (\Closure(mixed, string): string)|null
+     */
+    public static $generateRecoveryCodeCallback;
+
+    /**
      * Generate a new recovery code.
      *
      * @return string
      */
     public static function generate()
     {
+        if (static::$generateRecoveryCodeCallback) {
+            return call_user_func(static::$generateRecoveryCodeCallback);
+        }
+
         return Str::random(10).'-'.Str::random(10);
+    }
+
+    /**
+     * Set a callback that should be used when generating a recovery code.
+     *
+     * @param  \Closure(mixed, string): string  $callback
+     * @return void
+     */
+    public static function generateRecoveryCodeUsing($callback)
+    {
+        static::$generateRecoveryCodeCallback = $callback;
     }
 }

--- a/tests/RecoveryCodeTest.php
+++ b/tests/RecoveryCodeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Fortify\Tests;
+
+use Illuminate\Support\Str;
+use Laravel\Fortify\RecoveryCode;
+
+class RecoveryCodeTest extends OrchestraTestCase
+{
+    public function test_recovery_codes_can_be_generated_with_a_custom_generator()
+    {
+        Str::createRandomStringsUsingSequence(['123', 'abc']);
+
+        RecoveryCode::generateRecoveryCodeUsing(function () {
+            return Str::random().'-'.Str::random();
+        });
+
+        $this->assertEquals('123-abc', RecoveryCode::generate());
+    }
+}


### PR DESCRIPTION
Hi all,

Recently I had a situation where I needed to choose a different length for the 2FA recovery codes and provide them as lowercase. As `RecoveryCode::generate()` is called statically in [TwoFactorAuthenticatable](https://github.com/laravel/fortify/blob/5c2e9cdf589e439feb1ed2911d4acc7ece0ec49e/src/TwoFactorAuthenticatable.php#L51), [EnableTwoFactorAuthentication](https://github.com/laravel/fortify/blob/5c2e9cdf589e439feb1ed2911d4acc7ece0ec49e/src/Actions/EnableTwoFactorAuthentication.php#L43) and [GenerateNewRecoveryCodes](https://github.com/laravel/fortify/blob/5c2e9cdf589e439feb1ed2911d4acc7ece0ec49e/src/Actions/GenerateNewRecoveryCodes.php#L21) I had to extend those classes to be able to call my own RecoveryCode class.

This PR aims to fix that paper cut by allowing developers to (optionally) define how recovery codes are generated by calling a new `RecoveryCode::generateRecoveryCodeUsing()` method and providing a callback. For example:

```php
RecoveryCode::generateRecoveryCodeUsing(function () {
    return Str::lower(Str::random(6).'-'.Str::random(6));
});
```

Another way so solve this issue might be to bind the RecoveryCode class to the container with a contract so it can be rebound, but this felt simpler and is a pattern used in other places within Laravel ([ResetPassword::createUrlUsing()](https://laravel.com/docs/11.x/passwords#reset-link-customization) for example) however happy to go that route if it is preferred.