### PR TITLE
Use scoped bindings for Octane compatibility

### DIFF
--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -254,7 +254,7 @@ class Fortify
      */
     public static function redirectUserForTwoFactorAuthenticationUsing($callback)
     {
-        app()->singleton(RedirectsIfTwoFactorAuthenticatable::class, $callback);
+        app()->scoped(RedirectsIfTwoFactorAuthenticatable::class, $callback);
     }
 
     /**

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -72,7 +72,7 @@ class FortifyServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton(RedirectsIfTwoFactorAuthenticatableContract::class, function ($app) {
+        $this->app->scoped(RedirectsIfTwoFactorAuthenticatableContract::class, function ($app) {
             return $app->make(RedirectIfTwoFactorAuthenticatable::class);
         });
 

--- a/tests/FortifyServiceProviderTest.php
+++ b/tests/FortifyServiceProviderTest.php
@@ -4,7 +4,10 @@ namespace Laravel\Fortify\Tests;
 
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Contracts\RedirectsIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Fortify;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 
 class FortifyServiceProviderTest extends OrchestraTestCase
 {
@@ -36,5 +39,61 @@ class FortifyServiceProviderTest extends OrchestraTestCase
 
         $response->assertOk();
         $response->assertExactJson(['foo' => 'bar']);
+    }
+
+    #[DefineEnvironment('withTwoFactorAuthentication')]
+    public function test_redirect_if_two_factor_authenticatable_is_resolved_fresh_after_flushing_scoped_instances()
+    {
+        $instanceA = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+        $instanceB = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+
+        $this->assertSame($instanceA, $instanceB);
+
+        $this->app->forgetScopedInstances();
+
+        $instanceC = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+
+        $this->assertNotSame($instanceA, $instanceC);
+    }
+
+    #[DefineEnvironment('withTwoFactorAuthentication')]
+    public function test_redirect_if_two_factor_authenticatable_receives_fresh_guard_after_flushing_scoped_instances()
+    {
+        $instance = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+
+        $guardProperty = new \ReflectionProperty($instance, 'guard');
+        $guardBefore = $guardProperty->getValue($instance);
+
+        // Simulate Octane request boundary.
+        Auth::forgetGuards();
+        $this->app->forgetScopedInstances();
+
+        $freshInstance = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+
+        $guardAfter = $guardProperty->getValue($freshInstance);
+
+        $this->assertNotSame($guardBefore, $guardAfter);
+    }
+
+    #[DefineEnvironment('withTwoFactorAuthentication')]
+    public function test_custom_redirect_if_two_factor_authenticatable_is_resolved_fresh_after_flushing_scoped_instances()
+    {
+        Fortify::redirectUserForTwoFactorAuthenticationUsing(TestRedirectIfTwoFactorAuthenticatable::class);
+
+        $instanceA = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+
+        $this->app->forgetScopedInstances();
+
+        $instanceB = $this->app->make(RedirectsIfTwoFactorAuthenticatable::class);
+
+        $this->assertNotSame($instanceA, $instanceB);
+    }
+}
+
+class TestRedirectIfTwoFactorAuthenticatable implements RedirectsIfTwoFactorAuthenticatable
+{
+    public function handle($request, $next)
+    {
+        return $next($request);
     }
 }


### PR DESCRIPTION
 ## Description

  This PR changes the `RedirectsIfTwoFactorAuthenticatable` contract binding from `singleton` to `scoped` in both `FortifyServiceProvider` and `Fortify::redirectUserForTwoFactorAuthenticationUsing()`.

  ## Problem
                                                                                                                                                                   
  `RedirectIfTwoFactorAuthenticatable` receives a `StatefulGuard` via constructor injection. Because it's bound as a `singleton`, the guard is resolved once and reused for the lifetime of the application.                                  

  In Octane, guards are flushed between requests via `forgetGuards()` on the `AuthManager`. However, the singleton still holds a reference to the original guard instance — it's never re-resolved. This means it can operate against a stale guard carrying the previous request's authentication state, resolving to the **wrong auth user**.
  
   ## Solution

  Changing `singleton` to `scoped` ensures the binding is re-resolved after Octane calls `forgetScopedInstances()` between requests, giving `RedirectIfTwoFactorAuthenticatable` a fresh `StatefulGuard` on each request.
   
   ## Benefit to end users

  Applications running Fortify with Octane get correct two-factor authentication behaviour across requests without needing to manually override Fortify's bindings in a service provider. 

  ## Why this doesn't break existing features
  
  - `scoped` bindings behave identically to `singleton` within a single request lifecycle — the instance is resolved once and reused for the duration of the request
  - The only behavioural difference is that scoped bindings are automatically flushed between Octane requests, which is the correct behaviour for anything holding a `StatefulGuard` reference
  - Non-Octane applications are completely unaffected
  - All 95 existing tests continue to pass without modification and added additional tests to ensure the solution works. 
  
  