### PR TITLE
[1.x] Change return type of CreatesNewUsers::create()

### DIFF
--- a/src/Contracts/CreatesNewUsers.php
+++ b/src/Contracts/CreatesNewUsers.php
@@ -8,7 +8,7 @@ interface CreatesNewUsers
      * Validate and create a newly registered user.
      *
      * @param  array  $input
-     * @return \Illuminate\Foundation\Auth\User
+     * @return \Illuminate\Contracts\Auth\Authenticatable
      */
     public function create(array $input);
 }


### PR DESCRIPTION
**[1.x] Change return type of `CreatesNewUsers::create()`
from `\Illuminate\Foundation\Auth\User`
to `\Illuminate\Contracts\Auth\Authenticatable`**

---

The method `CreatesNewUsers::create()` currently has a return type of `Illuminate\Foundation\Auth\User`.
https://github.com/laravel/fortify/blob/26db37ed915770e5f0f91f6b7e153d9b3e6c09e8/src/Contracts/CreatesNewUsers.php#L11

The only usage of the returned object occurs here:
https://github.com/laravel/fortify/blob/26db37ed915770e5f0f91f6b7e153d9b3e6c09e8/src/Http/Controllers/RegisteredUserController.php#L62-L64

Both `Illuminate\Auth\Events\Registered::__construct()` and `Illuminate\Contracts\Auth\StatefulGuard::login()` accept `Illuminate\Contracts\Auth\Authenticatable` as their user argument.

https://github.com/laravel/framework/blob/9474230c693695b1b5a64eff6dd9f6afd5c14e93/src/Illuminate/Auth/Events/Registered.php#L14

https://github.com/laravel/framework/blob/9474230c693695b1b5a64eff6dd9f6afd5c14e93/src/Illuminate/Contracts/Auth/StatefulGuard.php#L31

The return type is therefore probably narrower than it needs to be.

All other authentication classes use the `Authenticatable` contract to reference an authenticated user, and I believe it exists for that reason. So why not also use it here. Not everybody will extend `Illuminate\Foundation\Auth\User` to create their user class(es), but will have to implement the `Authenticatable` contract in order to work with Laravel's authentication system. A static analyzer (like PHPStan) will complain (rightfully so) if your implementation of `CreatesNewUsers` returns something that doesn't extend `Illuminate\Foundation\Auth\User` even-though it is an  `Authenticatable`.
