### PR TITLE
Move mergeConfigFrom from register to boot method

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -61,8 +61,6 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/fortify.php', 'fortify');
-
         $this->registerResponseBindings();
 
         $this->app->singleton(TwoFactorAuthenticationProviderContract::class, function ($app) {
@@ -117,6 +115,7 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/fortify.php', 'fortify');
         $this->configurePublishing();
         $this->configureRoutes();
         $this->registerCommands();


### PR DESCRIPTION
Why configs should be in [register()](https://laravel.com/docs/12.x/providers#the-register-method), not in boot()? As I know from docs: register() is used only to bind things and You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method [[ref]](https://laravel.com/docs/12.x/providers#the-register-method). It caused small error in our platform. We expand our core, from vendor, and in core we have a config merging logic in boot() like: client -> core -> fortify. For example Spatie packages, loads in boot and their solution works good with our logic. Just wondering why fortify did it in register()?
<img width="323" height="221" alt="image" src="https://github.com/user-attachments/assets/c66d3826-c3ce-4d78-aa7a-8d417532c288" /> Spatie packages example

!!!! Important. I did not double-check the fortify functionality of this MR, just relying to written tests. Just curious why in register()

