### PR TITLE
Extract credential validation logic and use StatefulGuard::once

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -2,14 +2,14 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Auth\Events\Failed;
-use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Validation\ValidationException;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\LoginRateLimiter;
+use Laravel\Fortify\ValidatesCredentials;
+use Illuminate\Contracts\Auth\StatefulGuard;
 
 class AttemptToAuthenticate
 {
+    use ValidatesCredentials;
+
     /**
      * The guard implementation.
      *
@@ -46,70 +46,10 @@ class AttemptToAuthenticate
      */
     public function handle($request, $next)
     {
-        if (Fortify::$authenticateUsingCallback) {
-            return $this->handleUsingCustomCallback($request, $next);
-        }
-
-        if ($this->guard->attempt(
-            $request->only(Fortify::username(), 'password'),
-            $request->boolean('remember'))
-        ) {
-            return $next($request);
-        }
-
-        $this->throwFailedAuthenticationException($request);
-    }
-
-    /**
-     * Attempt to authenticate using a custom callback.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  callable  $next
-     * @return mixed
-     */
-    protected function handleUsingCustomCallback($request, $next)
-    {
-        $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
-
-        if (! $user) {
-            $this->fireFailedEvent($request);
-
-            return $this->throwFailedAuthenticationException($request);
-        }
+        $user = $this->guard->user() ?? $this->validateCredentials($request);
 
         $this->guard->login($user, $request->boolean('remember'));
-
+        
         return $next($request);
-    }
-
-    /**
-     * Throw a failed authentication validation exception.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    protected function throwFailedAuthenticationException($request)
-    {
-        $this->limiter->increment($request);
-
-        throw ValidationException::withMessages([
-            Fortify::username() => [trans('auth.failed')],
-        ]);
-    }
-
-    /**
-     * Fire the failed authentication attempt event with the given arguments.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    protected function fireFailedEvent($request)
-    {
-        event(new Failed($this->guard?->name ?? config('fortify.guard'), null, [
-            Fortify::username() => $request->{Fortify::username()},
-            'password' => $request->password,
-        ]));
     }
 }

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -2,17 +2,18 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Auth\Events\Failed;
-use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Validation\ValidationException;
-use Laravel\Fortify\Contracts\RedirectsIfTwoFactorAuthenticatable;
-use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
 use Laravel\Fortify\Fortify;
 use Laravel\Fortify\LoginRateLimiter;
+use Laravel\Fortify\ValidatesCredentials;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
+use Laravel\Fortify\Contracts\RedirectsIfTwoFactorAuthenticatable;
 
 class RedirectIfTwoFactorAuthenticatable implements RedirectsIfTwoFactorAuthenticatable
 {
+    use ValidatesCredentials;
+
     /**
      * The guard implementation.
      *
@@ -49,7 +50,7 @@ class RedirectIfTwoFactorAuthenticatable implements RedirectsIfTwoFactorAuthenti
      */
     public function handle($request, $next)
     {
-        $user = $this->validateCredentials($request);
+        $user = $this->guard->user() ?? $this->validateCredentials($request);
 
         if (Fortify::confirmsTwoFactorAuthentication() &&
             is_null(optional($user)->two_factor_confirmed_at)) {
@@ -62,71 +63,6 @@ class RedirectIfTwoFactorAuthenticatable implements RedirectsIfTwoFactorAuthenti
         }
 
         return $next($request);
-    }
-
-    /**
-     * Attempt to validate the incoming credentials.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     */
-    protected function validateCredentials($request)
-    {
-        if (Fortify::$authenticateUsingCallback) {
-            return tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request) {
-                if (! $user) {
-                    $this->fireFailedEvent($request);
-
-                    $this->throwFailedAuthenticationException($request);
-                }
-            });
-        }
-
-        $provider = $this->guard->getProvider();
-
-        return tap($provider->retrieveByCredentials($request->only(Fortify::username(), 'password')), function ($user) use ($provider, $request) {
-            if (! $user || ! $provider->validateCredentials($user, ['password' => $request->password])) {
-                $this->fireFailedEvent($request, $user);
-
-                $this->throwFailedAuthenticationException($request);
-            }
-
-            if (config('hashing.rehash_on_login', true) && method_exists($provider, 'rehashPasswordIfRequired')) {
-                $provider->rehashPasswordIfRequired($user, ['password' => $request->password]);
-            }
-        });
-    }
-
-    /**
-     * Throw a failed authentication validation exception.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    protected function throwFailedAuthenticationException($request)
-    {
-        $this->limiter->increment($request);
-
-        throw ValidationException::withMessages([
-            Fortify::username() => [trans('auth.failed')],
-        ]);
-    }
-
-    /**
-     * Fire the failed authentication attempt event with the given arguments.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
-     * @return void
-     */
-    protected function fireFailedEvent($request, $user = null)
-    {
-        event(new Failed($this->guard?->name ?? config('fortify.guard'), $user, [
-            Fortify::username() => $request->{Fortify::username()},
-            'password' => $request->password,
-        ]));
     }
 
     /**

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -51,14 +51,9 @@ class RedirectIfTwoFactorAuthenticatable implements RedirectsIfTwoFactorAuthenti
     {
         $user = $this->validateCredentials($request);
 
-        if (Fortify::confirmsTwoFactorAuthentication()) {
-            if (optional($user)->two_factor_secret &&
-                ! is_null(optional($user)->two_factor_confirmed_at) &&
-                in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
-                return $this->twoFactorChallengeResponse($request, $user);
-            } else {
-                return $next($request);
-            }
+        if (Fortify::confirmsTwoFactorAuthentication() &&
+            is_null(optional($user)->two_factor_confirmed_at)) {
+            return $next($request);
         }
 
         if (optional($user)->two_factor_secret &&

--- a/src/ValidatesCredentials.php
+++ b/src/ValidatesCredentials.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Fortify;
+
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Fortify;
+
+trait ValidatesCredentials
+{
+    /**
+     * Attempt to validate the credentials given in the request.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function validateCredentials($request)
+    {
+        if (Fortify::$authenticateUsingCallback) {
+            $user = $this->handleUsingCustomCallback($request);
+        } else {
+            $this->guard->once($request->only(Fortify::username(), 'password'));
+            $user = $this->guard->user();
+        }
+
+        if (! $user) {
+            $this->throwFailedAuthenticationException($request);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Attempt to authenticate using a custom callback.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    protected function handleUsingCustomCallback($request)
+    {
+        $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
+
+        if (! $user) {
+            $this->fireFailedEvent($request);
+
+            return null;
+        }
+
+        $this->guard->setUser($user);
+
+        return $user;
+    }
+
+    /**
+     * Throw a failed authentication validation exception.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    protected function throwFailedAuthenticationException($request)
+    {
+        $this->limiter->increment($request);
+        
+        throw ValidationException::withMessages([
+            Fortify::username() => [trans('auth.failed')],
+        ]);
+    }
+
+    /**
+     * Fire the failed authentication attempt event with the given arguments.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function fireFailedEvent($request)
+    {
+        event(new Failed($this->guard?->name ?? config('fortify.guard'), null, [
+            Fortify::username() => $request->{Fortify::username()},
+            'password' => $request->password,
+        ]));
+    }
+}


### PR DESCRIPTION
#### What this PR addresses
I am currently working on a project that requires users with passwords older than 90 days to reset them when they log in. My plan was to essentially copy `RedirectIfTwoFactorAuthenticatable` and make a few adjustments, since there are some similarities in the desired flow. After looking at `RedirectIfTwoFactorAuthenticatable::validateCredentials`, I noticed some issues in how it handles credential validation. Because it skips the guard entirely and validates directly with the provider, the `Attempting` and `Validated` events are not fired, and `rehashPasswordIfRequired` has to be manually called. Also, it appears that nowhere during the 2FA process does the `Authenticated` event fire.

To avoid having to upkeep `RedirectIfTwoFactorAuthenticatable` to match the login logic from `SessionGuard`, I thought it would be best to utilize the existing authentication logic by using `StatefulGuard::once` to validate credentials. The credential validation logic is now extracted to a new trait `ValidatesCredentials`, which can be added to any pipeline action that needs to do so (great for my expired password use-case).

#### Possible issues
I tried to implement this as to avoid breaking changes, but there are still a few possible issues.
- Some Laravel projects may be functioning on the assumption that the `Attempting`, `Validated`, and `Authenticated` events will **not** fire in `RedirectIfTwoFactorAuthenticatable`.
- `AttemptToAuthenticate` used to use `StatefulGuard::attempt`, which would have fired all those events a second time. I switched it to use `StatefulGuard::login` to bypass those events. However, some Laravel projects may have their own implementation of `AttemptToAuthenticate` that will still fire the events a second time.
- When `StatefulGuard::once` is triggered in `RedirectIfTwoFactorAuthenticatable`, it will authenticate the user for the remainder of the current request only. Some Laravel projects may function under the assumption that there will be no authenticated user until `AttemptToAuthenticate`. An alternative might be to immediately clear the validated user after `StatefulGuard::once`, and pass the validated user through the authentication pipeline using a static property on the `Fortify` class.
- The new `ValidatesCredentials` trait assumes that the `$guard` and `$limiter` properties exist on the parent class. I can't think of any alternatives that wouldn't introduce a possible breaking change. Maybe class inheritance instead of a trait would work, but it didn't seem appropriate for this.
