### PR TITLE
Replace implicitly nullable parameters for PHP 8.4

### DIFF
--- a/src/TwoFactorAuthenticationProvider.php
+++ b/src/TwoFactorAuthenticationProvider.php
@@ -29,7 +29,7 @@ class TwoFactorAuthenticationProvider implements TwoFactorAuthenticationProvider
      * @param  \Illuminate\Contracts\Cache\Repository|null  $cache
      * @return void
      */
-    public function __construct(Google2FA $engine, Repository $cache = null)
+    public function __construct(Google2FA $engine, ?Repository $cache = null)
     {
         $this->engine = $engine;
         $this->cache = $cache;


### PR DESCRIPTION
This PR removes implicitly nullable parameters because these result in deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter