### PR TITLE
Fire ValidTwoFactorAuthenticationCodeProvided Event when 2FA session is authenticated

### DIFF
--- a/src/Events/TwoFactorAuthenticationVerified.php
+++ b/src/Events/TwoFactorAuthenticationVerified.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Fortify\Events;
+
+class TwoFactorAuthenticationVerified extends TwoFactorAuthenticationEvent
+{
+    //
+}

--- a/src/Events/TwoFactorAuthenticationVerified.php
+++ b/src/Events/TwoFactorAuthenticationVerified.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Laravel\Fortify\Events;
-
-class TwoFactorAuthenticationVerified extends TwoFactorAuthenticationEvent
-{
-    //
-}

--- a/src/Events/ValidTwoFactorAuthenticationCodeProvided.php
+++ b/src/Events/ValidTwoFactorAuthenticationCodeProvided.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Fortify\Events;
+
+class ValidTwoFactorAuthenticationCodeProvided extends TwoFactorAuthenticationEvent
+{
+    //
+}

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -10,6 +10,7 @@ use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Events\RecoveryCodeReplaced;
 use Laravel\Fortify\Events\TwoFactorAuthenticationFailed;
+use Laravel\Fortify\Events\TwoFactorAuthenticationVerified;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 
 class TwoFactorAuthenticatedSessionController extends Controller
@@ -66,6 +67,8 @@ class TwoFactorAuthenticatedSessionController extends Controller
 
             return app(FailedTwoFactorLoginResponse::class)->toResponse($request);
         }
+
+        event(new TwoFactorAuthenticationVerified($user));
 
         $this->guard->login($user, $request->remember());
 

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -10,7 +10,7 @@ use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse;
 use Laravel\Fortify\Events\RecoveryCodeReplaced;
 use Laravel\Fortify\Events\TwoFactorAuthenticationFailed;
-use Laravel\Fortify\Events\TwoFactorAuthenticationVerified;
+use Laravel\Fortify\Events\ValidTwoFactorAuthenticationCodeProvided;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 
 class TwoFactorAuthenticatedSessionController extends Controller
@@ -68,7 +68,7 @@ class TwoFactorAuthenticatedSessionController extends Controller
             return app(FailedTwoFactorLoginResponse::class)->toResponse($request);
         }
 
-        event(new TwoFactorAuthenticationVerified($user));
+        event(new ValidTwoFactorAuthenticationCodeProvided($user));
 
         $this->guard->login($user, $request->remember());
 

--- a/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
 use Laravel\Fortify\Events\TwoFactorAuthenticationFailed;
-use Laravel\Fortify\Events\TwoFactorAuthenticationVerified;
+use Laravel\Fortify\Events\ValidTwoFactorAuthenticationCodeProvided;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
@@ -177,7 +177,7 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
             'code' => $validOtp,
         ]);
 
-        Event::assertDispatched(TwoFactorAuthenticationVerified::class);
+        Event::assertDispatched(ValidTwoFactorAuthenticationCodeProvided::class);
 
         $response->assertRedirect('/home')
             ->assertSessionMissing('login.id');
@@ -255,7 +255,7 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
             'recovery_code' => 'valid-code',
         ]);
 
-        Event::assertDispatched(TwoFactorAuthenticationVerified::class);
+        Event::assertDispatched(ValidTwoFactorAuthenticationCodeProvided::class);
 
         $response->assertRedirect('/home')
             ->assertSessionMissing('login.id');

--- a/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
+++ b/tests/AuthenticatedSessionControllerWithTwoFactorTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
 use Laravel\Fortify\Events\TwoFactorAuthenticationFailed;
+use Laravel\Fortify\Events\TwoFactorAuthenticationVerified;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
@@ -156,6 +157,8 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
 
     public function test_two_factor_challenge_can_be_passed_via_code()
     {
+        Event::fake();
+
         $tfaEngine = app(Google2FA::class);
         $userSecret = $tfaEngine->generateSecretKey();
         $validOtp = $tfaEngine->getCurrentOtp($userSecret);
@@ -173,6 +176,8 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
         ])->withoutExceptionHandling()->post('/two-factor-challenge', [
             'code' => $validOtp,
         ]);
+
+        Event::assertDispatched(TwoFactorAuthenticationVerified::class);
 
         $response->assertRedirect('/home')
             ->assertSessionMissing('login.id');
@@ -234,6 +239,8 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
 
     public function test_two_factor_challenge_can_be_passed_via_recovery_code()
     {
+        Event::fake();
+
         $user = UserWithTwoFactor::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
@@ -247,6 +254,8 @@ class AuthenticatedSessionControllerWithTwoFactorTest extends OrchestraTestCase
         ])->withoutExceptionHandling()->post('/two-factor-challenge', [
             'recovery_code' => 'valid-code',
         ]);
+
+        Event::assertDispatched(TwoFactorAuthenticationVerified::class);
 
         $response->assertRedirect('/home')
             ->assertSessionMissing('login.id');


### PR DESCRIPTION
In an app I'm working on we would like to store a timestamp in the session, when the user last verified their 2FA[^1]. While source-diving I didn't find an event that would be fired, when the 2FA code was verified. (There are only events for when the verification failed.)

This PR adds a new event that is being fired when a new session is being authenticated using 2FA. Adding an event listener for our usecase is now trivial.

---

I was contemplating if this event should be fired within the `TwoFactorAuthenticationProvider`, but as no other events are fired within that implementation I think the controllers is the right place for them.

[^1]: In our app, the admin panel is protected with a `RequireTwoFactorAuthentication`-middleware that periodically asks users to confirm their 2FA code. (Similar to the `\Illuminate\Auth\Middleware\RequirePassword`-middleware). 
We currently run into an _UX_-issue where folks can't access the admin dashboard immediately after login, as the same 2FA code doesn't seem to be accepted by the `TwoFactorAuthenticationProvider` within the 30s window after login.