### PR TITLE
Adding context length configuration for 2FA to ensure better security standards

### DIFF
--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -37,9 +37,11 @@ class EnableTwoFactorAuthentication
     public function __invoke($user, $force = false)
     {
         if (empty($user->two_factor_secret) || $force === true) {
-            $secret_length = (int) config('fortify-options.two-factor-authentication.secret-length', 16);
+
+            $secretLength = (int) config('fortify-options.two-factor-authentication.secret-length', 16);
+
             $user->forceFill([
-                'two_factor_secret' => encrypt($this->provider->generateSecretKey($secret_length)),
+                'two_factor_secret' => encrypt($this->provider->generateSecretKey($secretLength)),
                 'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
                     return RecoveryCode::generate();
                 })->all())),

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -37,8 +37,9 @@ class EnableTwoFactorAuthentication
     public function __invoke($user, $force = false)
     {
         if (empty($user->two_factor_secret) || $force === true) {
+            $secret_length = (int) config('fortify-options.two-factor-authentication.secret-length', 16);
             $user->forceFill([
-                'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
+                'two_factor_secret' => encrypt($this->provider->generateSecretKey($secret_length)),
                 'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
                     return RecoveryCode::generate();
                 })->all())),

--- a/src/Contracts/TwoFactorAuthenticationProvider.php
+++ b/src/Contracts/TwoFactorAuthenticationProvider.php
@@ -7,9 +7,10 @@ interface TwoFactorAuthenticationProvider
     /**
      * Generate a new secret key.
      *
+     * @param  int  $secret_length
      * @return string
      */
-    public function generateSecretKey();
+    public function generateSecretKey($secret_length);
 
     /**
      * Get the two factor authentication QR code URL.

--- a/src/Contracts/TwoFactorAuthenticationProvider.php
+++ b/src/Contracts/TwoFactorAuthenticationProvider.php
@@ -7,10 +7,9 @@ interface TwoFactorAuthenticationProvider
     /**
      * Generate a new secret key.
      *
-     * @param  int  $secret_length
      * @return string
      */
-    public function generateSecretKey($secret_length);
+    public function generateSecretKey);
 
     /**
      * Get the two factor authentication QR code URL.

--- a/src/Contracts/TwoFactorAuthenticationProvider.php
+++ b/src/Contracts/TwoFactorAuthenticationProvider.php
@@ -9,7 +9,7 @@ interface TwoFactorAuthenticationProvider
      *
      * @return string
      */
-    public function generateSecretKey);
+    public function generateSecretKey();
 
     /**
      * Get the two factor authentication QR code URL.

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -38,12 +38,12 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     /**
      * Generate a new secret key.
      *
-     * @param  int  $secret_length = 16
+     * @param  int  $secretLength
      * @return string
      */
-    public function generateSecretKey(int $secret_length = 16)
+    public function generateSecretKey(int $secretLength = 16)
     {
-        return $this->engine->generateSecretKey($secret_length);
+        return $this->engine->generateSecretKey($secretLength);
     }
 
     /**

--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -38,11 +38,12 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
     /**
      * Generate a new secret key.
      *
+     * @param  int  $secret_length = 16
      * @return string
      */
-    public function generateSecretKey()
+    public function generateSecretKey(int $secret_length = 16)
     {
-        return $this->engine->generateSecretKey();
+        return $this->engine->generateSecretKey($secret_length);
     }
 
     /**


### PR DESCRIPTION
Follow up of [https://github.com/laravel/fortify/issues/567](https://github.com/laravel/fortify/issues/567)

### Description
We need to ensure a minimum length for 2FA secret, current secret length by default is 80-bit (16 characters), but 128-bit (26 characters) is becoming minimum in some cases and the best default is 160-bit.

It's recommended to use 128-bit or 160-bit because some Authenticator apps may have problems with non-RFC-recommended lengths (Namely https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp).

### Implementation
Added some contextual config via : 
config('fortify-options.two-factor-authentication.secret-length', 16);

Retro compatible and define a security standard as expected by new RFC.

