### PR TITLE
Use explicit query() for User creation

### DIFF
--- a/stubs/CreateNewUser.php
+++ b/stubs/CreateNewUser.php
@@ -31,7 +31,7 @@ class CreateNewUser implements CreatesNewUsers
             'password' => $this->passwordRules(),
         ])->validate();
 
-        return User::create([
+        return User::query()->create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),


### PR DESCRIPTION
This PR refactors the User::create call to use User::query()->create for explicitness.

There are no functional changes; the behavior remains exactly the same.