### PR TITLE
Prevent empty username fields from being added to requests

### DIFF
--- a/src/Actions/CanonicalizeUsername.php
+++ b/src/Actions/CanonicalizeUsername.php
@@ -16,9 +16,11 @@ class CanonicalizeUsername
      */
     public function handle($request, $next)
     {
-        $request->merge([
-            Fortify::username() => Str::lower($request->{Fortify::username()}),
-        ]);
+        if ($request->has(Fortify::username())) {
+            $request->merge([
+                Fortify::username() => Str::lower($request->{Fortify::username()}),
+            ]);
+        }
 
         return $next($request);
     }

--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -36,7 +36,7 @@ class PasswordResetLinkController extends Controller
     {
         $request->validate([Fortify::email() => 'required|email']);
 
-        if (config('fortify.lowercase_usernames')) {
+        if (config('fortify.lowercase_usernames') && $request->has(Fortify::email())) {
             $request->merge([
                 Fortify::email() => Str::lower($request->{Fortify::email()}),
             ]);

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -21,7 +21,7 @@ class ProfileInformationController extends Controller
     public function update(Request $request,
                            UpdatesUserProfileInformation $updater)
     {
-        if (config('fortify.lowercase_usernames')) {
+        if (config('fortify.lowercase_usernames') && $request->has(Fortify::username())) {
             $request->merge([
                 Fortify::username() => Str::lower($request->{Fortify::username()}),
             ]);

--- a/src/Http/Controllers/RegisteredUserController.php
+++ b/src/Http/Controllers/RegisteredUserController.php
@@ -53,7 +53,7 @@ class RegisteredUserController extends Controller
     public function store(Request $request,
                           CreatesNewUsers $creator): RegisterResponse
     {
-        if (config('fortify.lowercase_usernames')) {
+        if (config('fortify.lowercase_usernames') && $request->has(Fortify::username())) {
             $request->merge([
                 Fortify::username() => Str::lower($request->{Fortify::username()}),
             ]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


Current behavior of `CanonicalizeUsername` and checks related to `config('fortify.lowercase_usernames')` lead to empty fields being added to requests in some cases.

For example, if the request in the call to `src/Http/Controllers/ProfileInformationController.php` did not have whatever is set as `Fortify::username()` defined, an empty definition for `Fortify::username()` would be added to the request, potentially leading to issues during validation. This has happened to me and is the reason why I am making this pull request.