### PR TITLE
[1.x] Simplifying UpdateUserProfileInformation.php

### DIFF
--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -32,7 +32,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         $user->forceFill([
             'name' => $input['name'],
             'email' => $input['email'],
-        ])
+        ]);
 
         if ($user->isDirty('email') && $user instanceof MustVerifyEmail) {
             $user->email_verified_at = null;

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -28,7 +28,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 Rule::unique('users')->ignore($user->id),
             ],
         ])->validateWithBag('updateProfileInformation');
-        
+
         $user->forceFill([
             'name' => $input['name'],
             'email' => $input['email'],


### PR DESCRIPTION
This pull request includes changes to the `update` method in `UpdateUserProfileInformation.php` to streamline the process of updating user profile information, particularly focusing on email verification.

### Improvements to email verification logic:

* Simplified the email verification logic by removing the `updateVerifiedUser` method and handling email verification directly within the `update` method.
* Updated the condition to check if the email has changed using the `isDirty` method and set `email_verified_at` to null if the email is modified and the user must verify their email.
* Ensured that the email verification notification is sent if the email was changed by using the `wasChanged` method.