### PR TITLE
Delete existing tokens when user updates password

### DIFF
--- a/src/Http/Controllers/PasswordController.php
+++ b/src/Http/Controllers/PasswordController.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
+use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\PasswordUpdateResponse;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Laravel\Fortify\Events\PasswordUpdatedViaController;
@@ -21,8 +23,20 @@ class PasswordController extends Controller
     {
         $updater->update($request->user(), $request->all());
 
+        $this->broker()->deleteToken($request->user());
+
         event(new PasswordUpdatedViaController($request->user()));
 
         return app(PasswordUpdateResponse::class);
+    }
+
+    /**
+     * Get the broker to be used to delete any existing password reset tokens.
+     *
+     * @return \Illuminate\Contracts\Auth\PasswordBroker
+     */
+    protected function broker(): PasswordBroker
+    {
+        return Password::broker(config('fortify.passwords'));
     }
 }

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -4,9 +4,12 @@ namespace Laravel\Fortify\Tests;
 
 use App\Actions\Fortify\UpdateUserPassword;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
+use Mockery;
 
 class PasswordControllerTest extends OrchestraTestCase
 {
@@ -16,9 +19,20 @@ class PasswordControllerTest extends OrchestraTestCase
     {
         $user = UserFactory::new()->create();
 
+        Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
+
+        $broker->shouldReceive('deleteToken')
+            ->once()
+            ->with($user);
+
         $this->mock(UpdatesUserPasswords::class)
-                    ->shouldReceive('update')
-                    ->once();
+            ->shouldReceive('update')
+            ->once()
+            ->with($user, [
+                'current_password' => 'password',
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ]);
 
         $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/password', [
             'current_password' => 'password',


### PR DESCRIPTION
This prevents an attacker using an existing password reset link after a user has changed their password.

Some more info in the link below. 

https://community.auth0.com/t/invalidating-password-reset-links-after-password-change/150437?utm_source=chatgpt.com

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
