### PR TITLE
Clarify Two-Factor Authentication JSON responses for SPA mode

### DIFF
--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -83,6 +83,17 @@ Enable in `config/fortify.php` features array:
 
 > Use `search-docs` for integration and SPA authentication patterns.
 
+#### Two-Factor Authentication in SPA Mode
+
+When `views` is set to `false`, Fortify returns JSON responses instead of redirects.
+
+If a user attempts to log in and two-factor authentication is enabled, the login request will return a JSON response indicating that a two-factor challenge is required:
+
+```json
+{
+    "two_factor": true
+}
+```
 ## Best Practices
 
 ### Custom Authentication Logic

--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -94,6 +94,7 @@ If a user attempts to log in and two-factor authentication is enabled, the login
     "two_factor": true
 }
 ```
+
 ## Best Practices
 
 ### Custom Authentication Logic


### PR DESCRIPTION
This PR clarifies the JSON response behavior of two-factor authentication when Fortify is used in SPA mode (`'views' => false`).

When views are disabled, Fortify returns JSON responses instead of redirects. If a user with two-factor authentication enabled attempts to log in, the login request will indicate that a two-factor challenge is required.

This update adds documentation explaining:

- The JSON response when 2FA is required
- How the client should handle the `/two-factor-challenge` endpoint
- The expected flow for SPA authentication

This helps frontend developers better understand the authentication flow when building SPAs.
