### PR TITLE
Add name_prefix configuration option to Fortify

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -12,6 +12,7 @@ return [
     'views' => true,
     'home' => '/home',
     'prefix' => '',
+    'name_prefix' => '',
     'domain' => null,
     'lowercase_usernames' => false,
     'limiters' => [

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\EmailVerificationNotificationSentResponse as EmailVerificationNotificationSentResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswordConfirmationResponseContract;
@@ -158,11 +159,15 @@ class FortifyServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
+        $as = config('fortify.name_prefix', '');
+        $as = $as !== '' ? Str::finish($as, '.') : '';
+
         if (Fortify::$registersRoutes) {
             Route::group([
                 'namespace' => 'Laravel\Fortify\Http\Controllers',
                 'domain' => config('fortify.domain', null),
                 'prefix' => config('fortify.prefix'),
+                'as' => $as,
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
             });

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -81,12 +81,14 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you may specify which prefix Fortify will assign to all the routes
-    | that it registers with the application. If necessary, you may change
-    | subdomain under which all of the Fortify routes will be available.
+    | that it registers in the application. You may also give a route name
+    | prefix and the subdomain under which all the Fortify routes exist.
     |
     */
 
     'prefix' => '',
+
+    'name_prefix' => '',
 
     'domain' => null,
 


### PR DESCRIPTION
This PR adds support for a configurable `name_prefix` for all Fortify routes.

### Why

* Enables clean usage of Fortify inside **auth route groups**.
* Prevents **route name collisions**.
* Produces **clean, separated imports with Laravel Wayfinder**.

### Wayfinder Example

**Config:**

```php
'name_prefix' => 'auth',
```

**Before:**

```ts
import { store } from '@/routes/login';
import { request } from '@/routes/password';
```

**After:**

```ts
import { store } from '@/routes/auth/login';
import { request } from '@/routes/auth/password';
```

### Implementation

* Adds `name_prefix` to the Fortify config and stub.
* Applies it via the `as` option on the Fortify route group.
* Normalizes formatting using `Str`.

### Compatibility

* Fully opt-in.
* No breaking changes.
