### PR TITLE
[1.x] chore: bump to pragmarx/google2fa v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "symfony/console": "^6.0|^7.0",
-        "pragmarx/google2fa": "^8.0"
+        "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This PR updates the dependency `pragmarx/google2fa` to v9. This version contains [a breaking change](https://github.com/antonioribeiro/google2fa/releases/tag/v9.0.0): the default secret key length has been increased from 16 to 32 characters for enhanced security. However, Laravel Fortify explicitly sets the default value for the generation of a secret key to 16:

https://github.com/laravel/fortify/blob/bd38202ba8bfd0914707706f415da0995f25e975/src/TwoFactorAuthenticationProvider.php#L44-L47

Therefore, bumping to v9 is not a breaking change for Laravel Fortify.

In theory we could set the value to 32 as well, as in the migration the field `two_factor_secret` is of type TEXT so an increase in the length of the secret would not be an issue but there might be other side effects as well as mentioned in the release notes of `pragmarx/google2fa`. Such a change would be better for in a future 2.x-release.