### PR TITLE
 feat: Add mustConfirmTwoFactorAuthentication method

### DIFF
--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -28,7 +28,6 @@ trait TwoFactorAuthenticatable
         return ! is_null($this->two_factor_secret);
     }
 
-
     /**
      * Determine if the user must confirm two-factor authentication.
      *

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -28,6 +28,19 @@ trait TwoFactorAuthenticatable
         return ! is_null($this->two_factor_secret);
     }
 
+
+    /**
+     * Determine if the user must confirm two-factor authentication.
+     *
+     * @return bool
+     */
+    public function mustConfirmTwoFactorAuthentication()
+    {
+        return Fortify::confirmsTwoFactorAuthentication() &&
+               ! is_null($this->two_factor_secret) &&
+               is_null($this->two_factor_confirmed_at);
+    }
+
     /**
      * Get the user's two factor authentication recovery codes.
      *


### PR DESCRIPTION
This PR introduces the mustConfirmTwoFactorAuthentication() method to the TwoFactorAuthenticatable trait. This method determines if a user's two-factor authentication has been enabled but is awaiting a final confirmation step.

It provides a consistent point for developers to check this state, allowing for varied UI and flow implementations to guide users through 2FA confirmation. It also eliminates the need for individual developers to implement this common logic, reducing boilerplate.