### PR TITLE
Use fortify email method in failed password responses

### DIFF
--- a/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Fortify;
 
 class FailedPasswordResetLinkRequestResponse implements FailedPasswordResetLinkRequestResponseContract
 {
@@ -35,12 +36,12 @@ class FailedPasswordResetLinkRequestResponse implements FailedPasswordResetLinkR
     {
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([
-                'email' => [trans($this->status)],
+                Fortify::email() => [trans($this->status)],
             ]);
         }
 
         return back()
-                ->withInput($request->only('email'))
-                ->withErrors(['email' => trans($this->status)]);
+                ->withInput($request->only(Fortify::email()))
+                ->withErrors([Fortify::email() => trans($this->status)]);
     }
 }

--- a/src/Http/Responses/FailedPasswordResetResponse.php
+++ b/src/Http/Responses/FailedPasswordResetResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
+use Laravel\Fortify\Fortify;
 
 class FailedPasswordResetResponse implements FailedPasswordResetResponseContract
 {
@@ -35,12 +36,12 @@ class FailedPasswordResetResponse implements FailedPasswordResetResponseContract
     {
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([
-                'email' => [trans($this->status)],
+                Fortify::email() => [trans($this->status)],
             ]);
         }
 
         return back()
-                ->withInput($request->only('email'))
-                ->withErrors(['email' => trans($this->status)]);
+                ->withInput($request->only(Fortify::email()))
+                ->withErrors([Fortify::email() => trans($this->status)]);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Validation messages from classes `FailedPasswordResetLinkRequestResponse` and `FailedPasswordResetResponse` will use `email` as key. 
When using a custom email column, as enabled by the `Fortify::email()` method, the field in the request and in the response no longer match. 

Solved by using the field name provided by `Fortify::email()` as key in validation response.
