### PR TITLE
Added dedicated Request object to PasswordResetLinkController

### DIFF
--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -12,15 +12,12 @@ use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Fortify;
-use Laravel\Fortify\Http\Requests\PasswordResetLinkRequest;
+use Laravel\Fortify\Http\Requests\SendPasswordResetLinkRequest;
 
 class PasswordResetLinkController extends Controller
 {
     /**
      * Show the reset password link request view.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse
      */
     public function create(Request $request): RequestPasswordResetLinkViewResponse
     {
@@ -29,11 +26,8 @@ class PasswordResetLinkController extends Controller
 
     /**
      * Send a reset link to the given user.
-     *
-     * @param  PasswordResetLinkRequest  $request
-     * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(PasswordResetLinkRequest $request): Responsable
+    public function store(SendPasswordResetLinkRequest $request): Responsable
     {
         if (config('fortify.lowercase_usernames') && $request->has(Fortify::email())) {
             $request->merge([
@@ -55,8 +49,6 @@ class PasswordResetLinkController extends Controller
 
     /**
      * Get the broker to be used during password reset.
-     *
-     * @return \Illuminate\Contracts\Auth\PasswordBroker
      */
     protected function broker(): PasswordBroker
     {

--- a/src/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Http/Controllers/PasswordResetLinkController.php
@@ -12,6 +12,7 @@ use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Fortify;
+use Laravel\Fortify\Http\Requests\PasswordResetLinkRequest;
 
 class PasswordResetLinkController extends Controller
 {
@@ -29,13 +30,11 @@ class PasswordResetLinkController extends Controller
     /**
      * Send a reset link to the given user.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  PasswordResetLinkRequest  $request
      * @return \Illuminate\Contracts\Support\Responsable
      */
-    public function store(Request $request): Responsable
+    public function store(PasswordResetLinkRequest $request): Responsable
     {
-        $request->validate([Fortify::email() => 'required|email']);
-
         if (config('fortify.lowercase_usernames') && $request->has(Fortify::email())) {
             $request->merge([
                 Fortify::email() => Str::lower($request->{Fortify::email()}),

--- a/src/Http/Requests/PasswordResetLinkRequest.php
+++ b/src/Http/Requests/PasswordResetLinkRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Fortify\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Laravel\Fortify\Fortify;
+
+class PasswordResetLinkRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            Fortify::email() => 'required|email',
+        ];
+    }
+}

--- a/src/Http/Requests/SendPasswordResetLinkRequest.php
+++ b/src/Http/Requests/SendPasswordResetLinkRequest.php
@@ -5,7 +5,7 @@ namespace Laravel\Fortify\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use Laravel\Fortify\Fortify;
 
-class PasswordResetLinkRequest extends FormRequest
+class SendPasswordResetLinkRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
This PR introduces a dedicated request object to the PasswordResetLinkController. The purpose of this change is to allow extensibility of the PasswordResetLinkRequest so that additional validation can be implemented.

**Reason:** The reason I'd like to implement this is to add validation for reCAPTCHA to protect the forms for example. Using this I can extend the validation for the password reset link to ensure that a valid reCAPTCHA payload is also supplied.

**Non breaking:** This is a non-breaking change and by default implements the same validation rules.

Thanks,
Chris.