### PR TITLE
Changed migration of users table

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Laravel\Fortify\Fortify;
 
 return new class extends Migration
 {

--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -21,11 +21,9 @@ return new class extends Migration
                 ->after('two_factor_secret')
                 ->nullable();
 
-            if (Fortify::confirmsTwoFactorAuthentication()) {
-                $table->timestamp('two_factor_confirmed_at')
-                    ->after('two_factor_recovery_codes')
-                    ->nullable();
-            }
+            $table->timestamp('two_factor_confirmed_at')
+                ->after('two_factor_recovery_codes')
+                ->nullable();
         });
     }
 
@@ -35,12 +33,11 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn(array_merge([
+            $table->dropColumn([
                 'two_factor_secret',
                 'two_factor_recovery_codes',
-            ], Fortify::confirmsTwoFactorAuthentication() ? [
                 'two_factor_confirmed_at',
-            ] : []));
+            ]);
         });
     }
 };


### PR DESCRIPTION
When the laravel migration is run with TwoFactorAuthentication disabled it will not create the `two_factor_confirmed_at` field in database, but migration is completed.

If you would enable the TwoFactorAuthentication later this will result in a DBException and you have to create a new migration manually.

It would be better to just create the database field, which would allow enabled/disabling of 2FA without migration.
