### PR TITLE
Add two-factor code verification as alternative to password confirmation

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -18,6 +18,8 @@ use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController;
 use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
 use Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController;
+use Laravel\Fortify\Http\Controllers\VerifiableTwoFactorCodeController;
+use Laravel\Fortify\Http\Controllers\VerifiedTwoFactorCodeStatusController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 use Laravel\Fortify\RoutePath;
 
@@ -170,5 +172,19 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.regenerate-recovery-codes');
+
+        if ($enableViews) {
+            Route::get(RoutePath::for('two-factor.verify', '/user/verify-two-factor-code'), [VerifiableTwoFactorCodeController::class, 'show'])
+                ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+                ->name('two-factor.verify');
+        }
+
+        Route::get(RoutePath::for('two-factor.verification', '/user/verified-two-factor-code-status'), [VerifiedTwoFactorCodeStatusController::class, 'show'])
+            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+            ->name('two-factor.verification');
+
+        Route::post(RoutePath::for('two-factor.verify', '/user/verify-two-factor-code'), [VerifiableTwoFactorCodeController::class, 'store'])
+            ->middleware([config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')])
+            ->name('two-factor.verify.store');
     }
 });

--- a/src/Actions/VerifyTwoFactorCode.php
+++ b/src/Actions/VerifyTwoFactorCode.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Fortify\Actions;
+
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\Fortify;
+
+class VerifyTwoFactorCode
+{
+    /**
+     * The two factor authentication provider.
+     *
+     * @var \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider
+     */
+    protected $provider;
+
+    /**
+     * Create a new action instance.
+     *
+     * @param  \Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider  $provider
+     * @return void
+     */
+    public function __construct(TwoFactorAuthenticationProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Verify the two factor authentication code for the user.
+     *
+     * @param  mixed  $user
+     * @param  string|null  $code
+     * @return bool
+     */
+    public function __invoke($user, ?string $code = null): bool
+    {
+        if (empty($code) || ! $user->hasEnabledTwoFactorAuthentication()) {
+            return false;
+        }
+
+        return $this->provider->verify(
+            Fortify::currentEncrypter()->decrypt($user->two_factor_secret), $code
+        );
+    }
+}

--- a/src/Contracts/FailedTwoFactorCodeVerificationResponse.php
+++ b/src/Contracts/FailedTwoFactorCodeVerificationResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface FailedTwoFactorCodeVerificationResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/TwoFactorCodeVerifiedResponse.php
+++ b/src/Contracts/TwoFactorCodeVerifiedResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface TwoFactorCodeVerifiedResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/VerifyTwoFactorCodeViewResponse.php
+++ b/src/Contracts/VerifyTwoFactorCodeViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface VerifyTwoFactorCodeViewResponse extends Responsable
+{
+    //
+}

--- a/src/Fortify.php
+++ b/src/Fortify.php
@@ -16,6 +16,7 @@ use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
+use Laravel\Fortify\Contracts\VerifyTwoFactorCodeViewResponse;
 use Laravel\Fortify\Http\Responses\SimpleViewResponse;
 
 class Fortify
@@ -120,6 +121,7 @@ class Fortify
         static::resetPasswordView($prefix.'reset-password');
         static::verifyEmailView($prefix.'verify-email');
         static::confirmPasswordView($prefix.'confirm-password');
+        static::verifyTwoFactorCodeView($prefix.'verify-two-factor-code');
     }
 
     /**
@@ -196,6 +198,19 @@ class Fortify
     public static function confirmPasswordView($view)
     {
         app()->singleton(ConfirmPasswordViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
+    }
+
+    /**
+     * Specify which view should be used as the two factor code verification view.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public static function verifyTwoFactorCodeView($view)
+    {
+        app()->singleton(VerifyTwoFactorCodeViewResponse::class, function () use ($view) {
             return new SimpleViewResponse($view);
         });
     }

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -12,6 +12,7 @@ use Laravel\Fortify\Contracts\EmailVerificationNotificationSentResponse as Email
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswordConfirmationResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse as FailedPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse as FailedPasswordResetResponseContract;
+use Laravel\Fortify\Contracts\FailedTwoFactorCodeVerificationResponse as FailedTwoFactorCodeVerificationResponseContract;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
@@ -25,6 +26,7 @@ use Laravel\Fortify\Contracts\RedirectsIfTwoFactorAuthenticatable as RedirectsIf
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse as SuccessfulPasswordResetLinkRequestResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
+use Laravel\Fortify\Contracts\TwoFactorCodeVerifiedResponse as TwoFactorCodeVerifiedResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorConfirmedResponse as TwoFactorConfirmedResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorDisabledResponse as TwoFactorDisabledResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorEnabledResponse as TwoFactorEnabledResponseContract;
@@ -34,6 +36,7 @@ use Laravel\Fortify\Http\Responses\EmailVerificationNotificationSentResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordConfirmationResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetResponse;
+use Laravel\Fortify\Http\Responses\FailedTwoFactorCodeVerificationResponse;
 use Laravel\Fortify\Http\Responses\FailedTwoFactorLoginResponse;
 use Laravel\Fortify\Http\Responses\LockoutResponse;
 use Laravel\Fortify\Http\Responses\LoginResponse;
@@ -45,6 +48,7 @@ use Laravel\Fortify\Http\Responses\ProfileInformationUpdatedResponse;
 use Laravel\Fortify\Http\Responses\RecoveryCodesGeneratedResponse;
 use Laravel\Fortify\Http\Responses\RegisterResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Http\Responses\TwoFactorCodeVerifiedResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorConfirmedResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorDisabledResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorEnabledResponse;
@@ -91,6 +95,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(FailedPasswordConfirmationResponseContract::class, FailedPasswordConfirmationResponse::class);
         $this->app->singleton(FailedPasswordResetLinkRequestResponseContract::class, FailedPasswordResetLinkRequestResponse::class);
         $this->app->singleton(FailedPasswordResetResponseContract::class, FailedPasswordResetResponse::class);
+        $this->app->singleton(FailedTwoFactorCodeVerificationResponseContract::class, FailedTwoFactorCodeVerificationResponse::class);
         $this->app->singleton(FailedTwoFactorLoginResponseContract::class, FailedTwoFactorLoginResponse::class);
         $this->app->singleton(LockoutResponseContract::class, LockoutResponse::class);
         $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
@@ -103,6 +108,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(EmailVerificationNotificationSentResponseContract::class, EmailVerificationNotificationSentResponse::class);
         $this->app->singleton(SuccessfulPasswordResetLinkRequestResponseContract::class, SuccessfulPasswordResetLinkRequestResponse::class);
+        $this->app->singleton(TwoFactorCodeVerifiedResponseContract::class, TwoFactorCodeVerifiedResponse::class);
         $this->app->singleton(TwoFactorConfirmedResponseContract::class, TwoFactorConfirmedResponse::class);
         $this->app->singleton(TwoFactorDisabledResponseContract::class, TwoFactorDisabledResponse::class);
         $this->app->singleton(TwoFactorEnabledResponseContract::class, TwoFactorEnabledResponse::class);

--- a/src/Http/Controllers/VerifiableTwoFactorCodeController.php
+++ b/src/Http/Controllers/VerifiableTwoFactorCodeController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Fortify\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Date;
+use Laravel\Fortify\Actions\VerifyTwoFactorCode;
+use Laravel\Fortify\Contracts\FailedTwoFactorCodeVerificationResponse;
+use Laravel\Fortify\Contracts\TwoFactorCodeVerifiedResponse;
+use Laravel\Fortify\Contracts\VerifyTwoFactorCodeViewResponse;
+
+class VerifiableTwoFactorCodeController extends Controller
+{
+    /**
+     * Show the two factor code verification view.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Laravel\Fortify\Contracts\VerifyTwoFactorCodeViewResponse
+     */
+    public function show(Request $request)
+    {
+        return app(VerifyTwoFactorCodeViewResponse::class);
+    }
+
+    /**
+     * Verify the user's two factor authentication code.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Laravel\Fortify\Actions\VerifyTwoFactorCode  $verify
+     * @return \Illuminate\Contracts\Support\Responsable
+     */
+    public function store(Request $request, VerifyTwoFactorCode $verify)
+    {
+        $verified = $verify($request->user(), $request->input('code'));
+
+        if ($verified) {
+            $request->session()->put('auth.two_factor_confirmed_at', Date::now()->unix());
+        }
+
+        return $verified
+            ? app(TwoFactorCodeVerifiedResponse::class)
+            : app(FailedTwoFactorCodeVerificationResponse::class);
+    }
+}

--- a/src/Http/Controllers/VerifiedTwoFactorCodeStatusController.php
+++ b/src/Http/Controllers/VerifiedTwoFactorCodeStatusController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Fortify\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Date;
+
+class VerifiedTwoFactorCodeStatusController extends Controller
+{
+    /**
+     * Get the two factor code verification status.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(Request $request)
+    {
+        $lastConfirmation = $request->session()->get(
+            'auth.two_factor_confirmed_at', 0
+        );
+
+        $lastConfirmed = (Date::now()->unix() - $lastConfirmation);
+
+        $confirmed = $lastConfirmed < $request->input(
+            'seconds', config('auth.password_timeout', 900)
+        );
+
+        return response()->json([
+            'confirmed' => $confirmed,
+        ], headers: array_filter([
+            'X-Retry-After' => $confirmed ? $lastConfirmed : null,
+        ]));
+    }
+}

--- a/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/Http/Requests/TwoFactorLoginRequest.php
@@ -5,9 +5,8 @@ namespace Laravel\Fortify\Http\Requests;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Laravel\Fortify\Actions\VerifyTwoFactorCode;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse;
-use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
-use Laravel\Fortify\Fortify;
 
 class TwoFactorLoginRequest extends FormRequest
 {
@@ -55,8 +54,8 @@ class TwoFactorLoginRequest extends FormRequest
      */
     public function hasValidCode()
     {
-        return $this->code && tap(app(TwoFactorAuthenticationProvider::class)->verify(
-            Fortify::currentEncrypter()->decrypt($this->challengedUser()->two_factor_secret), $this->code
+        return $this->code && tap(app(VerifyTwoFactorCode::class)(
+            $this->challengedUser(), $this->code
         ), function ($result) {
             if ($result) {
                 $this->session()->forget('login.id');

--- a/src/Http/Responses/FailedTwoFactorCodeVerificationResponse.php
+++ b/src/Http/Responses/FailedTwoFactorCodeVerificationResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Contracts\FailedTwoFactorCodeVerificationResponse as FailedTwoFactorCodeVerificationResponseContract;
+
+class FailedTwoFactorCodeVerificationResponse implements FailedTwoFactorCodeVerificationResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function toResponse($request)
+    {
+        $message = __('The provided two factor authentication code was invalid.');
+
+        if ($request->wantsJson()) {
+            throw ValidationException::withMessages([
+                'code' => [$message],
+            ]);
+        }
+
+        return back()->withErrors(['code' => $message]);
+    }
+}

--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -10,6 +10,7 @@ use Laravel\Fortify\Contracts\RequestPasswordResetLinkViewResponse;
 use Laravel\Fortify\Contracts\ResetPasswordViewResponse;
 use Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse;
 use Laravel\Fortify\Contracts\VerifyEmailViewResponse;
+use Laravel\Fortify\Contracts\VerifyTwoFactorCodeViewResponse;
 
 class SimpleViewResponse implements
     LoginViewResponse,
@@ -18,7 +19,8 @@ class SimpleViewResponse implements
     RequestPasswordResetLinkViewResponse,
     TwoFactorChallengeViewResponse,
     VerifyEmailViewResponse,
-    ConfirmPasswordViewResponse
+    ConfirmPasswordViewResponse,
+    VerifyTwoFactorCodeViewResponse
 {
     /**
      * The name of the view or the callable used to generate the view.

--- a/src/Http/Responses/TwoFactorCodeVerifiedResponse.php
+++ b/src/Http/Responses/TwoFactorCodeVerifiedResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Fortify\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\TwoFactorCodeVerifiedResponse as TwoFactorCodeVerifiedResponseContract;
+use Laravel\Fortify\Fortify;
+
+class TwoFactorCodeVerifiedResponse implements TwoFactorCodeVerifiedResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $request->wantsJson()
+            ? new JsonResponse('', 200)
+            : redirect()->intended(Fortify::redirects('two-factor-code-verified'));
+    }
+}

--- a/tests/VerifyTwoFactorCodeControllerTest.php
+++ b/tests/VerifyTwoFactorCodeControllerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Laravel\Fortify\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\Attributes\WithMigration;
+use PragmaRX\Google2FA\Google2FA;
+
+#[WithMigration]
+#[DefineEnvironment('withTwoFactorAuthentication')]
+#[WithConfig('auth.providers.users.model', UserWithTwoFactor::class)]
+class VerifyTwoFactorCodeControllerTest extends OrchestraTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::encryptUsing(null);
+    }
+
+    public function test_two_factor_code_can_be_verified()
+    {
+        $tfaEngine = app(Google2FA::class);
+        $userSecret = $tfaEngine->generateSecretKey();
+        $validOtp = $tfaEngine->getCurrentOtp($userSecret);
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt($userSecret),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', ['code' => $validOtp]
+        );
+
+        $response->assertStatus(200);
+    }
+
+    public function test_two_factor_code_verification_fails_with_invalid_code()
+    {
+        $tfaEngine = app(Google2FA::class);
+        $userSecret = $tfaEngine->generateSecretKey();
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt($userSecret),
+        ]);
+
+        $response = $this->withExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', ['code' => 'invalid-code']
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function test_two_factor_code_verification_fails_without_code()
+    {
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt('test-secret'),
+        ]);
+
+        $response = $this->withExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', []
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function test_two_factor_code_verification_fails_without_two_factor_secret()
+    {
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->withExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', ['code' => '123456']
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function test_two_factor_code_verification_requires_authentication()
+    {
+        $response = $this->withExceptionHandling()->postJson(
+            '/user/verify-two-factor-code', ['code' => '123456']
+        );
+
+        $response->assertStatus(401);
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    public function test_two_factor_code_can_be_verified_when_confirmation_is_enabled()
+    {
+        $tfaEngine = app(Google2FA::class);
+        $userSecret = $tfaEngine->generateSecretKey();
+        $validOtp = $tfaEngine->getCurrentOtp($userSecret);
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt($userSecret),
+            'two_factor_confirmed_at' => now(),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', ['code' => $validOtp]
+        );
+
+        $response->assertStatus(200);
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    public function test_two_factor_code_verification_fails_when_not_confirmed()
+    {
+        $tfaEngine = app(Google2FA::class);
+        $userSecret = $tfaEngine->generateSecretKey();
+        $validOtp = $tfaEngine->getCurrentOtp($userSecret);
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt($userSecret),
+            'two_factor_confirmed_at' => null,
+        ]);
+
+        $response = $this->withExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', ['code' => $validOtp]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function test_two_factor_code_verification_sets_session_timestamp()
+    {
+        $tfaEngine = app(Google2FA::class);
+        $userSecret = $tfaEngine->generateSecretKey();
+        $validOtp = $tfaEngine->getCurrentOtp($userSecret);
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+            'two_factor_secret' => encrypt($userSecret),
+        ]);
+
+        $response = $this->withoutExceptionHandling()->actingAs($user)->postJson(
+            '/user/verify-two-factor-code', ['code' => $validOtp]
+        );
+
+        $response->assertStatus(200)
+            ->assertSessionHas('auth.two_factor_confirmed_at');
+    }
+
+    public function test_two_factor_code_verification_status_returns_confirmed()
+    {
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($user)
+            ->withSession(['auth.two_factor_confirmed_at' => time()])
+            ->getJson('/user/verified-two-factor-code-status');
+
+        $response->assertStatus(200)
+            ->assertJson(['confirmed' => true]);
+    }
+
+    public function test_two_factor_code_verification_status_returns_not_confirmed()
+    {
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Paulinus Perekpo',
+            'email' => 'perepaul@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($user)
+            ->getJson('/user/verified-two-factor-code-status');
+
+        $response->assertStatus(200)
+            ->assertJson(['confirmed' => false]);
+    }
+}


### PR DESCRIPTION
## Summary

This adds a complete two-factor code verification flow that serves as a drop-in alternative to password confirmation. Instead of requiring a password to access sensitive actions, users can verify their identity by providing a TOTP code from their authenticator app.

**New action:**
- `VerifyTwoFactorCode` — returns `bool` after verifying a TOTP code against the user's two-factor secret. Respects the confirmation flow by checking `hasEnabledTwoFactorAuthentication()`.

**New controllers (following existing naming conventions):**
- `VerifiableTwoFactorCodeController` — shows the verification view and handles code submission, storing a session timestamp on success (mirrors `ConfirmablePasswordController`).
- `VerifiedTwoFactorCodeStatusController` — returns JSON indicating whether the user has recently verified their two-factor code (mirrors `ConfirmedPasswordStatusController`).

**New contracts and responses:**
- `TwoFactorCodeVerifiedResponse` / `FailedTwoFactorCodeVerificationResponse`
- `VerifyTwoFactorCodeViewResponse` (integrated into `SimpleViewResponse`)

**Routes added (auth middleware only — no `password.confirm`, since this replaces it):**
- `GET /user/verify-two-factor-code` — view
- `POST /user/verify-two-factor-code` — store
- `GET /user/verified-two-factor-code-status` — status

**Refactor:**
- `TwoFactorLoginRequest::hasValidCode()` now delegates to the `VerifyTwoFactorCode` action, centralizing TOTP verification logic.

## Benefit

Users with two-factor authentication enabled can use their TOTP code as an alternative "sudo" check for sensitive operations, providing a consistent security UX without falling back to password re-entry.

All response contracts are swappable via the container, following the established Fortify pattern.

## Test plan

- [x] Valid TOTP code returns 200
- [x] Invalid code returns 422
- [x] Missing code returns 422
- [x] Missing two-factor secret returns 422
- [x] Unauthenticated request returns 401
- [x] Confirmed 2FA flow: valid code with `two_factor_confirmed_at` returns 200
- [x] Confirmed 2FA flow: valid code without `two_factor_confirmed_at` returns 422
- [x] Session timestamp is set on successful verification
- [x] Status endpoint returns `confirmed: true` when recently verified
- [x] Status endpoint returns `confirmed: false` when not verified
- [x] All 108 existing + new tests pass