### PR TITLE
[1.x] Add Laravel Fortify guidelines for boost

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,24 @@
+## Laravel Fortify
+
+Fortify is a headless authentication backend that provides routes and controllers but no views.
+**Before implementing any auth features, use the `search-docs` tool to get the latest docs for that specific feature.**
+
+### Configuration & Setup
+- Check `config/fortify.php` to see what's enabled. Use `search-docs` for detailed info on specific features.
+- Enable features by adding them to the `'features' => []` array: `Features::registration()`, `Features::resetPasswords()`, etc.
+- To see the all fortify registered routes use the `list-routes` tool with `only_vendor: true` and `action: "Fortify"` parameters.
+- Fortify includes view routes by default (login, register screens). Set `'views' => false` in config to disable them if you're handling views yourself.
+
+### Customization
+- Customize views in `FortifyServiceProvider`'s `boot()` method using `Fortify::loginView()`, `Fortify::registerView()`, etc.
+- Customize authentication logic with `Fortify::authenticateUsing()` for custom user retrieval/validation.
+- Actions in `app/Actions/Fortify/` handle business logic (user creation, password reset, etc.). They're fully customizable, so modify them to change feature behavior.
+
+## Available Features
+- `Features::registration()` for user registration
+- `Features::resetPasswords()` for password reset via email
+- `Features::emailVerification()` to verify new user emails
+- `Features::updateProfileInformation()` to let users update their profile
+- `Features::updatePasswords()` to let users change passwords
+- `Features::twoFactorAuthentication()` for 2FA with QR codes and recovery codes
+  - Add options: `['confirmPassword'=>true, 'confirm' => true]` to require password confirmation and confirm otp before enabling 2FA

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,24 +1,25 @@
 ## Laravel Fortify
 
-Fortify is a headless authentication backend that provides routes and controllers but no views.
-**Before implementing any auth features, use the `search-docs` tool to get the latest docs for that specific feature.**
+Fortify is a headless authentication backend that provides authentication routes and controllers for Laravel applications.
+
+**Before implementing any authentication features, use the `search-docs` tool to get the latest docs for that specific feature.**
 
 ### Configuration & Setup
-- Check `config/fortify.php` to see what's enabled. Use `search-docs` for detailed info on specific features.
+- Check `config/fortify.php` to see what's enabled. Use `search-docs` for detailed information on specific features.
 - Enable features by adding them to the `'features' => []` array: `Features::registration()`, `Features::resetPasswords()`, etc.
-- To see the all fortify registered routes use the `list-routes` tool with `only_vendor: true` and `action: "Fortify"` parameters.
-- Fortify includes view routes by default (login, register screens). Set `'views' => false` in config to disable them if you're handling views yourself.
+- To see the all Fortify registered routes, use the `list-routes` tool with the `only_vendor: true` and `action: "Fortify"` parameters.
+- Fortify includes view routes by default (login, register). Set `'views' => false` in the configuration file to disable them if you're handling views yourself.
 
 ### Customization
-- Customize views in `FortifyServiceProvider`'s `boot()` method using `Fortify::loginView()`, `Fortify::registerView()`, etc.
-- Customize authentication logic with `Fortify::authenticateUsing()` for custom user retrieval/validation.
-- Actions in `app/Actions/Fortify/` handle business logic (user creation, password reset, etc.). They're fully customizable, so modify them to change feature behavior.
+- Views can be customized in `FortifyServiceProvider`'s `boot()` method using `Fortify::loginView()`, `Fortify::registerView()`, etc.
+- Customize authentication logic with `Fortify::authenticateUsing()` for custom user retrieval / validation.
+- Actions in `app/Actions/Fortify/` handle business logic (user creation, password reset, etc.). They're fully customizable, so you can modify them to change feature behavior.
 
 ## Available Features
-- `Features::registration()` for user registration
-- `Features::resetPasswords()` for password reset via email
-- `Features::emailVerification()` to verify new user emails
-- `Features::updateProfileInformation()` to let users update their profile
-- `Features::updatePasswords()` to let users change passwords
-- `Features::twoFactorAuthentication()` for 2FA with QR codes and recovery codes
-  - Add options: `['confirmPassword'=>true, 'confirm' => true]` to require password confirmation and confirm otp before enabling 2FA
+- `Features::registration()` for user registration.
+- `Features::emailVerification()` to verify new user emails.
+- `Features::twoFactorAuthentication()` for 2FA with QR codes and recovery codes.
+  - Add options: `['confirmPassword' => true, 'confirm' => true]` to require password confirmation and OTP confirmation before enabling 2FA.
+- `Features::updateProfileInformation()` to let users update their profile.
+- `Features::updatePasswords()` to let users change their passwords.
+- `Features::resetPasswords()` for password reset via email.


### PR DESCRIPTION
This pull request adds Laravel Fortify guidelines for Laravel Boost which can be used by Boost Third-Party Package AI Guidelines. User will be prompted if they need guidelines before installing so completely optional.