### PR TITLE
Clarify required guard for SPA authentication setup

### DIFF
--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -77,8 +77,6 @@ Enable in `config/fortify.php` features array:
 - [ ] Set 'views' => false in config/fortify.php
 - [ ] Install and configure Laravel Sanctum
 - [ ] Use the 'web' guard in config/fortify.php (required for session-based authentication)
-- [ ] Install and configure Laravel Sanctum for session-based SPA authentication
-- [ ] Use 'web' guard in fortify config
 - [ ] Set up CSRF token handling
 - [ ] Test XHR authentication flows
 ```

--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -76,7 +76,7 @@ Enable in `config/fortify.php` features array:
 ```
 - [ ] Set 'views' => false in config/fortify.php
 - [ ] Install and configure Laravel Sanctum
-- [ ] Use 'web' guard in fortify config
+- [ ] Use the 'web' guard in config/fortify.php (required for session-based authentication)
 - [ ] Set up CSRF token handling
 - [ ] Test XHR authentication flows
 ```


### PR DESCRIPTION
This PR improves clarity in the SPA Authentication Setup section by specifying that the 'web' guard must be used in config/fortify.php.

Since Fortify relies on session-based authentication for SPA setups, using a different guard (e.g., 'api') may lead to authentication issues. This clarification helps prevent common misconfiguration.
