### PR TITLE
[1.x] Rehash password if required when user uses two factor

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -94,6 +94,10 @@ class RedirectIfTwoFactorAuthenticatable
 
                 $this->throwFailedAuthenticationException($request);
             }
+
+            if (config('hashing.rehash_on_login', true) && method_exists($this->guard->getProvider(), 'rehashPasswordIfRequired')) {
+                $this->guard->getProvider()->rehashPasswordIfRequired($user, ['password' => $request->password]);
+            }
         });
     }
 


### PR DESCRIPTION
In Laravel 11, "automatic rehashing of user passwords when validating credentials" was added as a feature (https://github.com/laravel/framework/pull/48665). This PR ensures this feature also works when a user uses two-factor authentication.

When a user with two-factor enters their username and password, the user is not logged in because the user is redirected to the two-factor challenge page. This means the password rehashing is not triggered because it is only triggered when the user is immediately logged in when validating the credentials.