### PR TITLE
Add detailed Error Handling documentation for SPA and view modes in Laravel Fortify

### DIFF
--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -126,3 +126,85 @@ Configure via `fortify.limiters.login` in config. Default configuration throttle
 | 2FA Challenge          | POST     | `/two-factor-challenge`                     |
 | Get QR Code            | GET      | `/user/two-factor-qr-code`                  |
 | Recovery Codes         | GET/POST | `/user/two-factor-recovery-codes`           |
+
+## Error Handling
+
+Laravel Fortify returns standard Laravel validation and authentication error responses.  
+This section covers View mode and SPA (headless) mode.
+
+---
+
+### Validation Errors
+
+When validation fails, Fortify returns a `422 Unprocessable Entity` response.
+
+**View-enabled mode:**
+- Users are redirected back
+- Validation errors are flashed to the session
+
+**SPA mode (`'views' => false`):**
+- A JSON response is returned
+- Errors are included in the `errors` object
+
+Example JSON response:
+
+```json
+{
+    "message": "The given data was invalid.",
+    "errors": {
+        "email": [
+            "The email field is required."
+        ],
+        "password": [
+            "The password must be at least 8 characters."
+        ]
+    }
+}
+```
+
+---
+
+### Authentication Failures
+
+If authentication fails (invalid credentials):
+
+- **View mode:** Redirect back with errors
+- **SPA mode:** JSON response with validation error message (typically 422 status code)
+
+Example JSON response:
+
+```json
+{
+    "message": "These credentials do not match our records."
+}
+```
+
+---
+
+### Two-Factor Challenge Response (SPA Mode)
+
+If two-factor authentication is enabled and a challenge is required, the login attempt will return:
+
+```json
+{
+    "two_factor": true
+}
+```
+
+The client should then redirect the user to the `/two-factor-challenge` endpoint.
+
+---
+
+### Rate Limiting Errors
+
+If too many login attempts are made, Fortify returns a validation error.
+
+**SPA mode:** typically returns a `429 Too Many Requests` response
+
+Example JSON response:
+
+```json
+{
+    "message": "Too many login attempts. Please try again in 60 seconds."
+}
+```

--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -76,7 +76,7 @@ Enable in `config/fortify.php` features array:
 ```
 - [ ] Set 'views' => false in config/fortify.php
 - [ ] Install and configure Laravel Sanctum for session-based SPA authentication
-- [ ] Use 'web' guard in fortify config
+- [ ] Use the 'web' guard in config/fortify.php (required for session-based authentication)
 - [ ] Set up CSRF token handling
 - [ ] Test XHR authentication flows
 ```

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
@@ -14,6 +15,8 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      * Validate and update the given user's profile information.
      *
      * @param  array<string, string>  $input
+     *
+     * @throws ValidationException
      */
     public function update(User $user, array $input): void
     {


### PR DESCRIPTION
This PR enhances the Laravel Fortify development guide by adding a comprehensive 
Error Handling section. It covers how Fortify handles validation, authentication, 
two-factor authentication, and rate-limiting errors in both traditional (view-enabled) 
and SPA (headless) modes.

Key updates include:

- **Validation Errors:** 422 responses, session flash for view mode, JSON structure for SPA mode
- **Authentication Failures:** Example JSON responses for invalid credentials
- **Two-Factor Authentication Challenges:** JSON response structure for SPA mode
- **Rate Limiting Errors:** 429 response examples when login attempts exceed limits

These additions provide developers with practical, ready-to-use examples 
to correctly handle errors when implementing Fortify in Laravel applications, 
especially for headless or SPA setups.