### PR TITLE
Update error response of password reset, so that they reflect the correct input name for email

### DIFF
--- a/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
+use Laravel\Fortify\Fortify;
 
 class FailedPasswordResetLinkRequestResponse implements FailedPasswordResetLinkRequestResponseContract
 {
@@ -35,12 +36,12 @@ class FailedPasswordResetLinkRequestResponse implements FailedPasswordResetLinkR
     {
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([
-                'email' => [trans($this->status)],
+                Fortify::email() => [trans($this->status)],
             ]);
         }
 
         return back()
-                ->withInput($request->only('email'))
-                ->withErrors(['email' => trans($this->status)]);
+                ->withInput($request->only(Fortify::email()))
+                ->withErrors([Fortify::email() => trans($this->status)]);
     }
 }

--- a/src/Http/Responses/FailedPasswordResetResponse.php
+++ b/src/Http/Responses/FailedPasswordResetResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Fortify\Http\Responses;
 
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
+use Laravel\Fortify\Fortify;
 
 class FailedPasswordResetResponse implements FailedPasswordResetResponseContract
 {
@@ -35,12 +36,12 @@ class FailedPasswordResetResponse implements FailedPasswordResetResponseContract
     {
         if ($request->wantsJson()) {
             throw ValidationException::withMessages([
-                'email' => [trans($this->status)],
+                Fortify::email() => [trans($this->status)],
             ]);
         }
 
         return back()
-                ->withInput($request->only('email'))
-                ->withErrors(['email' => trans($this->status)]);
+                ->withInput($request->only(Fortify::email()))
+                ->withErrors([Fortify::email() => trans($this->status)]);
     }
 }


### PR DESCRIPTION
Currently the default `FailedPasswordResetLinkRequestResponse` and `FailedPasswordResetResponse` return the error message on the hardcoded name "email".

In the Controllers `Fortify::email()` is used to validate the incoming requests, but this configuration option is not reflected in the response classes. 
