### PR TITLE
Make user contracts generic

### DIFF
--- a/src/Contracts/CreatesNewUsers.php
+++ b/src/Contracts/CreatesNewUsers.php
@@ -2,13 +2,16 @@
 
 namespace Laravel\Fortify\Contracts;
 
+/**
+ * @template TUser of \Illuminate\Database\Eloquent\Model = \Illuminate\Foundation\Auth\User
+ */
 interface CreatesNewUsers
 {
     /**
      * Validate and create a newly registered user.
      *
      * @param  array  $input
-     * @return \Illuminate\Foundation\Auth\User
+     * @return TUser
      */
     public function create(array $input);
 }

--- a/src/Contracts/ResetsUserPasswords.php
+++ b/src/Contracts/ResetsUserPasswords.php
@@ -3,7 +3,9 @@
 namespace Laravel\Fortify\Contracts;
 
 /**
- * @method void reset(\Illuminate\Foundation\Auth\User $user, array $input)
+ * @template TUser of \Illuminate\Database\Eloquent\Model = \Illuminate\Foundation\Auth\User
+ *
+ * @method void reset(TUser $user, array $input)
  */
 interface ResetsUserPasswords
 {

--- a/src/Contracts/UpdatesUserPasswords.php
+++ b/src/Contracts/UpdatesUserPasswords.php
@@ -3,7 +3,9 @@
 namespace Laravel\Fortify\Contracts;
 
 /**
- * @method void update(\Illuminate\Foundation\Auth\User $user, array $input)
+ * @template TUser of \Illuminate\Database\Eloquent\Model = \Illuminate\Foundation\Auth\User
+ *
+ * @method void update(TUser $user, array $input)
  */
 interface UpdatesUserPasswords
 {

--- a/src/Contracts/UpdatesUserProfileInformation.php
+++ b/src/Contracts/UpdatesUserProfileInformation.php
@@ -3,7 +3,9 @@
 namespace Laravel\Fortify\Contracts;
 
 /**
- * @method void update(\Illuminate\Foundation\Auth\User $user, array $input)
+ * @template TUser of \Illuminate\Database\Eloquent\Model = \Illuminate\Foundation\Auth\User
+ *
+ * @method void update(TUser $user, array $input)
  */
 interface UpdatesUserProfileInformation
 {


### PR DESCRIPTION
The contracts for the actions that interact with users currently specify `\Illuminate\Foundation\Auth\User` as the user type. However, this definition doesn't allow other user models that don't extend `\Illuminate\Foundation\Auth\User`, which leads to PHPStan errors, as shown in this example:

https://phpstan.org/r/c0fd079b-3cbf-4fa6-91be-d35bfc7f791c

By adding generics to these contracts, the actions can use any user model (as long as it extends `\Illuminate\Database\Eloquent\Model`):

https://phpstan.org/r/e5721cf1-e7f2-4803-b97f-e5c2d14e728c

This is not a breaking change because `\Illuminate\Foundation\Auth\User` is used as the default type.