### PR TITLE
Add string type hint to replaceRecoveryCode method

### DIFF
--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -44,7 +44,7 @@ trait TwoFactorAuthenticatable
      * @param  string  $code
      * @return void
      */
-    public function replaceRecoveryCode($code)
+    public function replaceRecoveryCode(string $code)
     {
         $this->forceFill([
             'two_factor_recovery_codes' => Fortify::currentEncrypter()->encrypt(str_replace(


### PR DESCRIPTION
This PR adds a `string` type hint to the `$code` parameter of the `replaceRecoveryCode` method.

No functional changes are introduced. Improves static analysis and readability.
