### PR TITLE
Resolves issue #592 - RecoveryCodeReplaced event dispatched twice

### DIFF
--- a/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -60,8 +60,6 @@ class TwoFactorAuthenticatedSessionController extends Controller
 
         if ($code = $request->validRecoveryCode()) {
             $user->replaceRecoveryCode($code);
-
-            event(new RecoveryCodeReplaced($user, $code));
         } elseif (! $request->hasValidCode()) {
             event(new TwoFactorAuthenticationFailed($user));
 


### PR DESCRIPTION
Resolves the issue by removing the manual event trigger from the TwoFactorAuthenticatedSessionController::store function.