### PR TITLE
Fix unnamed routes when views are disabled (with original code formatting)

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -138,7 +138,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         RoutePath::for('password.confirm', '/user/confirm-password'),
         [ConfirmablePasswordController::class, 'store']
     )
-    ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
+        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
 
     if (! $enableViews) {
         $passwordConfirm->name('password.confirm');

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -35,10 +35,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
 
-    $login = Route::post(
-        RoutePath::for('login', '/login'),
-        [AuthenticatedSessionController::class, 'store']
-    )
+    $login = Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
             'guest:'.config('fortify.guard'),
             $limiter ? 'throttle:'.$limiter : null,
@@ -81,10 +78,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->name('register');
         }
 
-        $register = Route::post(
-            RoutePath::for('register', '/register'),
-            [RegisteredUserController::class, 'store']
-        )
+        $register = Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
             ->middleware(['guest:'.config('fortify.guard')]);
 
         if (! $enableViews) {
@@ -134,10 +128,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
         ->name('password.confirmation');
 
-    $passwordConfirm = Route::post(
-        RoutePath::for('password.confirm', '/user/confirm-password'),
-        [ConfirmablePasswordController::class, 'store']
-    )
+    $passwordConfirm = Route::post(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'store'])
         ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
 
     if (! $enableViews) {
@@ -152,9 +143,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->name('two-factor.login');
         }
 
-        $twoFactorLogin = Route::post(
-            RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store']
-        )
+        $twoFactorLogin = Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
                 $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -35,11 +35,18 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
 
-    Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
+    $login = Route::post(
+        RoutePath::for('login', '/login'),
+        [AuthenticatedSessionController::class, 'store']
+    )
         ->middleware(array_filter([
             'guest:'.config('fortify.guard'),
             $limiter ? 'throttle:'.$limiter : null,
         ]));
+
+    if (! $enableViews) {
+        $login->name('login');
+    }
 
     Route::post(RoutePath::for('logout', '/logout'), [AuthenticatedSessionController::class, 'destroy'])
         ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
@@ -74,8 +81,15 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->name('register');
         }
 
-        Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
+        $register = Route::post(
+            RoutePath::for('register', '/register'),
+            [RegisteredUserController::class, 'store']
+        )
             ->middleware(['guest:'.config('fortify.guard')]);
+
+        if (! $enableViews) {
+            $register->name('register');
+        }
     }
 
     // Email Verification...
@@ -131,11 +145,17 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
                 ->name('two-factor.login');
         }
 
-        Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
+        $twoFactorLogin = Route::post(
+            RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store']
+        )
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
                 $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
             ]));
+
+        if (! $enableViews) {
+            $twoFactorLogin->name('two-factor.login');
+        }
 
         $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
             ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -126,16 +126,23 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     // Password Confirmation...
     if ($enableViews) {
         Route::get(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'show'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
+            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+            ->name('password.confirm');
     }
 
     Route::get(RoutePath::for('password.confirmation', '/user/confirmed-password-status'), [ConfirmedPasswordStatusController::class, 'show'])
         ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
         ->name('password.confirmation');
 
-    Route::post(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'store'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-        ->name('password.confirm');
+    $passwordConfirm = Route::post(
+        RoutePath::for('password.confirm', '/user/confirm-password'),
+        [ConfirmablePasswordController::class, 'store']
+    )
+    ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')]);
+
+    if (! $enableViews) {
+        $passwordConfirm->name('password.confirm');
+    }
 
     // Two Factor Authentication...
     if (Features::enabled(Features::twoFactorAuthentication())) {


### PR DESCRIPTION
This PR fixes additional unnamed routes, such as login and register, when views are disabled.
It also fixes the issue with breadcrumbs potentially not working when GET routes don't have a name. (https://github.com/laravel/fortify/pull/368#issuecomment-1248084298)

In the current state, routes like login and register have to be hardcoded since they don't have names when views are disabled.