### PR TITLE
Registration Rate Limiter Option

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -18,6 +18,7 @@ return [
         'login' => null,
         'two-factor' => null,
         'verification' => '6,1',
+        'registration' => null,
     ],
     'paths' => [
         'login' => null,

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -16,6 +16,8 @@ return [
     'lowercase_usernames' => false,
     'limiters' => [
         'login' => null,
+        'two-factor' => null,
+        'verification' => '6,1',
     ],
     'paths' => [
         'login' => null,

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -34,6 +34,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     $limiter = config('fortify.limiters.login');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
     $verificationLimiter = config('fortify.limiters.verification');
+    $registrationLimiter = config('fortify.limiters.registration');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([
@@ -75,7 +76,10 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         }
 
         Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
+            ->middleware(array_filter([
+                'guest:'.config('fortify.guard'),
+                $registrationLimiter ? 'throttle:'.$registrationLimiter : null,
+            ]))
             ->name('register.store');
     }
 

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -33,7 +33,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     $limiter = config('fortify.limiters.login');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
-    $verificationLimiter = config('fortify.limiters.verification', '6,1');
+    $verificationLimiter = config('fortify.limiters.verification');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
         ->middleware(array_filter([

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -117,6 +117,7 @@ return [
     'limiters' => [
         'login' => 'login',
         'two-factor' => 'two-factor',
+        'registration' => null,
     ],
 
     /*


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds a configurable option for a registration rate limiter. It does not include any rate limits for registration.

It updates some of the config files. Let me know if that's unwanted, happy to pull it out.

## Why?
Most developers would reach for recaptcha/etc for their registration protection needs, but I'm doing something that cannot make external service calls. 

The next best option seems to be a rate limiter based on the MaxMind database's ASN information. But there's no nice way to add a limiter to the registration route right now!