### PR TITLE
Add rate limiter for registration route

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -32,6 +32,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     }
 
     $limiter = config('fortify.limiters.login');
+    $registrationLimiter = config('fortify.limiters.registration');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
 
@@ -75,7 +76,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
+            ->middleware(array_filter([
+                'guest:'.config('fortify.guard'),
+                $registrationLimiter ? 'throttle:'.$registrationLimiter : null,
+            ]))
             ->name('register.store');
     }
 

--- a/stubs/FortifyServiceProvider.php
+++ b/stubs/FortifyServiceProvider.php
@@ -42,5 +42,9 @@ class FortifyServiceProvider extends ServiceProvider
         RateLimiter::for('two-factor', function (Request $request) {
             return Limit::perMinute(5)->by($request->session()->get('login.id'));
         });
+
+        RateLimiter::for('registration', function (Request $request) {
+            return Limit::perMinute(5)->by($request->ip());
+        });
     }
 }

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -117,6 +117,7 @@ return [
     'limiters' => [
         'login' => 'login',
         'two-factor' => 'two-factor',
+        'registration' => 'registration',
     ],
 
     /*


### PR DESCRIPTION
This PR adds an (optional) rate limiter to the registration route to help mitigate abuse. Without throttling, bots or malicious users could potentially create millions of accounts in a short period or perform a denial-of-service attack by overwhelming the endpoint.

## Testing Considerations
I haven't included automated tests for this functionality yet. If someone can offer guidance or assistance on the best approach to test this rate limiter, that would be greatly appreciated.

## Documentation
The UPGRADE.md file currently includes changes to the two-factor rate limiting. I was uncertain, if this addition should be included aswell.

## Rate Limiting Logic
The current logic (5 registrations per minute per IP) is debatable. I welcome discussion on whether this limit should be adjusted, made configurable, or if alternative approaches should be considered.