### PR TITLE
Add `Fortify::encryptUsing()` to allow customising the default encryption

### DIFF
--- a/src/Actions/ConfirmTwoFactorAuthentication.php
+++ b/src/Actions/ConfirmTwoFactorAuthentication.php
@@ -2,11 +2,10 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
+use Laravel\Fortify\Fortify;
 
 class ConfirmTwoFactorAuthentication
 {
@@ -39,7 +38,7 @@ class ConfirmTwoFactorAuthentication
     {
         if (empty($user->two_factor_secret) ||
             empty($code) ||
-            ! $this->provider->verify((Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($user->two_factor_secret), $code)) {
+            ! $this->provider->verify(Fortify::currentEncrypter()->decrypt($user->two_factor_secret), $code)) {
             throw ValidationException::withMessages([
                 'code' => [__('The provided two factor authentication code was invalid.')],
             ])->errorBag('confirmTwoFactorAuthentication');

--- a/src/Actions/EnableTwoFactorAuthentication.php
+++ b/src/Actions/EnableTwoFactorAuthentication.php
@@ -2,11 +2,10 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\RecoveryCode;
 
 class EnableTwoFactorAuthentication
@@ -42,8 +41,8 @@ class EnableTwoFactorAuthentication
             $secretLength = (int) config('fortify-options.two-factor-authentication.secret-length', 16);
 
             $user->forceFill([
-                'two_factor_secret' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt($this->provider->generateSecretKey($secretLength)),
-                'two_factor_recovery_codes' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt(json_encode(Collection::times(8, function () {
+                'two_factor_secret' => Fortify::currentEncrypter()->encrypt($this->provider->generateSecretKey($secretLength)),
+                'two_factor_recovery_codes' => Fortify::currentEncrypter()->encrypt(json_encode(Collection::times(8, function () {
                     return RecoveryCode::generate();
                 })->all())),
             ])->save();

--- a/src/Actions/GenerateNewRecoveryCodes.php
+++ b/src/Actions/GenerateNewRecoveryCodes.php
@@ -2,10 +2,9 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Events\RecoveryCodesGenerated;
+use Laravel\Fortify\Fortify;
 use Laravel\Fortify\RecoveryCode;
 
 class GenerateNewRecoveryCodes
@@ -19,7 +18,7 @@ class GenerateNewRecoveryCodes
     public function __invoke($user)
     {
         $user->forceFill([
-            'two_factor_recovery_codes' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt(json_encode(Collection::times(8, function () {
+            'two_factor_recovery_codes' => Fortify::currentEncrypter()->encrypt(json_encode(Collection::times(8, function () {
                 return RecoveryCode::generate();
             })->all())),
         ])->save();

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Fortify;
 
+use Illuminate\Database\Eloquent\Model;
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\LoginViewResponse;
@@ -45,6 +46,13 @@ class Fortify
      * @var bool
      */
     public static $registersRoutes = true;
+
+    /**
+     * The encrypter instance that is used to encrypt attributes.
+     *
+     * @var \Illuminate\Contracts\Encryption\Encrypter|null
+     */
+    public static $encrypter;
 
     const PASSWORD_UPDATED = 'password-updated';
     const PROFILE_INFORMATION_UPDATED = 'profile-information-updated';
@@ -312,6 +320,29 @@ class Fortify
     {
         return Features::enabled(Features::twoFactorAuthentication()) &&
                Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm');
+    }
+
+    /**
+     * Set the encrypter instance that will be used to encrypt attributes.
+     *
+     * @param  \Illuminate\Contracts\Encryption\Encrypter|null  $encrypter
+     * @return static
+     */
+    public static function encryptUsing($encrypter)
+    {
+        static::$encrypter = $encrypter;
+
+        return new static;
+    }
+
+    /**
+     * Get the current encrypter being used by the model.
+     *
+     * @return \Illuminate\Contracts\Encryption\Encrypter
+     */
+    public static function currentEncrypter()
+    {
+        return static::$encrypter ?? Model::$encrypter ?? Crypt::getFacadeRoot();
     }
 
     /**

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\LoginViewResponse;

--- a/src/Http/Controllers/RecoveryCodeController.php
+++ b/src/Http/Controllers/RecoveryCodeController.php
@@ -2,12 +2,11 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 use Laravel\Fortify\Contracts\RecoveryCodesGeneratedResponse;
+use Laravel\Fortify\Fortify;
 
 class RecoveryCodeController extends Controller
 {
@@ -24,7 +23,7 @@ class RecoveryCodeController extends Controller
             return [];
         }
 
-        return response()->json(json_decode((Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt(
+        return response()->json(json_decode(Fortify::currentEncrypter()->decrypt(
             $request->user()->two_factor_recovery_codes
         ), true));
     }

--- a/src/Http/Controllers/TwoFactorSecretKeyController.php
+++ b/src/Http/Controllers/TwoFactorSecretKeyController.php
@@ -2,10 +2,9 @@
 
 namespace Laravel\Fortify\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Crypt;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorSecretKeyController extends Controller
 {
@@ -22,7 +21,7 @@ class TwoFactorSecretKeyController extends Controller
         }
 
         return response()->json([
-            'secretKey' => (Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($request->user()->two_factor_secret),
+            'secretKey' => Fortify::currentEncrypter()->decrypt($request->user()->two_factor_secret),
         ]);
     }
 }

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -3,12 +3,11 @@
 namespace Laravel\Fortify\Http\Requests;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorLoginRequest extends FormRequest
 {
@@ -57,7 +56,7 @@ class TwoFactorLoginRequest extends FormRequest
     public function hasValidCode()
     {
         return $this->code && tap(app(TwoFactorAuthenticationProvider::class)->verify(
-            (Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($this->challengedUser()->two_factor_secret), $this->code
+            Fortify::currentEncrypter()->decrypt($this->challengedUser()->two_factor_secret), $this->code
         ), function ($result) {
             if ($result) {
                 $this->session()->forget('login.id');

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -8,8 +8,6 @@ use BaconQrCode\Renderer\ImageRenderer;
 use BaconQrCode\Renderer\RendererStyle\Fill;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 use Laravel\Fortify\Events\RecoveryCodeReplaced;
 
@@ -37,7 +35,7 @@ trait TwoFactorAuthenticatable
      */
     public function recoveryCodes()
     {
-        return json_decode((Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($this->two_factor_recovery_codes), true);
+        return json_decode(Fortify::currentEncrypter()->decrypt($this->two_factor_recovery_codes), true);
     }
 
     /**
@@ -49,10 +47,10 @@ trait TwoFactorAuthenticatable
     public function replaceRecoveryCode($code)
     {
         $this->forceFill([
-            'two_factor_recovery_codes' => (Model::$encrypter ?? Crypt::getFacadeRoot())->encrypt(str_replace(
+            'two_factor_recovery_codes' => Fortify::currentEncrypter()->encrypt(str_replace(
                 $code,
                 RecoveryCode::generate(),
-                (Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($this->two_factor_recovery_codes)
+                Fortify::currentEncrypter()->decrypt($this->two_factor_recovery_codes)
             )),
         ])->save();
 
@@ -86,7 +84,7 @@ trait TwoFactorAuthenticatable
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
             $this->{Fortify::username()},
-            (Model::$encrypter ?? Crypt::getFacadeRoot())->decrypt($this->two_factor_secret)
+            Fortify::currentEncrypter()->decrypt($this->two_factor_secret)
         );
     }
 }

--- a/tests/PasswordControllerTest.php
+++ b/tests/PasswordControllerTest.php
@@ -48,7 +48,7 @@ class PasswordControllerTest extends OrchestraTestCase
         $user = UserFactory::new()->create();
 
         try {
-            (new UpdateUserPassword())->update($user, [
+            (new UpdateUserPassword)->update($user, [
                 'password' => 'new-password',
                 'password_confirmation' => 'new-password',
             ]);
@@ -65,7 +65,7 @@ class PasswordControllerTest extends OrchestraTestCase
         $user = UserFactory::new()->create();
 
         try {
-            (new UpdateUserPassword())->update($user, [
+            (new UpdateUserPassword)->update($user, [
                 'current_password' => 'invalid-password',
                 'password' => 'new-password',
                 'password_confirmation' => 'new-password',


### PR DESCRIPTION
fix #607

Existing applications using `Model::encryptUsing()` are unable to upgrade to [1.28.0](https://github.com/laravel/fortify/releases/tag/v1.28.0) due to the change from using the app's default encryption to `Model::$encrypter`. 

They now can use the latest version by adding this to `FortifyServiceProvider`:

```php
use Illuminate\Support\Facades\Crypt;

class FortifyServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        //
    }

    /**
     * Bootstrap any application services.
     */
    public function boot(): void
    {
        Fortify::encryptUsing(fn () => Crypt::getFacadeRoot());
    }
}
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
