### PR TITLE
feat() : make Fortify honour Model::encryptUsing to enable app key rotation

### DIFF
--- a/src/Actions/ConfirmTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmTwoFactorAuthentication.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Fortify\Actions;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
@@ -37,7 +39,7 @@ class ConfirmTwoFactorAuthentication
     {
         if (empty($user->two_factor_secret) ||
             empty($code) ||
-            ! $this->provider->verify(decrypt($user->two_factor_secret), $code)) {
+            ! $this->provider->verify((Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($user->two_factor_secret), $code)) {
             throw ValidationException::withMessages([
                 'code' => [__('The provided two factor authentication code was invalid.')],
             ])->errorBag('confirmTwoFactorAuthentication');

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Fortify\Actions;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
 use Laravel\Fortify\RecoveryCode;
@@ -40,8 +42,8 @@ class EnableTwoFactorAuthentication
             $secretLength = (int) config('fortify-options.two-factor-authentication.secret-length', 16);
 
             $user->forceFill([
-                'two_factor_secret' => encrypt($this->provider->generateSecretKey($secretLength)),
-                'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
+                'two_factor_secret' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt($this->provider->generateSecretKey($secretLength)),
+                'two_factor_recovery_codes' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt(json_encode(Collection::times(8, function () {
                     return RecoveryCode::generate();
                 })->all())),
             ])->save();

--- a/src/Actions/GenerateNewRecoveryCodes.php
+++ b/src/Actions/GenerateNewRecoveryCodes.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Fortify\Actions;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Events\RecoveryCodesGenerated;
 use Laravel\Fortify\RecoveryCode;
 
@@ -17,7 +19,7 @@ class GenerateNewRecoveryCodes
     public function __invoke($user)
     {
         $user->forceFill([
-            'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
+            'two_factor_recovery_codes' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt(json_encode(Collection::times(8, function () {
                 return RecoveryCode::generate();
             })->all())),
         ])->save();

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 use Laravel\Fortify\Contracts\RecoveryCodesGeneratedResponse;
 
@@ -22,7 +24,7 @@ class RecoveryCodeController extends Controller
             return [];
         }
 
-        return response()->json(json_decode(decrypt(
+        return response()->json(json_decode((Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt(
             $request->user()->two_factor_recovery_codes
         ), true));
     }

--- a/src/Http/Controllers/TwoFactorSecretKeyController.php
+++ b/src/Http/Controllers/TwoFactorSecretKeyController.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Crypt;
 
 class TwoFactorSecretKeyController extends Controller
 {
@@ -20,7 +22,7 @@ class TwoFactorSecretKeyController extends Controller
         }
 
         return response()->json([
-            'secretKey' => decrypt($request->user()->two_factor_secret),
+            'secretKey' => (Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($request->user()->two_factor_secret),
         ]);
     }
 }

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -3,8 +3,10 @@
 namespace Laravel\Fortify\Http\Requests;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 
@@ -55,7 +57,7 @@ class TwoFactorLoginRequest extends FormRequest
     public function hasValidCode()
     {
         return $this->code && tap(app(TwoFactorAuthenticationProvider::class)->verify(
-            decrypt($this->challengedUser()->two_factor_secret), $this->code
+            (Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($this->challengedUser()->two_factor_secret), $this->code
         ), function ($result) {
             if ($result) {
                 $this->session()->forget('login.id');

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -2,8 +2,11 @@
 
 namespace Laravel\Fortify\Tests;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
 use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
 use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
@@ -238,5 +241,30 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
 
         $this->assertNull($user->two_factor_secret);
         $this->assertNull($user->two_factor_recovery_codes);
+    }
+
+    public function test_two_factor_authentication_secret_key_can_be_retrieved_with_model_encrypter()
+    {
+        Event::fake();
+
+        Model::encryptUsing(new Encrypter(
+            base64_decode(Str::after('base64:FXvqP4Rg3XycgbIND25bhmjYiiFn1Z+AuAC98GU3Cew=', 'base64:')),
+            'aes-256-gcm',
+        ));
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => Model::$encrypter->encrypt('foo'),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->getJson(
+            '/user/two-factor-secret-key'
+        );
+
+        $response->assertStatus(200);
+
+        $this->assertEquals('foo', $response->original['secretKey']);
     }
 }


### PR DESCRIPTION
Currently Laravel Fortify not using the encrypter defined in `Model::encryptUsing()` method (if any).

This can cause some difficulties rotating the `APP_KEY`, as without having a separate encrypter for the encrypted model attributes the maintainer have to re-encrypt the `two_factor_secret` and `two_factor_recovery_codes` fields for every user in the database before setting the new key. 

And theoretically speaking as these fields are encrypted model attributes, the package writing and reading these should honour the frameworks settings for encyrpting them.

This PR changes this, making Fortify to use the `Model::$encrypter` if defined, or fall back to the `Crypt::getFacadeRoot()`.

PS: _Unfortunately I could not use the `Model::currentEncrypter()` method, as it was introduced in Laravel 11, but Fortify still supports Laravel 10 as far as I understand._

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
