### PR TITLE
Allow UpdatesUserProfileInformation to receive Request instance instead of array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -8,18 +8,19 @@ use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Laravel\Fortify\Fortify;
+use ReflectionException;
+use ReflectionMethod;
 
 class ProfileInformationController extends Controller
 {
     /**
      * Update the user's profile information.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
-     * @return \Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse
+     * @param  Request  $request
+     * @param  UpdatesUserProfileInformation  $updater
+     * @return ProfileInformationUpdatedResponse
      */
-    public function update(Request $request,
-                           UpdatesUserProfileInformation $updater)
+    public function update(Request $request, UpdatesUserProfileInformation $updater)
     {
         if (config('fortify.lowercase_usernames') && $request->has(Fortify::username())) {
             $request->merge([
@@ -27,8 +28,37 @@ class ProfileInformationController extends Controller
             ]);
         }
 
-        $updater->update($request->user(), $request->all());
+        $updater->update($request->user(), $this->resolveInput($updater, $request));
 
         return app(ProfileInformationUpdatedResponse::class);
+    }
+
+    /**
+     * Resolve the input for the updater based on the expected parameter type.
+     *
+     * @param  UpdatesUserProfileInformation  $updater
+     * @param  Request  $request
+     * @return Request|array
+     */
+    protected function resolveInput(UpdatesUserProfileInformation $updater, Request $request): Request|array
+    {
+        try {
+            $reflection = new ReflectionMethod($updater::class, 'update');
+            $parameter = $reflection->getParameters()[1] ?? null;
+
+            $type = $parameter?->getType();
+
+            if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                $name = $type->getName();
+
+                if ($name === Request::class || is_subclass_of($name, Request::class)) {
+                    return $request;
+                }
+            }
+        } catch (ReflectionException) {
+            // Fallback for mocks or dynamic implementations.
+        }
+
+        return $request->all();
     }
 }

--- a/src/Http/Controllers/ProfileInformationController.php
+++ b/src/Http/Controllers/ProfileInformationController.php
@@ -48,7 +48,7 @@ class ProfileInformationController extends Controller
 
             $type = $parameter?->getType();
 
-            if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+            if ($type instanceof \ReflectionNamedType && ! $type->isBuiltin()) {
                 $name = $type->getName();
 
                 if ($name === Request::class || is_subclass_of($name, Request::class)) {

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -3,7 +3,6 @@
 namespace Laravel\Fortify\Tests;
 
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Http\Request;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Mockery;
 

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -50,9 +50,12 @@ class ProfileInformationControllerTest extends OrchestraTestCase
     public function test_request_is_passed_when_updater_expects_request_instance()
     {
         $user = Mockery::mock(Authenticatable::class);
-        $updater = new class() implements UpdatesUserProfileInformation {
-            public function update($user, Request $input): void
+
+        $updater = new class() implements UpdatesUserProfileInformation
+        {
+            public function update($user, \Illuminate\Http\Request $input): void
             {
+                //
             }
         };
 

--- a/tests/ProfileInformationControllerTest.php
+++ b/tests/ProfileInformationControllerTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Fortify\Tests;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Mockery;
 
@@ -13,8 +14,8 @@ class ProfileInformationControllerTest extends OrchestraTestCase
         $user = Mockery::mock(Authenticatable::class);
 
         $this->mock(UpdatesUserProfileInformation::class)
-                    ->shouldReceive('update')
-                    ->once();
+            ->shouldReceive('update')
+            ->once();
 
         $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/profile-information', [
             'name' => 'Taylor Otwell',
@@ -31,16 +32,35 @@ class ProfileInformationControllerTest extends OrchestraTestCase
         $user = Mockery::mock(Authenticatable::class);
 
         $this->mock(UpdatesUserProfileInformation::class)
-                    ->shouldReceive('update')
-                    ->with($user, [
-                        'name' => 'Taylor Otwell',
-                        'email' => 'taylor@laravel.com',
-                    ])
-                    ->once();
+            ->shouldReceive('update')
+            ->with($user, [
+                'name' => 'Taylor Otwell',
+                'email' => 'taylor@laravel.com',
+            ])
+            ->once();
 
         $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/profile-information', [
             'name' => 'Taylor Otwell',
             'email' => 'TAYLOR@LARAVEL.COM',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_request_is_passed_when_updater_expects_request_instance()
+    {
+        $user = Mockery::mock(Authenticatable::class);
+        $updater = new class() implements UpdatesUserProfileInformation {
+            public function update($user, Request $input): void
+            {
+            }
+        };
+
+        $this->app->instance(UpdatesUserProfileInformation::class, $updater);
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->putJson('/user/profile-information', [
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
         ]);
 
         $response->assertStatus(200);


### PR DESCRIPTION
This PR adds support for receiving an `Illuminate\Http\Request` instance in the `UpdatesUserProfileInformation` implementation, while maintaining full backward compatibility with the existing `array` signature.

## Problem

The current `ProfileInformationController` always passes `$request->all()` to the updater, which strips away access to the original Request object. This makes it impossible to use `$request->file()`, `$request->headers`, `$request->ip()`, or any other Request-specific functionality inside the 
updater implementation.

Developers who need file uploads (e.g., avatar), request metadata, or custom validation via Form Requests are forced to work around this limitation by accessing the request through the service container or other indirect means.

## Solution

The controller now inspects the second parameter type of the `update()` method via Reflection. If the implementation declares `Illuminate\Http\Request` (or a subclass), the full Request object is passed. Otherwise, `$request->all()` is passed as before.

```php
// Before (only option):
public function update(User $user, array $input): void

// After (also supported):
public function update(User $user, Request $input): void
```

## Backward Compatibility

- Existing implementations using `array $input` continue to work unchanged.
- Mocks and dynamic proxies gracefully fall back to `array` via try-catch.
- No changes to the `UpdatesUserProfileInformation` contract interface.
- Zero breaking changes.