### PR TITLE
Add method DI

### DIFF
--- a/src/Http/Controllers/AuthenticatedSessionController.php
+++ b/src/Http/Controllers/AuthenticatedSessionController.php
@@ -95,10 +95,15 @@ class AuthenticatedSessionController extends Controller
      * Destroy an authenticated session.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard|null  $guard
      * @return \Laravel\Fortify\Contracts\LogoutResponse
      */
-    public function destroy(Request $request): LogoutResponse
+    public function destroy(Request $request, StatefulGuard|null $guard = null): LogoutResponse
     {
+        if ($guard) {
+            $this->guard = $guard;
+        }
+
         $this->guard->logout();
 
         if ($request->hasSession()) {

--- a/src/Http/Controllers/ConfirmablePasswordController.php
+++ b/src/Http/Controllers/ConfirmablePasswordController.php
@@ -46,10 +46,15 @@ class ConfirmablePasswordController extends Controller
      * Confirm the user's password.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard|null  $guard
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request)
+    public function store(Request $request, StatefulGuard|null $guard = null)
     {
+        if ($guard) {
+            $this->guard = $guard;
+        }
+
         $confirmed = app(ConfirmPassword::class)(
             $this->guard, $request->user(), $request->input('password')
         );

--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -50,10 +50,15 @@ class NewPasswordController extends Controller
      * Reset the user's password.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard|null  $guard
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request): Responsable
+    public function store(Request $request, StatefulGuard|null $guard = null): Responsable
     {
+        if ($guard) {
+            $this->guard = $guard;
+        }
+
         $request->validate([
             'token' => 'required',
             Fortify::email() => 'required|email',

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -48,11 +48,16 @@ class RegisteredUserController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Fortify\Contracts\CreatesNewUsers  $creator
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard|null  $guard
      * @return \Laravel\Fortify\Contracts\RegisterResponse
      */
     public function store(Request $request,
-                          CreatesNewUsers $creator): RegisterResponse
+                          CreatesNewUsers $creator, StatefulGuard|null $guard = null): RegisterResponse
     {
+        if ($guard) {
+            $this->guard = $guard;
+        }
+
         if (config('fortify.lowercase_usernames')) {
             $request->merge([
                 Fortify::username() => Str::lower($request->{Fortify::username()}),

--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -52,10 +52,15 @@ class TwoFactorAuthenticatedSessionController extends Controller
      * Attempt to authenticate a new session using the two factor authentication code.
      *
      * @param  \Laravel\Fortify\Http\Requests\TwoFactorLoginRequest  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard|null  $guard
      * @return mixed
      */
-    public function store(TwoFactorLoginRequest $request)
+    public function store(TwoFactorLoginRequest $request, StatefulGuard|null $guard = null)
     {
+        if ($guard) {
+            $this->guard = $guard;
+        }
+
         $user = $request->challengedUser();
 
         if ($code = $request->validRecoveryCode()) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently Fortify uses constructor DI but some 3th party packages such as [Laravel tenancy](https://tenancyforlaravel.com/) have a hard time using this. "The reason is Constructor DI is executed before middleware". Based on a earlier [PR](https://github.com/laravel/fortify/pull/169), this PR adds method DI. 

References:
- https://github.com/laravel/fortify/issues/163;
- https://tenancyforlaravel.com/docs/v3/early-identification;
- https://github.com/archtechx/tenancy/issues/564;
- https://github.com/archtechx/tenancy/issues/702;