### PR TITLE
Rewrite Fortify core guidelines and skill descriptions in imperative style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.DS_Store

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,5 +1,0 @@
-# Laravel Fortify
-
-- Fortify is a headless authentication backend that provides authentication routes and controllers for Laravel applications.
-- IMPORTANT: Always use the `search-docs` tool for detailed Laravel Fortify patterns and documentation.
-- IMPORTANT: Activate `developing-with-fortify` skill when working with Fortify authentication features.

--- a/resources/boost/skills/fortify-development/SKILL.md
+++ b/resources/boost/skills/fortify-development/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: fortify-development
-description: Laravel Fortify headless authentication backend development. Activate when implementing authentication features including login, registration, password reset, email verification, two-factor authentication (2FA/TOTP), profile updates, headless auth, authentication scaffolding, or auth guards in Laravel applications.
+description: 'ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.'
+license: MIT
+metadata:
+  author: laravel
 ---
 
 # Laravel Fortify Development


### PR DESCRIPTION
When we first wrote the Fortify skill descriptions, they were verbose and passive — describing what the skill does rather than telling the model when to activate it. This wasted tokens and made triggering inconsistent.

We now have an eval system for testing and improving skill descriptions, so they trigger reliably. This PR rewrites the core Fortify guidelines and skill descriptions in a concise imperative style following the structured trigger/coverage/boundary pattern.