### PR TITLE
`DisableTwoFactorAuthentication` should always set `two_factor_confirmed_at` to `null` when it has a value

### DIFF
--- a/src/Actions/DisableTwoFactorAuthentication.php
+++ b/src/Actions/DisableTwoFactorAuthentication.php
@@ -21,7 +21,7 @@ class DisableTwoFactorAuthentication
             $user->forceFill([
                 'two_factor_secret' => null,
                 'two_factor_recovery_codes' => null,
-            ] + (Fortify::confirmsTwoFactorAuthentication() ? [
+            ] + (Fortify::confirmsTwoFactorAuthentication() || ! is_null($user->two_factor_confirmed_at) ? [
                 'two_factor_confirmed_at' => null,
             ] : []))->save();
 


### PR DESCRIPTION
fixes #588