### PR TITLE
Extract credential validation logic and use StatefulGuard::once

### DIFF
--- a/src/Actions/AttemptToAuthenticate.php
+++ b/src/Actions/AttemptToAuthenticate.php
@@ -2,39 +2,26 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Auth\Events\Failed;
-use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Validation\ValidationException;
-use Laravel\Fortify\Fortify;
-use Laravel\Fortify\LoginRateLimiter;
+use Laravel\Fortify\CredentialsValidator;
 
 class AttemptToAuthenticate
 {
     /**
-     * The guard implementation.
+     * The credentials validator instance.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var \Laravel\Fortify\CredentialsValidator
      */
-    protected $guard;
-
-    /**
-     * The login rate limiter instance.
-     *
-     * @var \Laravel\Fortify\LoginRateLimiter
-     */
-    protected $limiter;
+    protected $validator;
 
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
-     * @param  \Laravel\Fortify\LoginRateLimiter  $limiter
+     * @param  \Laravel\Fortify\CredentialsValidator  $validator
      * @return void
      */
-    public function __construct(StatefulGuard $guard, LoginRateLimiter $limiter)
+    public function __construct(CredentialsValidator $validator)
     {
-        $this->guard = $guard;
-        $this->limiter = $limiter;
+        $this->validator = $validator;
     }
 
     /**
@@ -46,70 +33,8 @@ class AttemptToAuthenticate
      */
     public function handle($request, $next)
     {
-        if (Fortify::$authenticateUsingCallback) {
-            return $this->handleUsingCustomCallback($request, $next);
-        }
-
-        if ($this->guard->attempt(
-            $request->only(Fortify::username(), 'password'),
-            $request->boolean('remember'))
-        ) {
-            return $next($request);
-        }
-
-        $this->throwFailedAuthenticationException($request);
-    }
-
-    /**
-     * Attempt to authenticate using a custom callback.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  callable  $next
-     * @return mixed
-     */
-    protected function handleUsingCustomCallback($request, $next)
-    {
-        $user = call_user_func(Fortify::$authenticateUsingCallback, $request);
-
-        if (! $user) {
-            $this->fireFailedEvent($request);
-
-            return $this->throwFailedAuthenticationException($request);
-        }
-
-        $this->guard->login($user, $request->boolean('remember'));
-
+        $this->validator->getGuard()->login($this->validator->validateCredentials($request), $request->boolean('remember'));
+        
         return $next($request);
-    }
-
-    /**
-     * Throw a failed authentication validation exception.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    protected function throwFailedAuthenticationException($request)
-    {
-        $this->limiter->increment($request);
-
-        throw ValidationException::withMessages([
-            Fortify::username() => [trans('auth.failed')],
-        ]);
-    }
-
-    /**
-     * Fire the failed authentication attempt event with the given arguments.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    protected function fireFailedEvent($request)
-    {
-        event(new Failed($this->guard?->name ?? config('fortify.guard'), null, [
-            Fortify::username() => $request->{Fortify::username()},
-            'password' => $request->password,
-        ]));
     }
 }

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -50,14 +50,9 @@ class RedirectIfTwoFactorAuthenticatable
     {
         $user = $this->validateCredentials($request);
 
-        if (Fortify::confirmsTwoFactorAuthentication()) {
-            if (optional($user)->two_factor_secret &&
-                ! is_null(optional($user)->two_factor_confirmed_at) &&
-                in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user))) {
-                return $this->twoFactorChallengeResponse($request, $user);
-            } else {
-                return $next($request);
-            }
+        if (Fortify::confirmsTwoFactorAuthentication() &&
+            is_null(optional($user)->two_factor_confirmed_at)) {
+            return $next($request);
         }
 
         if (optional($user)->two_factor_secret &&

--- a/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -2,41 +2,29 @@
 
 namespace Laravel\Fortify\Actions;
 
-use Illuminate\Auth\Events\Failed;
-use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Validation\ValidationException;
-use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
 use Laravel\Fortify\Fortify;
-use Laravel\Fortify\LoginRateLimiter;
+use Laravel\Fortify\CredentialsValidator;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
 
 class RedirectIfTwoFactorAuthenticatable
 {
     /**
-     * The guard implementation.
+     * The credentials validator instance.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var \Laravel\Fortify\CredentialsValidator
      */
-    protected $guard;
-
-    /**
-     * The login rate limiter instance.
-     *
-     * @var \Laravel\Fortify\LoginRateLimiter
-     */
-    protected $limiter;
+    protected $validator;
 
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
-     * @param  \Laravel\Fortify\LoginRateLimiter  $limiter
+     * @param  \Laravel\Fortify\CredentialsValidator  $validator
      * @return void
      */
-    public function __construct(StatefulGuard $guard, LoginRateLimiter $limiter)
+    public function __construct(CredentialsValidator $validator)
     {
-        $this->guard = $guard;
-        $this->limiter = $limiter;
+        $this->validator = $validator;
     }
 
     /**
@@ -48,7 +36,7 @@ class RedirectIfTwoFactorAuthenticatable
      */
     public function handle($request, $next)
     {
-        $user = $this->validateCredentials($request);
+        $user = $this->validator->validateCredentials($request);
 
         if (Fortify::confirmsTwoFactorAuthentication() &&
             is_null(optional($user)->two_factor_confirmed_at)) {
@@ -61,71 +49,6 @@ class RedirectIfTwoFactorAuthenticatable
         }
 
         return $next($request);
-    }
-
-    /**
-     * Attempt to validate the incoming credentials.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     */
-    protected function validateCredentials($request)
-    {
-        if (Fortify::$authenticateUsingCallback) {
-            return tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request) {
-                if (! $user) {
-                    $this->fireFailedEvent($request);
-
-                    $this->throwFailedAuthenticationException($request);
-                }
-            });
-        }
-
-        $provider = $this->guard->getProvider();
-
-        return tap($provider->retrieveByCredentials($request->only(Fortify::username(), 'password')), function ($user) use ($provider, $request) {
-            if (! $user || ! $provider->validateCredentials($user, ['password' => $request->password])) {
-                $this->fireFailedEvent($request, $user);
-
-                $this->throwFailedAuthenticationException($request);
-            }
-
-            if (config('hashing.rehash_on_login', true) && method_exists($provider, 'rehashPasswordIfRequired')) {
-                $provider->rehashPasswordIfRequired($user, ['password' => $request->password]);
-            }
-        });
-    }
-
-    /**
-     * Throw a failed authentication validation exception.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    protected function throwFailedAuthenticationException($request)
-    {
-        $this->limiter->increment($request);
-
-        throw ValidationException::withMessages([
-            Fortify::username() => [trans('auth.failed')],
-        ]);
-    }
-
-    /**
-     * Fire the failed authentication attempt event with the given arguments.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
-     * @return void
-     */
-    protected function fireFailedEvent($request, $user = null)
-    {
-        event(new Failed($this->guard?->name ?? config('fortify.guard'), $user, [
-            Fortify::username() => $request->{Fortify::username()},
-            'password' => $request->password,
-        ]));
     }
 
     /**

--- a/src/CredentialsValidator.php
+++ b/src/CredentialsValidator.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Laravel\Fortify;
+
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Fortify;
+
+class CredentialsValidator
+{
+    /**
+     * The guard implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected $guard;
+
+    /**
+     * The login rate limiter instance.
+     *
+     * @var \Laravel\Fortify\LoginRateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @param  \Laravel\Fortify\LoginRateLimiter  $limiter
+     * @return void
+     */
+    public function __construct(StatefulGuard $guard, LoginRateLimiter $limiter)
+    {
+        $this->guard = $guard;
+        $this->limiter = $limiter;
+    }
+
+    /**
+     * Attempt to validate the credentials given in the request.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function validateCredentials($request)
+    {
+        if ($user = $this->guard->user()) {
+            return $user;
+        }
+
+        if (Fortify::$authenticateUsingCallback) {
+            $user = $this->handleUsingCustomCallback($request);
+        } else {
+            $this->guard->once($request->only(Fortify::username(), 'password'));
+            $user = $this->guard->user();
+        }
+
+        if (! $user) {
+            $this->throwFailedAuthenticationException($request);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Attempt to authenticate using a custom callback.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    protected function handleUsingCustomCallback($request)
+    {
+        return tap(call_user_func(Fortify::$authenticateUsingCallback, $request), function ($user) use ($request) {
+            if ($user) {
+                $this->guard->setUser($user);
+            } else {
+                $this->fireFailedEvent($request);
+            }
+        });
+    }
+
+    /**
+     * Throw a failed authentication validation exception.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    protected function throwFailedAuthenticationException($request)
+    {
+        $this->limiter->increment($request);
+        
+        throw ValidationException::withMessages([
+            Fortify::username() => [trans('auth.failed')],
+        ]);
+    }
+
+    /**
+     * Fire the failed authentication attempt event with the given arguments.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function fireFailedEvent($request)
+    {
+        event(new Failed($this->guard->name ?? config('fortify.guard'), null, $request->only(Fortify::username(), 'password')));
+    }
+
+    /**
+     * Get the guard implementation.
+     *
+     * @return \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    public function getGuard()
+    {
+        return $this->guard;
+    }
+}


### PR DESCRIPTION
This is an adjusted version of PR #615 , intended for the master branch. Since breaking changes were unavoidable, I took a slightly different approach and extracted the credential validation logic to a new class `CredentialsValidator` so I could be explicit about the `StatefulGuard` and `LoginRateLimiter` requirements.

#### Purpose of this PR
1. Extract the credential validation logic to a reusable class `CredentialsValidator` that can be utilized on any step in the authentication pipeline. My use-case in (#615) was a step that redirects users with expired passwords to create a new one before logging in.
2. Within this new class, actually use the `StatefulGuard` implementation to validate credentials instead of duplicating the logic from `SessionGuard`, as `RedirectIfTwoFactorAuthenticatable` was basically doing before. I used `StatefulGuard::once` so the user is only authenticated for the remainder of the request.

#### Possible breaking changes
- `RedirectIfTwoFactorAuthenticatable` and `AttemptToAuthenticate` are significantly leaner in this PR. For anyone who is extending these two classes, the methods they are overriding may no longer exist.
- After  `CredentialsValidator::validateCredentials` is executed for the first time in the authentication pipeline, the validated user will be authenticated for the remainder of the request, but not fully logged in. Some projects may have a custom pipeline that assumes no authenticated user until `AttemptToAuthenticate`.
- `StatefulGuard::attempt` is no longer called as part of the authentication pipeline, only `StatefulGuard::once`. While `StatefulGuard::once` is required by the interface, some projects may not expect the switch.
- When using `SessionGuard`, the `Authenticated` event will now trigger twice. Once in `SessionGuard::once`, and once in `SessionGuard::login`.
