### PR TITLE
Validate password is a string when confirming password

### DIFF
--- a/src/Http/Controllers/ConfirmablePasswordController.php
+++ b/src/Http/Controllers/ConfirmablePasswordController.php
@@ -10,6 +10,7 @@ use Laravel\Fortify\Actions\ConfirmPassword;
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse;
+use Laravel\Fortify\Http\Requests\ConfirmPasswordRequest;
 
 class ConfirmablePasswordController extends Controller
 {
@@ -45,10 +46,10 @@ class ConfirmablePasswordController extends Controller
     /**
      * Confirm the user's password.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Laravel\Fortify\Http\Requests\ConfirmPasswordRequest  $request
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request)
+    public function store(ConfirmPasswordRequest $request)
     {
         $confirmed = app(ConfirmPassword::class)(
             $this->guard, $request->user(), $request->input('password')

--- a/src/Http/Requests/ConfirmPasswordRequest.php
+++ b/src/Http/Requests/ConfirmPasswordRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Fortify\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConfirmPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'password' => 'nullable|string',
+        ];
+    }
+}

--- a/tests/ConfirmablePasswordControllerTest.php
+++ b/tests/ConfirmablePasswordControllerTest.php
@@ -205,6 +205,16 @@ class ConfirmablePasswordControllerTest extends OrchestraTestCase
             ->assertHeaderMissing('X-Retry-After');
     }
 
+    public function test_password_must_be_a_string()
+    {
+        $response = $this->actingAs($this->user)->post('/user/confirm-password', [
+            'password' => [],
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['password']);
+    }
+
     protected function defineEnvironment($app)
     {
         parent::defineEnvironment($app);


### PR DESCRIPTION
A type error can occur when the `password` input is not a string or null.

https://github.com/laravel/fortify/blob/72701af72327f5c3c0712fc42d2f16c382279d06/src/Actions/ConfirmPassword.php#L18

This PR adds form validation to ensure the password field is either a string or null.