### PR TITLE
Add schema check for two factor authentication columns in migration file

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -13,18 +13,27 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->text('two_factor_secret')
-                ->after('password')
-                ->nullable();
-
-            $table->text('two_factor_recovery_codes')
-                ->after('two_factor_secret')
-                ->nullable();
-
-            if (Fortify::confirmsTwoFactorAuthentication()) {
-                $table->timestamp('two_factor_confirmed_at')
-                    ->after('two_factor_recovery_codes')
+            if (! Schema::hasColumns(
+                'users',
+                [
+                    'two_factor_secret',
+                    'two_factor_recovery_codes',
+                    'two_factor_confirmed_at',
+                ]
+            )) {
+                $table->text('two_factor_secret')
+                    ->after('password')
                     ->nullable();
+
+                $table->text('two_factor_recovery_codes')
+                    ->after('two_factor_secret')
+                    ->nullable();
+
+                if (Fortify::confirmsTwoFactorAuthentication()) {
+                    $table->timestamp('two_factor_confirmed_at')
+                        ->after('two_factor_recovery_codes')
+                        ->nullable();
+                }
             }
         });
     }


### PR DESCRIPTION
Hi 👋 

I propose this change in the migration file to avoid "existing columns" errors when installing `laravel/fortify` in an existing project.

Thank you very much.