### PR TITLE
Clarify Laravel Sanctum requirement for SPA authentication

### DIFF
--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -75,7 +75,7 @@ Enable in `config/fortify.php` features array:
 
 ```
 - [ ] Set 'views' => false in config/fortify.php
-- [ ] Install and configure Laravel Sanctum for session-based SPA authentication
+- [ ] Install and configure Laravel Sanctum for session-based SPA authentication.Sanctum is required when using Fortify with session-based authentication for SPAs.
 - [ ] Use the 'web' guard in config/fortify.php (required for session-based authentication)
 - [ ] Set up CSRF token handling
 - [ ] Test XHR authentication flows

--- a/resources/boost/skills/developing-with-fortify/SKILL.md
+++ b/resources/boost/skills/developing-with-fortify/SKILL.md
@@ -76,7 +76,7 @@ Enable in `config/fortify.php` features array:
 ```
 - [ ] Set 'views' => false in config/fortify.php
 - [ ] Install and configure Laravel Sanctum for session-based SPA authentication
-- [ ] Use 'web' guard in fortify config
+- [ ] Use the 'web' guard in config/fortify.php (required for session-based authentication)
 - [ ] Set up CSRF token handling
 - [ ] Test XHR authentication flows
 ```

--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
@@ -14,6 +15,8 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      * Validate and update the given user's profile information.
      *
      * @param  array<string, string>  $input
+     *
+     * @throws ValidationException
      */
     public function update(User $user, array $input): void
     {


### PR DESCRIPTION
This PR clarifies that Laravel Sanctum is required when using Fortify for session-based SPA authentication.

The previous wording could imply that Sanctum configuration is optional, while it is actually necessary for session-based SPA setups.

This change improves documentation clarity without introducing any functional changes.