### PR TITLE
Update reference from Jetstream to Starter Kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Introduction
 
-Laravel Fortify is a frontend agnostic authentication backend for Laravel. Fortify powers the registration, authentication, and two-factor authentication features of [Laravel Jetstream](https://github.com/laravel/jetstream).
+Laravel Fortify is a frontend agnostic authentication backend for Laravel. Fortify powers the registration, authentication, and two-factor authentication features of [Laravel Starter Kits](https://laravel.com/starter-kits).
 
 ## Official Documentation
 


### PR DESCRIPTION
I think, as Jetstream is no longer the first choice for new projects, we have new awesome starter kits that use Fortify as well. This will be a good idea to point them to instead of Jetstream.