### PR TITLE
[1.x] Use `retrieveByCredentials()` on the User Provider instead of a hardcoded Eloquent query

### DIFF
--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -86,17 +86,17 @@ class RedirectIfTwoFactorAuthenticatable
             });
         }
 
-        $model = $this->guard->getProvider()->getModel();
+        $provider = $this->guard->getProvider();
 
-        return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use ($request) {
-            if (! $user || ! $this->guard->getProvider()->validateCredentials($user, ['password' => $request->password])) {
+        return tap($provider->retrieveByCredentials($request->only(Fortify::username(), 'password')), function ($user) use ($provider, $request) {
+            if (! $user || ! $provider->validateCredentials($user, ['password' => $request->password])) {
                 $this->fireFailedEvent($request, $user);
 
                 $this->throwFailedAuthenticationException($request);
             }
 
-            if (config('hashing.rehash_on_login', true) && method_exists($this->guard->getProvider(), 'rehashPasswordIfRequired')) {
-                $this->guard->getProvider()->rehashPasswordIfRequired($user, ['password' => $request->password]);
+            if (config('hashing.rehash_on_login', true) && method_exists($provider, 'rehashPasswordIfRequired')) {
+                $provider->rehashPasswordIfRequired($user, ['password' => $request->password]);
             }
         });
     }


### PR DESCRIPTION
The `AttemptToAuthenticate` action calls the `attempt()` method on the guard, which calls `retrieveByCredentials()` under the hood. Unfortunately, the `RedirectIfTwoFactorAuthenticatable` does not use this method but instead uses a hardcoded query on the Eloquent Model, effectively skipping any logic that might be implemented in a custom User Provider.

This PR changes the `RedirectIfTwoFactorAuthenticatable` action by also using the `retrieveByCredentials()` method, making it consistent with the `AttemptToAuthenticate` action and allowing for custom User Providers to be used.

In our case, we don't have such a complex custom User Provider; we just extend the default `EloquentUserProvider` and override the `retrieveByCredentials()` method to query the username against two columns in the database (email + username).