### PR TITLE
Clarify Sanctum usage in SPA authentication setup

### DIFF
--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -75,7 +75,7 @@ Enable in `config/fortify.php` features array:
 
 ```
 - [ ] Set 'views' => false in config/fortify.php
-- [ ] Install and configure Laravel Sanctum
+- [ ] Install and configure Laravel Sanctum for session-based SPA authentication
 - [ ] Use 'web' guard in fortify config
 - [ ] Set up CSRF token handling
 - [ ] Test XHR authentication flows


### PR DESCRIPTION
This PR clarifies that Laravel Sanctum should be configured for session-based SPA authentication when using Fortify in SPA mode.

The previous wording could be interpreted as token-based API authentication, while Fortify's SPA setup typically relies on session-based authentication.
