### PR TITLE
[1.x] Add `X-Retry-After` to `/user/confirm-password/status` response

### DIFF
--- a/src/Http/Controllers/ConfirmedPasswordStatusController.php
+++ b/src/Http/Controllers/ConfirmedPasswordStatusController.php
@@ -16,9 +16,15 @@ class ConfirmedPasswordStatusController extends Controller
      */
     public function show(Request $request)
     {
-        $lastConfirmation = $request->session()->get('auth.password_confirmed_at', 0);
+        $lastConfirmation = $request->session()->get(
+            'auth.password_confirmed_at', 0
+        );
+
         $lastConfirmed = (Date::now()->unix() - $lastConfirmation);
-        $confirmed = $lastConfirmed < $request->input('seconds', config('auth.password_timeout', 900));
+
+        $confirmed = $lastConfirmed < $request->input(
+            'seconds', config('auth.password_timeout', 900)
+        );
 
         return response()->json([
             'confirmed' => $confirmed,

--- a/src/Http/Controllers/ConfirmedPasswordStatusController.php
+++ b/src/Http/Controllers/ConfirmedPasswordStatusController.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Date;
 
 class ConfirmedPasswordStatusController extends Controller
 {
@@ -15,8 +16,14 @@ class ConfirmedPasswordStatusController extends Controller
      */
     public function show(Request $request)
     {
+        $lastConfirmation = $request->session()->get('auth.password_confirmed_at', 0);
+        $lastConfirmed = (Date::now()->unix() - $lastConfirmation);
+        $confirmed = $lastConfirmed < $request->input('seconds', config('auth.password_timeout', 900));
+
         return response()->json([
-            'confirmed' => (time() - $request->session()->get('auth.password_confirmed_at', 0)) < $request->input('seconds', config('auth.password_timeout', 900)),
-        ]);
+            'confirmed' => $confirmed,
+        ], headers: array_filter([
+            'X-Retry-After' => $confirmed ? $lastConfirmed : null,
+        ]));
     }
 }


### PR DESCRIPTION
This would be useful for SPA application where we can register a timeout before checking the endpoint again.

Here, I chosen to use `X-Retry-After` instead of [Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) since the documentation suggest the usage to be limited to `301`, `429` and `503` response status.
