### PR TITLE
fix: add missing route name to `/user/two-factor-recovery-codes`

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -169,6 +169,6 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
         Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
             ->middleware($twoFactorMiddleware)
-            ->name('two-factor.recovery-codes.regenerate');
+            ->name('two-factor.regenerate-recovery-codes');
     }
 });

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -168,6 +168,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             ->name('two-factor.recovery-codes');
 
         Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
-            ->middleware($twoFactorMiddleware);
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.recevory-codes.regenerate');
     }
 });

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -169,6 +169,6 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
         Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
             ->middleware($twoFactorMiddleware)
-            ->name('two-factor.recevory-codes.regenerate');
+            ->name('two-factor.recovery-codes.regenerate');
     }
 });


### PR DESCRIPTION
Hello 👋,

The route `/user/two-factor-recovery-codes` does not have a name. That's not a real issue but with Wayfinder, there is no route generate which makes it impossible to use with `form.submit()`. The workaround is to use the `actions` instead which breaks the coherence within my project.