### PR TITLE
[1.x] Ability to enforce 2FA

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -17,7 +17,6 @@ return [
     'limiters' => [
         'login' => null,
     ],
-    'enforce_two_factor_auth' => false,
     'paths' => [
         'login' => null,
         'logout' => null,

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -17,6 +17,7 @@ return [
     'limiters' => [
         'login' => null,
     ],
+    'enforce_two_factor_auth' => false,
     'paths' => [
         'login' => null,
         'logout' => null,

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -129,6 +129,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             Route::get(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'create'])
                 ->middleware(['guest:'.config('fortify.guard')])
                 ->name('two-factor.login');
+
+            Route::get(RoutePath::for('two-factor.setup', '/two-factor-setup'), [TwoFactorAuthenticatedSessionController::class, 'setup'])
+                ->middleware(['guest:'.config('fortify.guard')])
+                ->name('two-factor.setup');
         }
 
         Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
@@ -136,6 +140,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 'guest:'.config('fortify.guard'),
                 $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
             ]));
+
+        Route::post(RoutePath::for('two-factor.setup', '/two-factor-setup'), [TwoFactorAuthenticatedSessionController::class, 'completeSetup'])
+            ->middleware(['guest:'.config('fortify.guard')])
+            ->name('two-factor.setup');
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -130,9 +130,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->middleware(['guest:'.config('fortify.guard')])
                 ->name('two-factor.login');
 
-            Route::get(RoutePath::for('two-factor.setup', '/two-factor-setup'), [TwoFactorAuthenticatedSessionController::class, 'setup'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('two-factor.setup');
+            if (Features::optionEnabled(Features::twoFactorAuthentication(), 'enforced')) {
+                Route::get(RoutePath::for('two-factor.setup', '/two-factor-setup'), [TwoFactorAuthenticatedSessionController::class, 'setup'])
+                    ->middleware(['guest:'.config('fortify.guard')])
+                    ->name('two-factor.setup');
+            }
         }
 
         Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
@@ -141,9 +143,11 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
             ]));
 
-        Route::post(RoutePath::for('two-factor.setup', '/two-factor-setup'), [TwoFactorAuthenticatedSessionController::class, 'completeSetup'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('two-factor.setup');
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'enforced')) {
+            Route::post(RoutePath::for('two-factor.setup', '/two-factor-setup'), [TwoFactorAuthenticatedSessionController::class, 'completeSetup'])
+                ->middleware(['guest:'.config('fortify.guard')])
+                ->name('two-factor.setup');
+        }
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -6,7 +6,6 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
-use Laravel\Fortify\Events\TwoFactorAuthenticationRequired;
 use Laravel\Fortify\Events\TwoFactorAuthenticationSetupRequired;
 use Laravel\Fortify\Fortify;
 use Laravel\Fortify\LoginRateLimiter;

--- a/src/Contracts/FailedTwoFactorConfirmResponse.php
+++ b/src/Contracts/FailedTwoFactorConfirmResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface FailedTwoFactorConfirmResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/TwoFactorSetupEnforcedViewResponse.php
+++ b/src/Contracts/TwoFactorSetupEnforcedViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface TwoFactorSetupEnforcedViewResponse extends Responsable
+{
+    //
+}

--- a/src/Events/TwoFactorAuthenticationSetupRequired.php
+++ b/src/Events/TwoFactorAuthenticationSetupRequired.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Fortify\Events;
+
+class TwoFactorAuthenticationSetupRequired extends TwoFactorAuthenticationEvent
+{
+    //
+}

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -10,6 +10,7 @@ use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
+use Laravel\Fortify\Contracts\TwoFactorSetupEnforcedViewResponse;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
@@ -105,6 +106,7 @@ class Fortify
     {
         static::loginView($prefix.'login');
         static::twoFactorChallengeView($prefix.'two-factor-challenge');
+        static::twoFactorSetupEnforcedView($prefix.'two-factor-setup');
         static::registerView($prefix.'register');
         static::requestPasswordResetLinkView($prefix.'forgot-password');
         static::resetPasswordView($prefix.'reset-password');
@@ -134,6 +136,20 @@ class Fortify
     public static function twoFactorChallengeView($view)
     {
         app()->singleton(TwoFactorChallengeViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
+    }
+
+    /**
+     * Specify which view should be used as the two factor authentication setup page when
+     * a user logs in with two factor authentication enforced.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public static function twoFactorSetupEnforcedView($view)
+    {
+        app()->singleton(TwoFactorSetupEnforcedViewResponse::class, function () use ($view) {
             return new SimpleViewResponse($view);
         });
     }

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -308,6 +308,17 @@ class Fortify
     }
 
     /**
+     * Determine if Fortify is enforcing two factor authentication.
+     *
+     * @return bool
+     */
+    public static function enforcesTwoFactorAuthentication()
+    {
+        return Features::enabled(Features::twoFactorAuthentication()) &&
+               Features::optionEnabled(Features::twoFactorAuthentication(), 'enforced');
+    }
+
+    /**
      * Determine if Fortify is confirming two factor authentication configurations.
      *
      * @return bool

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -11,8 +11,8 @@ use Laravel\Fortify\Contracts\EmailVerificationNotificationSentResponse as Email
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswordConfirmationResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
-use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\FailedTwoFactorConfirmResponse as FailedTwoFactorConfirmResponseContract;
+use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -12,6 +12,7 @@ use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswo
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
+use Laravel\Fortify\Contracts\FailedTwoFactorConfirmResponse as FailedTwoFactorConfirmResponseContract;
 use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
@@ -32,6 +33,7 @@ use Laravel\Fortify\Http\Responses\EmailVerificationNotificationSentResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
+use Laravel\Fortify\Http\Responses\FailedTwoFactorConfirmResponse;
 use Laravel\Fortify\Http\Responses\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Http\Responses\LockoutResponse;
 use Laravel\Fortify\Http\Responses\LoginResponse;
@@ -86,6 +88,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(FailedPasswordResetLinkRequestResponseContract::class, FailedPasswordResetLinkRequestResponse::class);
         $this->app->singleton(FailedPasswordResetResponseContract::class, FailedPasswordResetResponse::class);
         $this->app->singleton(FailedTwoFactorLoginResponseContract::class, FailedTwoFactorLoginResponse::class);
+        $this->app->singleton(FailedTwoFactorConfirmResponseContract::class, FailedTwoFactorConfirmResponse::class);
         $this->app->singleton(LockoutResponseContract::class, LockoutResponse::class);
         $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
         $this->app->singleton(LogoutResponseContract::class, LogoutResponse::class);

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -4,7 +4,6 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;

--- a/src/Http/Requests/TwoFactorEnforcedSetupRequest.php
+++ b/src/Http/Requests/TwoFactorEnforcedSetupRequest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Laravel\Fortify\Http\Requests;
+
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+
+class TwoFactorEnforcedSetupRequest extends FormRequest
+{
+    /**
+     * The user setting up two factor authentication.
+     *
+     * @var mixed
+     */
+    protected $setupUser;
+
+    /**
+     * Indicates if the user wished to be remembered after login.
+     *
+     * @var bool
+     */
+    protected $remember;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'code' => 'nullable|string',
+        ];
+    }
+
+    /**
+     * Determine if there is a user in the current session.
+     *
+     * @return bool
+     */
+    public function hasSetupUser()
+    {
+        if ($this->user) {
+            return true;
+        }
+
+        $model = app(StatefulGuard::class)->getProvider()->getModel();
+
+        return $this->session()->has('login.id') &&
+            $model::find($this->session()->get('login.id'));
+    }
+
+    /**
+     * Get the user that is setting up two factor authentication.
+     *
+     * @return mixed
+     */
+    public function setupUser()
+    {
+        if ($this->setupUser) {
+            return $this->setupUser;
+        }
+
+        $model = app(StatefulGuard::class)->getProvider()->getModel();
+
+        if (! $this->session()->has('login.id') ||
+            ! $user = $model::find($this->session()->get('login.id'))) {
+            throw new HttpResponseException(
+                app(FailedTwoFactorLoginResponse::class)->toResponse($this)
+            );
+        }
+
+        return $this->setupUser = $user;
+    }
+
+    /**
+     * Determine if the user wanted to be remembered after login.
+     *
+     * @return bool
+     */
+    public function remember()
+    {
+        if (! $this->remember) {
+            $this->remember = $this->session()->pull('login.remember', false);
+        }
+
+        return $this->remember;
+    }
+}

--- a/src/Http/Requests/TwoFactorEnforcedSetupRequest.php
+++ b/src/Http/Requests/TwoFactorEnforcedSetupRequest.php
@@ -53,7 +53,7 @@ class TwoFactorEnforcedSetupRequest extends FormRequest
      */
     public function hasSetupUser()
     {
-        if ($this->user) {
+        if ($this->setupUser) {
             return true;
         }
 

--- a/src/Http/Requests/TwoFactorEnforcedSetupRequest.php
+++ b/src/Http/Requests/TwoFactorEnforcedSetupRequest.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
-use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 
 class TwoFactorEnforcedSetupRequest extends FormRequest
 {

--- a/src/Http/Responses/FailedTwoFactorConfirmResponse.php
+++ b/src/Http/Responses/FailedTwoFactorConfirmResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
+
+class FailedTwoFactorConfirmResponse implements FailedTwoFactorLoginResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        [$key, $message] = [
+            'code',
+            __('The provided two factor authentication code was invalid.')
+        ];
+
+        if ($request->wantsJson()) {
+            throw ValidationException::withMessages([
+                $key => [$message],
+            ]);
+        }
+
+        return redirect()->route('two-factor.setup')->withErrors([$key => $message]);
+    }
+}

--- a/src/Http/Responses/FailedTwoFactorConfirmResponse.php
+++ b/src/Http/Responses/FailedTwoFactorConfirmResponse.php
@@ -17,7 +17,7 @@ class FailedTwoFactorConfirmResponse implements FailedTwoFactorLoginResponseCont
     {
         [$key, $message] = [
             'code',
-            __('The provided two factor authentication code was invalid.')
+            __('The provided two factor authentication code was invalid.'),
         ];
 
         if ($request->wantsJson()) {

--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -9,6 +9,7 @@ use Laravel\Fortify\Contracts\RegisterViewResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
+use Laravel\Fortify\Contracts\TwoFactorSetupEnforcedViewResponse;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
 
 class SimpleViewResponse implements
@@ -17,6 +18,7 @@ class SimpleViewResponse implements
     RegisterViewResponse,
     RequestPasswordResetLinkViewResponse,
     TwoFactorChallengeViewResponse,
+    TwoFactorSetupEnforcedViewResponse,
     VerifyEmailViewResponse,
     ConfirmPasswordViewResponse
 {

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -19,7 +19,7 @@ trait TwoFactorAuthenticatable
      */
     public function twoFactorAuthenticationEnforced()
     {
-        return config('fortify.enforce_two_factor_auth');
+        return Fortify::enforcesTwoFactorAuthentication();
     }
 
     /**

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -13,6 +13,16 @@ use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 trait TwoFactorAuthenticatable
 {
     /**
+     * Determine if two-factor authentication should be enforced for the user.
+     *
+     * @return bool
+     */
+    public function twoFactorAuthenticationEnforced()
+    {
+        return config('fortify.enforce_two_factor_auth');
+    }
+
+    /**
      * Determine if two-factor authentication has been enabled.
      *
      * @return bool

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -152,6 +152,7 @@ return [
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,
+            'enforced' => false,
             // 'window' => 0,
         ]),
     ],

--- a/tests/AuthenticatedSessionControllerWithEnforcedTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithEnforcedTwoFactorTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Laravel\Fortify\Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
+use Laravel\Fortify\Events\TwoFactorAuthenticationSetupRequired;
+use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\Attributes\WithMigration;
+use PragmaRX\Google2FA\Google2FA;
+
+#[WithMigration]
+#[DefineEnvironment('withTwoFactorAuthentication')]
+#[WithConfig('auth.providers.users.model', UserWithTwoFactor::class)]
+#[WithConfig('fortify.enforce_two_factor_auth', true)]
+class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraTestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_is_redirected_to_setup_page_when_two_factor_is_enforced()
+    {
+        Event::fake();
+
+        UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $response->assertRedirect('/two-factor-setup');
+
+        Event::assertDispatched(TwoFactorAuthenticationSetupRequired::class);
+    }
+
+    public function test_json_response_contains_data_required_for_setting_up_two_factor_when_enforced()
+    {
+        Event::fake();
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->postJson('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $user->refresh();
+
+        $response->assertJson([
+            'two_factor_setup_required' => true,
+            'setup_info' => [
+                'code' => decrypt($user->two_factor_secret),
+                'url' => $user->twoFactorQrCodeUrl(),
+                'qr_svg' => $user->twoFactorQrCodeSvg(),
+                'recovery_codes' => $user->recoveryCodes(),
+            ],
+        ]);
+    }
+
+    public function test_user_is_redirected_to_challenge_when_two_factor_is_already_setup()
+    {
+        Event::fake();
+
+        UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => 'test-secret',
+        ]);
+
+        $response = $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        Event::assertDispatched(TwoFactorAuthenticationChallenged::class);
+
+        $response->assertRedirect('/two-factor-challenge');
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    public function test_two_factor_is_confirmed_when_feature_enabled_after_successful_setup()
+    {
+        Event::fake();
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        // Now get a valid key
+        $tfaEngine = app(Google2FA::class);
+        $validOtp = $tfaEngine->getCurrentOtp(
+            decrypt($user->refresh()->two_factor_secret)
+        );
+
+        $this->post('/two-factor-setup', [
+            'code' => $validOtp,
+        ]);
+
+        $user->refresh();
+
+        $this->assertNotNull($user->two_factor_confirmed_at);
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    public function test_user_is_redirected_to_home_when_two_factor_is_successfully_set_up()
+    {
+        Event::fake();
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->withoutExceptionHandling()->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        // Now get a valid key
+        $tfaEngine = app(Google2FA::class);
+        $validOtp = $tfaEngine->getCurrentOtp(
+            decrypt($user->refresh()->two_factor_secret)
+        );
+
+        $response = $this->post('/two-factor-setup', [
+            'code' => $validOtp,
+        ]);
+
+        $response->assertRedirect('/home')
+            ->assertSessionMissing('login.id');
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    public function test_setup_fails_if_confirm_two_factor_is_enabled_and_code_is_incorrect()
+    {
+        Event::fake();
+
+        UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->post('/login', [
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $response = $this->post('/two-factor-setup', [
+            'code' => '123',
+        ]);
+
+        $response->assertRedirect('/two-factor-setup')
+            ->assertSessionHas('login.id')
+            ->assertSessionHasErrors(['code']);
+    }
+}

--- a/tests/AuthenticatedSessionControllerWithEnforcedTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithEnforcedTwoFactorTest.php
@@ -13,13 +13,12 @@ use Orchestra\Testbench\Attributes\WithMigration;
 use PragmaRX\Google2FA\Google2FA;
 
 #[WithMigration]
-#[DefineEnvironment('withTwoFactorAuthentication')]
 #[WithConfig('auth.providers.users.model', UserWithTwoFactor::class)]
-#[WithConfig('fortify.enforce_two_factor_auth', true)]
 class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraTestCase
 {
     use RefreshDatabase;
 
+    #[DefineEnvironment('withConfirmedEnforcedTwoFactorAuthentication')]
     public function test_user_is_redirected_to_setup_page_when_two_factor_is_enforced()
     {
         Event::fake();
@@ -40,6 +39,7 @@ class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraT
         Event::assertDispatched(TwoFactorAuthenticationSetupRequired::class);
     }
 
+    #[DefineEnvironment('withConfirmedEnforcedTwoFactorAuthentication')]
     public function test_json_response_contains_data_required_for_setting_up_two_factor_when_enforced()
     {
         Event::fake();
@@ -68,6 +68,7 @@ class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraT
         ]);
     }
 
+    #[DefineEnvironment('withConfirmedEnforcedTwoFactorAuthentication')]
     public function test_user_is_redirected_to_challenge_when_two_factor_is_already_setup()
     {
         Event::fake();
@@ -77,6 +78,7 @@ class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraT
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
             'two_factor_secret' => 'test-secret',
+            'two_factor_confirmed_at' => now(),
         ]);
 
         $response = $this->withoutExceptionHandling()->post('/login', [
@@ -89,7 +91,7 @@ class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraT
         $response->assertRedirect('/two-factor-challenge');
     }
 
-    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    #[DefineEnvironment('withConfirmedEnforcedTwoFactorAuthentication')]
     public function test_two_factor_is_confirmed_when_feature_enabled_after_successful_setup()
     {
         Event::fake();
@@ -120,7 +122,7 @@ class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraT
         $this->assertNotNull($user->two_factor_confirmed_at);
     }
 
-    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    #[DefineEnvironment('withConfirmedEnforcedTwoFactorAuthentication')]
     public function test_user_is_redirected_to_home_when_two_factor_is_successfully_set_up()
     {
         Event::fake();
@@ -150,7 +152,7 @@ class AuthenticatedSessionControllerWithEnforcedTwoFactorTest extends OrchestraT
             ->assertSessionMissing('login.id');
     }
 
-    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    #[DefineEnvironment('withConfirmedEnforcedTwoFactorAuthentication')]
     public function test_setup_fails_if_confirm_two_factor_is_enabled_and_code_is_incorrect()
     {
         Event::fake();

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -39,4 +39,14 @@ abstract class OrchestraTestCase extends TestCase
             $config->set('fortify.features', $features);
         });
     }
+
+    protected function withConfirmedEnforcedTwoFactorAuthentication($app)
+    {
+        $app['config']->set('fortify.features', [
+            Features::twoFactorAuthentication([
+                'confirm' => true,
+                'enforced' => true,
+            ]),
+        ]);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds the ability to enforce two factor authentication (2FA).

It's quite a common feature for organisation administrators to want to enforce that their users to have 2FA enabled.

**How does it work?**

When a user logs in, if they do not have 2FA enabled and the enforce 2FA feature is enabled, a user will be redirected to a "Setup two factor authentication" page before they can proceed.

For XHR requests, the response will indicate that 2FA is required, and will contain all the required information to set up 2FA.

**How is it enabled?**

It's off by default, and it's derived from `twoFactorAuthenticationEnforced()` in the `TwoFactorAuthenticatable` trait. This means it'll be easy to conditionally activate this based on the application needs.

You'll also need to enable the "enforced" option on the features:

```php
Features::twoFactorAuthentication([
  'enforced' => true,
])
```

**How do I implement this?**

Enable the `enforced` option. And optionally define custom logic in the `twoFactorAuthenticationEnforced()` method to restrict enforcement to a subset of users.

Create a new view, `auth/two-factor-setup.blade.php`, which instructs the user that they need to enable 2FA before they can proceed.

The view should contain a form which makes a POST request to `route('two-factor.setup')`. If the Fortify "confirm" feature is enabled, this form must include a field for the user to enter their 2FA code.

**Are there any breaking changes?**

No.

**Are there tests?**

Yes! 


---

I've got a branch of Laravel Jetstream which includes the required blade files, plus support for enabling 2FA on the team level. If you're interested in this feature, I'd be happy to raise a PR in the Jetstream repo too, as well as updating documentation.
