### PR TITLE
[1.x] Add TwoFactorAuthenticationFailed event

### DIFF
--- a/src/Events/TwoFactorAuthenticationFailed.php
+++ b/src/Events/TwoFactorAuthenticationFailed.php
@@ -2,27 +2,7 @@
 
 namespace Laravel\Fortify\Events;
 
-use Illuminate\Queue\SerializesModels;
-
-class TwoFactorAuthenticationFailed
+class TwoFactorAuthenticationFailed extends TwoFactorAuthenticationEvent
 {
-    use SerializesModels;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
-     * Create a new event instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return void
-     */
-    public function __construct($user)
-    {
-        $this->user = $user;
-    }
+    //
 }

--- a/src/Events/TwoFactorAuthenticationFailed.php
+++ b/src/Events/TwoFactorAuthenticationFailed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Fortify\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class TwoFactorAuthenticationFailed
+{
+    use SerializesModels;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -63,7 +63,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
             event(new RecoveryCodeReplaced($user, $code));
         } elseif (! $request->hasValidCode()) {
             event(new TwoFactorAuthenticationFailed($user));
-            
+
             return app(FailedTwoFactorLoginResponse::class)->toResponse($request);
         }
 

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -63,6 +63,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
             event(new RecoveryCodeReplaced($user, $code));
         } elseif (! $request->hasValidCode()) {
             event(new TwoFactorAuthenticationFailed($user));
+            
             return app(FailedTwoFactorLoginResponse::class)->toResponse($request);
         }
 

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -9,6 +9,7 @@ use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Events\RecoveryCodeReplaced;
+use Laravel\Fortify\Events\TwoFactorAuthenticationFailed;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 
 class TwoFactorAuthenticatedSessionController extends Controller
@@ -61,6 +62,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
 
             event(new RecoveryCodeReplaced($user, $code));
         } elseif (! $request->hasValidCode()) {
+            event(new TwoFactorAuthenticationFailed($user));
             return app(FailedTwoFactorLoginResponse::class)->toResponse($request);
         }
 

--- a/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
@@ -202,6 +202,7 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
     public function test_two_factor_challenge_fails_for_old_otp_and_zero_window()
     {
         Event::fake();
+        
         // Setting window to 0 should mean any old OTP is instantly invalid
         Features::twoFactorAuthentication(['window' => 0]);
 

--- a/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
@@ -202,7 +202,7 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
     public function test_two_factor_challenge_fails_for_old_otp_and_zero_window()
     {
         Event::fake();
-        
+
         // Setting window to 0 should mean any old OTP is instantly invalid
         Features::twoFactorAuthentication(['window' => 0]);
 

--- a/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
+use Laravel\Fortify\Events\TwoFactorAuthenticationFailed;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
@@ -200,6 +201,7 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
 
     public function test_two_factor_challenge_fails_for_old_otp_and_zero_window()
     {
+        Event::fake();
         // Setting window to 0 should mean any old OTP is instantly invalid
         Features::twoFactorAuthentication(['window' => 0]);
 
@@ -221,6 +223,8 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
         ])->withoutExceptionHandling()->post('/two-factor-challenge', [
             'code' => $previousOtp,
         ]);
+
+        Event::assertDispatched(TwoFactorAuthenticationFailed::class);
 
         $response->assertRedirect('/two-factor-challenge')
                  ->assertSessionHas('login.id')


### PR DESCRIPTION
Hi Taylor,

Thank you for Fortify. It's our first time using it heavily, and we really enjoy the package so far.

In our project, we need to log 2FA events in a database table. Although Fortify already dispatches some events, we require one that is currently missing. This PR adds that event. I believe this is a low-risk change, and I'm happy to move the event call elsewhere if you prefer.