### PR TITLE
#625 Add Two Additional Routes

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -106,9 +106,9 @@ Route::group( [ 'middleware' => config( 'fortify.middleware', [ 'web' ] ) ], fun
     // Profile Information...
     if ( Features::enabled( Features::updateProfileInformation() ) )
     {
-        Route::get( RoutePath::for( 'user-profile', '/user/profile' ), [ ProfileInformationController::class, 'create' ] )
+        Route::get( RoutePath::for( 'profile.edit', '/profile' ), [ ProfileInformationController::class, 'create' ] )
              ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
-             ->name( 'user-profile' );
+             ->name( 'profile.edit' );
 
         Route::put( RoutePath::for( 'user-profile-information.update', '/user/profile-information' ), [ ProfileInformationController::class, 'update' ] )
              ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -21,154 +21,174 @@ use Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 use Laravel\Fortify\RoutePath;
 
-Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
-    $enableViews = config('fortify.views', true);
+Route::group( [ 'middleware' => config( 'fortify.middleware', [ 'web' ] ) ], function () {
+    $enableViews = config( 'fortify.views', true );
 
     // Authentication...
-    if ($enableViews) {
-        Route::get(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'create'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('login');
+    if ( $enableViews )
+    {
+        Route::get( RoutePath::for( 'login', '/login' ), [ AuthenticatedSessionController::class, 'create' ] )
+             ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+             ->name( 'login' );
     }
 
-    $limiter = config('fortify.limiters.login');
-    $twoFactorLimiter = config('fortify.limiters.two-factor');
-    $verificationLimiter = config('fortify.limiters.verification', '6,1');
+    $limiter             = config( 'fortify.limiters.login' );
+    $twoFactorLimiter    = config( 'fortify.limiters.two-factor' );
+    $verificationLimiter = config( 'fortify.limiters.verification', '6,1' );
 
-    Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
-        ->middleware(array_filter([
-            'guest:'.config('fortify.guard'),
-            $limiter ? 'throttle:'.$limiter : null,
-        ]))->name('login.store');
+    Route::post( RoutePath::for( 'login', '/login' ), [ AuthenticatedSessionController::class, 'store' ] )
+         ->middleware( array_filter( [
+                                         'guest:' . config( 'fortify.guard' ),
+                                         $limiter ? 'throttle:' . $limiter : null,
+                                     ] ) )->name( 'login.store' );
 
-    Route::post(RoutePath::for('logout', '/logout'), [AuthenticatedSessionController::class, 'destroy'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-        ->name('logout');
+    Route::post( RoutePath::for( 'logout', '/logout' ), [ AuthenticatedSessionController::class, 'destroy' ] )
+         ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+         ->name( 'logout' );
 
     // Password Reset...
-    if (Features::enabled(Features::resetPasswords())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('password.request', '/forgot-password'), [PasswordResetLinkController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('password.request');
+    if ( Features::enabled( Features::resetPasswords() ) )
+    {
+        if ( $enableViews )
+        {
+            Route::get( RoutePath::for( 'password.request', '/forgot-password' ), [ PasswordResetLinkController::class, 'create' ] )
+                 ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+                 ->name( 'password.request' );
 
-            Route::get(RoutePath::for('password.reset', '/reset-password/{token}'), [NewPasswordController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('password.reset');
+            Route::get( RoutePath::for( 'password.reset', '/reset-password/{token}' ), [ NewPasswordController::class, 'create' ] )
+                 ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+                 ->name( 'password.reset' );
         }
 
-        Route::post(RoutePath::for('password.email', '/forgot-password'), [PasswordResetLinkController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('password.email');
+        Route::post( RoutePath::for( 'password.email', '/forgot-password' ), [ PasswordResetLinkController::class, 'store' ] )
+             ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+             ->name( 'password.email' );
 
-        Route::post(RoutePath::for('password.update', '/reset-password'), [NewPasswordController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('password.update');
+        Route::post( RoutePath::for( 'password.update', '/reset-password' ), [ NewPasswordController::class, 'store' ] )
+             ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+             ->name( 'password.update' );
     }
 
     // Registration...
-    if (Features::enabled(Features::registration())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('register');
+    if ( Features::enabled( Features::registration() ) )
+    {
+        if ( $enableViews )
+        {
+            Route::get( RoutePath::for( 'register', '/register' ), [ RegisteredUserController::class, 'create' ] )
+                 ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+                 ->name( 'register' );
         }
 
-        Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
-            ->middleware(['guest:'.config('fortify.guard')])
-            ->name('register.store');
+        Route::post( RoutePath::for( 'register', '/register' ), [ RegisteredUserController::class, 'store' ] )
+             ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+             ->name( 'register.store' );
     }
 
     // Email Verification...
-    if (Features::enabled(Features::emailVerification())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('verification.notice', '/email/verify'), [EmailVerificationPromptController::class, '__invoke'])
-                ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-                ->name('verification.notice');
+    if ( Features::enabled( Features::emailVerification() ) )
+    {
+        if ( $enableViews )
+        {
+            Route::get( RoutePath::for( 'verification.notice', '/email/verify' ), [ EmailVerificationPromptController::class, '__invoke' ] )
+                 ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+                 ->name( 'verification.notice' );
         }
 
-        Route::get(RoutePath::for('verification.verify', '/email/verify/{id}/{hash}'), [VerifyEmailController::class, '__invoke'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'signed', 'throttle:'.$verificationLimiter])
-            ->name('verification.verify');
+        Route::get( RoutePath::for( 'verification.verify', '/email/verify/{id}/{hash}' ), [ VerifyEmailController::class, '__invoke' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ), 'signed', 'throttle:' . $verificationLimiter ] )
+             ->name( 'verification.verify' );
 
-        Route::post(RoutePath::for('verification.send', '/email/verification-notification'), [EmailVerificationNotificationController::class, 'store'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'throttle:'.$verificationLimiter])
-            ->name('verification.send');
+        Route::post( RoutePath::for( 'verification.send', '/email/verification-notification' ), [ EmailVerificationNotificationController::class, 'store' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ), 'throttle:' . $verificationLimiter ] )
+             ->name( 'verification.send' );
     }
 
     // Profile Information...
-    if (Features::enabled(Features::updateProfileInformation())) {
-        Route::put(RoutePath::for('user-profile-information.update', '/user/profile-information'), [ProfileInformationController::class, 'update'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('user-profile-information.update');
+    if ( Features::enabled( Features::updateProfileInformation() ) )
+    {
+        Route::get( RoutePath::for( 'user-profile', '/user/profile' ), [ ProfileInformationController::class, 'create' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+             ->name( 'user-profile' );
+
+        Route::put( RoutePath::for( 'user-profile-information.update', '/user/profile-information' ), [ ProfileInformationController::class, 'update' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+             ->name( 'user-profile-information.update' );
+
+        Route::delete( RoutePath::for( 'user-profile.destroy', '/user/profile' ), [ ProfileInformationController::class, 'destroy' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+             ->name( 'user-profile.destroy' );
     }
 
     // Passwords...
-    if (Features::enabled(Features::updatePasswords())) {
-        Route::put(RoutePath::for('user-password.update', '/user/password'), [PasswordController::class, 'update'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('user-password.update');
+    if ( Features::enabled( Features::updatePasswords() ) )
+    {
+        Route::put( RoutePath::for( 'user-password.update', '/user/password' ), [ PasswordController::class, 'update' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+             ->name( 'user-password.update' );
     }
 
     // Password Confirmation...
-    if ($enableViews) {
-        Route::get(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'show'])
-            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-            ->name('password.confirm');
+    if ( $enableViews )
+    {
+        Route::get( RoutePath::for( 'password.confirm', '/user/confirm-password' ), [ ConfirmablePasswordController::class, 'show' ] )
+             ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+             ->name( 'password.confirm' );
     }
 
-    Route::get(RoutePath::for('password.confirmation', '/user/confirmed-password-status'), [ConfirmedPasswordStatusController::class, 'show'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-        ->name('password.confirmation');
+    Route::get( RoutePath::for( 'password.confirmation', '/user/confirmed-password-status' ), [ ConfirmedPasswordStatusController::class, 'show' ] )
+         ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+         ->name( 'password.confirmation' );
 
-    Route::post(RoutePath::for('password.confirm', '/user/confirm-password'), [ConfirmablePasswordController::class, 'store'])
-        ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
-        ->name('password.confirm.store');
+    Route::post( RoutePath::for( 'password.confirm', '/user/confirm-password' ), [ ConfirmablePasswordController::class, 'store' ] )
+         ->middleware( [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ] )
+         ->name( 'password.confirm.store' );
 
     // Two Factor Authentication...
-    if (Features::enabled(Features::twoFactorAuthentication())) {
-        if ($enableViews) {
-            Route::get(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'create'])
-                ->middleware(['guest:'.config('fortify.guard')])
-                ->name('two-factor.login');
+    if ( Features::enabled( Features::twoFactorAuthentication() ) )
+    {
+        if ( $enableViews )
+        {
+            Route::get( RoutePath::for( 'two-factor.login', '/two-factor-challenge' ), [ TwoFactorAuthenticatedSessionController::class, 'create' ] )
+                 ->middleware( [ 'guest:' . config( 'fortify.guard' ) ] )
+                 ->name( 'two-factor.login' );
         }
 
-        Route::post(RoutePath::for('two-factor.login', '/two-factor-challenge'), [TwoFactorAuthenticatedSessionController::class, 'store'])
-            ->middleware(array_filter([
-                'guest:'.config('fortify.guard'),
-                $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
-            ]))->name('two-factor.login.store');
+        Route::post( RoutePath::for( 'two-factor.login', '/two-factor-challenge' ), [ TwoFactorAuthenticatedSessionController::class, 'store' ] )
+             ->middleware( array_filter( [
+                                             'guest:' . config( 'fortify.guard' ),
+                                             $twoFactorLimiter ? 'throttle:' . $twoFactorLimiter : null,
+                                         ] ) )->name( 'two-factor.login.store' );
 
-        $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
-            ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']
-            : [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
+        $twoFactorMiddleware = Features::optionEnabled( Features::twoFactorAuthentication(), 'confirmPassword' )
+            ? [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ), 'password.confirm' ]
+            : [ config( 'fortify.auth_middleware', 'auth' ) . ':' . config( 'fortify.guard' ) ];
 
-        Route::post(RoutePath::for('two-factor.enable', '/user/two-factor-authentication'), [TwoFactorAuthenticationController::class, 'store'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.enable');
+        Route::post( RoutePath::for( 'two-factor.enable', '/user/two-factor-authentication' ), [ TwoFactorAuthenticationController::class, 'store' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.enable' );
 
-        Route::post(RoutePath::for('two-factor.confirm', '/user/confirmed-two-factor-authentication'), [ConfirmedTwoFactorAuthenticationController::class, 'store'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.confirm');
+        Route::post( RoutePath::for( 'two-factor.confirm', '/user/confirmed-two-factor-authentication' ), [ ConfirmedTwoFactorAuthenticationController::class, 'store' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.confirm' );
 
-        Route::delete(RoutePath::for('two-factor.disable', '/user/two-factor-authentication'), [TwoFactorAuthenticationController::class, 'destroy'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.disable');
+        Route::delete( RoutePath::for( 'two-factor.disable', '/user/two-factor-authentication' ), [ TwoFactorAuthenticationController::class, 'destroy' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.disable' );
 
-        Route::get(RoutePath::for('two-factor.qr-code', '/user/two-factor-qr-code'), [TwoFactorQrCodeController::class, 'show'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.qr-code');
+        Route::get( RoutePath::for( 'two-factor.qr-code', '/user/two-factor-qr-code' ), [ TwoFactorQrCodeController::class, 'show' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.qr-code' );
 
-        Route::get(RoutePath::for('two-factor.secret-key', '/user/two-factor-secret-key'), [TwoFactorSecretKeyController::class, 'show'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.secret-key');
+        Route::get( RoutePath::for( 'two-factor.secret-key', '/user/two-factor-secret-key' ), [ TwoFactorSecretKeyController::class, 'show' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.secret-key' );
 
-        Route::get(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'index'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.recovery-codes');
+        Route::get( RoutePath::for( 'two-factor.recovery-codes', '/user/two-factor-recovery-codes' ), [ RecoveryCodeController::class, 'index' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.recovery-codes' );
 
-        Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
-            ->middleware($twoFactorMiddleware)
-            ->name('two-factor.regenerate-recovery-codes');
+        Route::post( RoutePath::for( 'two-factor.recovery-codes', '/user/two-factor-recovery-codes' ), [ RecoveryCodeController::class, 'store' ] )
+             ->middleware( $twoFactorMiddleware )
+             ->name( 'two-factor.regenerate-recovery-codes' );
     }
-});
+} );

--- a/src/Contracts/ProfileViewResponse.php
+++ b/src/Contracts/ProfileViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface ProfileViewResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/RequestPasswordResetLinkViewResponse.php
+++ b/src/Contracts/RequestPasswordResetLinkViewResponse.php
@@ -6,5 +6,5 @@ use Illuminate\Contracts\Support\Responsable;
 
 interface RequestPasswordResetLinkViewResponse extends Responsable
 {
-    //
+    // 
 }

--- a/src/Contracts/UserProfileLinkViewResponse.php
+++ b/src/Contracts/UserProfileLinkViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface UserProfileLinkViewResponse extends Responsable
+{
+    //
+}

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -15,53 +15,49 @@ use Laravel\Fortify\Contracts\ResetsUserPasswords;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+use Laravel\Fortify\Contracts\UserProfileLinkViewResponse;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
 use Laravel\Fortify\Http\Responses\SimpleViewResponse;
 
 class Fortify
 {
+    const PASSWORD_UPDATED                    = 'password-updated';
+    const PROFILE_INFORMATION_UPDATED         = 'profile-information-updated';
+    const RECOVERY_CODES_GENERATED            = 'recovery-codes-generated';
+    const TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
+    const TWO_FACTOR_AUTHENTICATION_DISABLED  = 'two-factor-authentication-disabled';
+    const TWO_FACTOR_AUTHENTICATION_ENABLED   = 'two-factor-authentication-enabled';
+    const VERIFICATION_LINK_SENT              = 'verification-link-sent';
     /**
      * The callback that is responsible for building the authentication pipeline array, if applicable.
      *
      * @var callable|null
      */
     public static $authenticateThroughCallback;
-
     /**
      * The callback that is responsible for validating authentication credentials, if applicable.
      *
      * @var callable|null
      */
     public static $authenticateUsingCallback;
-
     /**
      * The callback that is responsible for confirming user passwords.
      *
      * @var callable|null
      */
     public static $confirmPasswordsUsingCallback;
-
     /**
      * Indicates if Fortify routes will be registered.
      *
      * @var bool
      */
     public static $registersRoutes = true;
-
     /**
      * The encrypter instance that is used to encrypt attributes.
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter|null
      */
     public static $encrypter;
-
-    const PASSWORD_UPDATED = 'password-updated';
-    const PROFILE_INFORMATION_UPDATED = 'profile-information-updated';
-    const RECOVERY_CODES_GENERATED = 'recovery-codes-generated';
-    const TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
-    const TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
-    const TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
-    const VERIFICATION_LINK_SENT = 'verification-link-sent';
 
     /**
      * Get the username used for authentication.
@@ -70,7 +66,7 @@ class Fortify
      */
     public static function username()
     {
-        return config('fortify.username', 'email');
+        return config( 'fortify.username', 'email' );
     }
 
     /**
@@ -80,157 +76,183 @@ class Fortify
      */
     public static function email()
     {
-        return config('fortify.email', 'email');
+        return config( 'fortify.email', 'email' );
     }
 
     /**
      * Get a completion redirect path for a specific feature.
      *
-     * @param  string  $redirect
+     * @param string $redirect
+     *
      * @return string
      */
-    public static function redirects(string $redirect, $default = null)
+    public static function redirects( string $redirect, $default = null )
     {
-        return config('fortify.redirects.'.$redirect) ?? $default ?? config('fortify.home');
+        return config( 'fortify.redirects.' . $redirect ) ?? $default ?? config( 'fortify.home' );
     }
 
     /**
      * Register the views for Fortify using conventional names under the given namespace.
      *
-     * @param  string  $namespace
+     * @param string $namespace
+     *
      * @return void
      */
-    public static function viewNamespace(string $namespace)
+    public static function viewNamespace( string $namespace )
     {
-        static::viewPrefix($namespace.'::');
+        static::viewPrefix( $namespace . '::' );
     }
 
     /**
      * Register the views for Fortify using conventional names under the given prefix.
      *
-     * @param  string  $prefix
+     * @param string $prefix
+     *
      * @return void
      */
-    public static function viewPrefix(string $prefix)
+    public static function viewPrefix( string $prefix )
     {
-        static::loginView($prefix.'login');
-        static::twoFactorChallengeView($prefix.'two-factor-challenge');
-        static::registerView($prefix.'register');
-        static::requestPasswordResetLinkView($prefix.'forgot-password');
-        static::resetPasswordView($prefix.'reset-password');
-        static::verifyEmailView($prefix.'verify-email');
-        static::confirmPasswordView($prefix.'confirm-password');
+        static::loginView( $prefix . 'login' );
+        static::twoFactorChallengeView( $prefix . 'two-factor-challenge' );
+        static::registerView( $prefix . 'register' );
+        static::requestPasswordResetLinkView( $prefix . 'forgot-password' );
+        static::resetPasswordView( $prefix . 'reset-password' );
+        static::verifyEmailView( $prefix . 'verify-email' );
+        static::confirmPasswordView( $prefix . 'confirm-password' );
     }
 
     /**
      * Specify which view should be used as the login view.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function loginView($view)
+    public static function loginView( $view )
     {
-        app()->singleton(LoginViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( LoginViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Specify which view should be used as the two factor authentication challenge view.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function twoFactorChallengeView($view)
+    public static function twoFactorChallengeView( $view )
     {
-        app()->singleton(TwoFactorChallengeViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( TwoFactorChallengeViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Specify which view should be used as the new password view.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function resetPasswordView($view)
+    public static function resetPasswordView( $view )
     {
-        app()->singleton(ResetPasswordViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( ResetPasswordViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Specify which view should be used as the registration view.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function registerView($view)
+    public static function registerView( $view )
     {
-        app()->singleton(RegisterViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( RegisterViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Specify which view should be used as the email verification prompt.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function verifyEmailView($view)
+    public static function verifyEmailView( $view )
     {
-        app()->singleton(VerifyEmailViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( VerifyEmailViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Specify which view should be used as the password confirmation prompt.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function confirmPasswordView($view)
+    public static function confirmPasswordView( $view )
     {
-        app()->singleton(ConfirmPasswordViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( ConfirmPasswordViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Specify which view should be used as the request password reset link view.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public static function requestPasswordResetLinkView($view)
+    public static function requestPasswordResetLinkView( $view )
     {
-        app()->singleton(RequestPasswordResetLinkViewResponse::class, function () use ($view) {
-            return new SimpleViewResponse($view);
-        });
+        app()->singleton( RequestPasswordResetLinkViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
+    }
+
+    /**
+     * Specify which view should be used as the user profile link view.
+     *
+     * @param callable|string $view
+     *
+     * @return void
+     */
+    public static function requestUserProfileLinkView( $view )
+    {
+        app()->singleton( UserProfileLinkViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
     }
 
     /**
      * Register a callback that is responsible for building the authentication pipeline array.
      *
-     * @param  callable  $callback
+     * @param callable $callback
+     *
      * @return void
      */
-    public static function loginThrough(callable $callback)
+    public static function loginThrough( callable $callback )
     {
-        static::authenticateThrough($callback);
+        static::authenticateThrough( $callback );
     }
 
     /**
      * Register a callback that is responsible for building the authentication pipeline array.
      *
-     * @param  callable  $callback
+     * @param callable $callback
+     *
      * @return void
      */
-    public static function authenticateThrough(callable $callback)
+    public static function authenticateThrough( callable $callback )
     {
         static::$authenticateThroughCallback = $callback;
     }
@@ -238,10 +260,11 @@ class Fortify
     /**
      * Register a callback that is responsible for validating incoming authentication credentials.
      *
-     * @param  callable  $callback
+     * @param callable $callback
+     *
      * @return void
      */
-    public static function authenticateUsing(callable $callback)
+    public static function authenticateUsing( callable $callback )
     {
         static::$authenticateUsingCallback = $callback;
     }
@@ -249,21 +272,23 @@ class Fortify
     /**
      * Register a class / callback that should be used to redirect users for two factor authentication.
      *
-     * @param  string  $callback
+     * @param string $callback
+     *
      * @return void
      */
-    public static function redirectUserForTwoFactorAuthenticationUsing(string $callback)
+    public static function redirectUserForTwoFactorAuthenticationUsing( string $callback )
     {
-        app()->singleton(RedirectsIfTwoFactorAuthenticatable::class, $callback);
+        app()->singleton( RedirectsIfTwoFactorAuthenticatable::class, $callback );
     }
 
     /**
      * Register a callback that is responsible for confirming existing user passwords as valid.
      *
-     * @param  callable  $callback
+     * @param callable $callback
+     *
      * @return void
      */
-    public static function confirmPasswordsUsing(callable $callback)
+    public static function confirmPasswordsUsing( callable $callback )
     {
         static::$confirmPasswordsUsingCallback = $callback;
     }
@@ -271,45 +296,49 @@ class Fortify
     /**
      * Register a class / callback that should be used to create new users.
      *
-     * @param  string  $callback
+     * @param string $callback
+     *
      * @return void
      */
-    public static function createUsersUsing(string $callback)
+    public static function createUsersUsing( string $callback )
     {
-        app()->singleton(CreatesNewUsers::class, $callback);
+        app()->singleton( CreatesNewUsers::class, $callback );
     }
 
     /**
      * Register a class / callback that should be used to update user profile information.
      *
-     * @param  string  $callback
+     * @param string $callback
+     *
      * @return void
      */
-    public static function updateUserProfileInformationUsing(string $callback)
+    public static function updateUserProfileInformationUsing( string $callback )
     {
-        app()->singleton(UpdatesUserProfileInformation::class, $callback);
+        app()->singleton( UpdatesUserProfileInformation::class, $callback );
     }
 
     /**
      * Register a class / callback that should be used to update user passwords.
      *
-     * @param  string  $callback
+     * @param string $callback
+     *
      * @return void
      */
-    public static function updateUserPasswordsUsing(string $callback)
+    public static function updateUserPasswordsUsing( string $callback )
     {
-        app()->singleton(UpdatesUserPasswords::class, $callback);
+        app()->singleton( UpdatesUserPasswords::class, $callback );
     }
 
     /**
      * Register a class / callback that should be used to reset user passwords.
      *
-     * @param  string  $callback
+     * @param string $callback
+     *
      * @return void
      */
-    public static function resetUserPasswordsUsing(string $callback)
+    public static function resetUserPasswordsUsing( string $callback )
     {
-        app()->singleton(ResetsUserPasswords::class, $callback);
+        app()->singleton( ResetsUserPasswords::class, $callback );
     }
 
     /**
@@ -319,17 +348,18 @@ class Fortify
      */
     public static function confirmsTwoFactorAuthentication()
     {
-        return Features::enabled(Features::twoFactorAuthentication()) &&
-               Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm');
+        return Features::enabled( Features::twoFactorAuthentication() ) &&
+               Features::optionEnabled( Features::twoFactorAuthentication(), 'confirm' );
     }
 
     /**
      * Set the encrypter instance that will be used to encrypt attributes.
      *
-     * @param  \Illuminate\Contracts\Encryption\Encrypter|null  $encrypter
+     * @param \Illuminate\Contracts\Encryption\Encrypter|null $encrypter
+     *
      * @return static
      */
-    public static function encryptUsing($encrypter)
+    public static function encryptUsing( $encrypter )
     {
         static::$encrypter = $encrypter;
 

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Crypt;
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Contracts\LoginViewResponse;
+use Laravel\Fortify\Contracts\ProfileViewResponse;
 use Laravel\Fortify\Contracts\RedirectsIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
@@ -15,7 +16,6 @@ use Laravel\Fortify\Contracts\ResetsUserPasswords;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
-use Laravel\Fortify\Contracts\UserProfileLinkViewResponse;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
 use Laravel\Fortify\Http\Responses\SimpleViewResponse;
 
@@ -115,6 +115,7 @@ class Fortify
         static::loginView( $prefix . 'login' );
         static::twoFactorChallengeView( $prefix . 'two-factor-challenge' );
         static::registerView( $prefix . 'register' );
+        static::profileView( $prefix . 'profile' );
         static::requestPasswordResetLinkView( $prefix . 'forgot-password' );
         static::resetPasswordView( $prefix . 'reset-password' );
         static::verifyEmailView( $prefix . 'verify-email' );
@@ -178,6 +179,20 @@ class Fortify
     }
 
     /**
+     * Specify which view should be used as the registration view.
+     *
+     * @param callable|string $view
+     *
+     * @return void
+     */
+    public static function profileView( $view )
+    {
+        app()->singleton( ProfileViewResponse::class, function () use ( $view ) {
+            return new SimpleViewResponse( $view );
+        } );
+    }
+
+    /**
      * Specify which view should be used as the email verification prompt.
      *
      * @param callable|string $view
@@ -215,20 +230,6 @@ class Fortify
     public static function requestPasswordResetLinkView( $view )
     {
         app()->singleton( RequestPasswordResetLinkViewResponse::class, function () use ( $view ) {
-            return new SimpleViewResponse( $view );
-        } );
-    }
-
-    /**
-     * Specify which view should be used as the user profile link view.
-     *
-     * @param callable|string $view
-     *
-     * @return void
-     */
-    public static function requestUserProfileLinkView( $view )
-    {
-        app()->singleton( UserProfileLinkViewResponse::class, function () use ( $view ) {
             return new SimpleViewResponse( $view );
         } );
     }

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -4,31 +4,74 @@ namespace Laravel\Fortify\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
+use Laravel\Fortify\Contracts\ProfileViewResponse;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Laravel\Fortify\Fortify;
 
 class ProfileInformationController extends Controller
 {
     /**
+     * Show the profile view.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Laravel\Fortify\Contracts\ProfileViewResponse
+     */
+    public function create( Request $request ): ProfileViewResponse
+    {
+        return app( ProfileViewResponse::class );
+    }
+
+    /**
      * Update the user's profile information.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
+     * @param \Illuminate\Http\Request $request
+     * @param \Laravel\Fortify\Contracts\UpdatesUserProfileInformation $updater
+     *
      * @return \Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse
      */
-    public function update(Request $request,
-                           UpdatesUserProfileInformation $updater)
+    public function update( Request $request,
+        UpdatesUserProfileInformation $updater )
     {
-        if (config('fortify.lowercase_usernames') && $request->has(Fortify::username())) {
-            $request->merge([
-                Fortify::username() => Str::lower($request->{Fortify::username()}),
-            ]);
+        if ( config( 'fortify.lowercase_usernames' ) && $request->has( Fortify::username() ) )
+        {
+            $request->merge( [
+                                 Fortify::username() => Str::lower( $request->{Fortify::username()} ),
+                             ] );
         }
 
-        $updater->update($request->user(), $request->all());
+        $updater->update( $request->user(), $request->all() );
 
-        return app(ProfileInformationUpdatedResponse::class);
+        return app( ProfileInformationUpdatedResponse::class );
+    }
+
+
+    /**
+     * Destroy the user's profile.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy( Request $request )
+    {
+        $request->validateWithBag( 'userDeletion', [
+            'password' => [ 'required', 'current_password' ],
+        ] );
+
+        $user = $request->user();
+
+        Auth::logout();
+
+        $user->delete();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return Redirect::to( '/' );
     }
 }

--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -5,6 +5,7 @@ namespace Laravel\Fortify\Http\Responses;
 use Illuminate\Contracts\Support\Responsable;
 use Laravel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Laravel\Fortify\Contracts\LoginViewResponse;
+use Laravel\Fortify\Contracts\ProfileViewResponse;
 use Laravel\Fortify\Contracts\RegisterViewResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
@@ -15,6 +16,7 @@ class SimpleViewResponse implements
     LoginViewResponse,
     ResetPasswordViewResponse,
     RegisterViewResponse,
+    ProfileViewResponse,
     RequestPasswordResetLinkViewResponse,
     TwoFactorChallengeViewResponse,
     VerifyEmailViewResponse,
@@ -30,10 +32,11 @@ class SimpleViewResponse implements
     /**
      * Create a new response instance.
      *
-     * @param  callable|string  $view
+     * @param callable|string $view
+     *
      * @return void
      */
-    public function __construct($view)
+    public function __construct( $view )
     {
         $this->view = $view;
     }
@@ -41,19 +44,22 @@ class SimpleViewResponse implements
     /**
      * Create an HTTP response that represents the object.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function toResponse($request)
+    public function toResponse( $request )
     {
-        if (! is_callable($this->view) || is_string($this->view)) {
-            return view($this->view, ['request' => $request]);
+        if ( ! is_callable( $this->view ) || is_string( $this->view ) )
+        {
+            return view( $this->view, [ 'request' => $request ] );
         }
 
-        $response = call_user_func($this->view, $request);
+        $response = call_user_func( $this->view, $request );
 
-        if ($response instanceof Responsable) {
-            return $response->toResponse($request);
+        if ( $response instanceof Responsable )
+        {
+            return $response->toResponse( $request );
         }
 
         return $response;


### PR DESCRIPTION
I recently combined Laravel Fortify with Laravel Breeze front-end components. After completing that integration, noticed that there were two routes where I needed to have the ProfileController from Laravel Breeze to manage those routes. It would be nice to add those into Laravel Fortify. Here are the routes:

GET /profile (profile.edit) - to show the profile page for the user
DELETE /profile (profile.destroy) - to delete the user and their profile

Adding these, I believe, "completes" the route list for Fortify.

Adding these changes.