### PR TITLE
[1.x] Add `Features::canUpdatePasswords()` method

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -62,7 +62,7 @@ class Features
     }
 
     /**
-     * Determine if the application can user passwords.
+     * Determine if the application can update user passwords.
      *
      * @return bool
      */

--- a/src/Features.php
+++ b/src/Features.php
@@ -62,11 +62,11 @@ class Features
     }
 
     /**
-     * Determine if the application can update a user's password.
+     * Determine if the application can user passwords.
      *
      * @return bool
      */
-    public static function canUpdatePassword()
+    public static function canUpdatePasswords()
     {
         return static::enabled(static::updatePasswords());
     }

--- a/src/Features.php
+++ b/src/Features.php
@@ -62,6 +62,16 @@ class Features
     }
 
     /**
+     * Determine if the application can update a user's password.
+     *
+     * @return bool
+     */
+    public static function canUpdatePassword()
+    {
+        return static::enabled(static::updatePasswords());
+    }
+
+    /**
      * Determine if the application can manage two factor authentication.
      *
      * @return bool


### PR DESCRIPTION
This PR will allow calls to `Features::enabled(Features::updatePasswords)` to be simplified can be updated by adding a `canUpdatePasswords` method in `Features.php` similar to the current `canUpdateProfileInformation` and `canManageTwoFactorAuthentication` methods.

## Usage
Current:
```php
if (Features::enabled(Features::updatePasswords())) {
    Route::get('settings/password', [PasswordController::class, 'edit'])
        ->name('password.edit');
}
```

After PR:
```php
if (Features::canUpdatePasswords()) {
    Route::get('settings/password', [PasswordController::class, 'edit'])
        ->name('password.edit');
}
```
