### PR TITLE
Feat/add passkeys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "laravel/passkeys": "dev-main#f3f8e93",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
@@ -48,6 +49,12 @@
             ]
         }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/laravel/passkeys-server"
+        }
+    ],
     "config": {
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main#58f0d4b",
+        "laravel/passkeys": "dev-main#f4f7a72c",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main#64632ef",
+        "laravel/passkeys": "dev-main",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
@@ -49,12 +49,6 @@
             ]
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/laravel/passkeys-server"
-        }
-    ],
     "config": {
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main#50bda636",
+        "laravel/passkeys": "dev-main#64632ef",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
-        "laravel/passkeys": "0.1.0",
+        "laravel/passkeys": "^0.1.0",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main#aaa87a3",
+        "laravel/passkeys": "dev-main#58f0d4b",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main#f3f8e93",
+        "laravel/passkeys": "dev-main#aaa87a3",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main",
+        "laravel/passkeys": "0.1.0",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passkeys": "dev-main#f4f7a72c",
+        "laravel/passkeys": "dev-main#50bda636",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -70,6 +70,8 @@ return [
     ],
     'passkeys' => [
         'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
+        'allowed_origins' => [config('app.url')],
+        'user_handle_secret' => env('PASSKEYS_USER_HANDLE_SECRET', config('app.key')),
         'timeout' => 60000,
     ],
     'features' => [

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -51,8 +51,10 @@ return [
             'recovery-codes' => null,
         ],
         'passkey' => [
-            'verification-options' => null,
-            'verify' => null,
+            'login-options' => null,
+            'login' => null,
+            'confirm-options' => null,
+            'confirm' => null,
             'registration-options' => null,
             'store' => null,
             'destroy' => null,

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -16,6 +16,7 @@ return [
     'lowercase_usernames' => false,
     'limiters' => [
         'login' => null,
+        'passkeys' => null,
     ],
     'paths' => [
         'login' => null,
@@ -49,6 +50,13 @@ return [
             'secret-key' => null,
             'recovery-codes' => null,
         ],
+        'passkey' => [
+            'verification-options' => null,
+            'verify' => null,
+            'registration-options' => null,
+            'store' => null,
+            'destroy' => null,
+        ],
     ],
     'redirects' => [
         'login' => null,
@@ -58,6 +66,10 @@ return [
         'email-verification' => null,
         'password-reset' => null,
     ],
+    'passkeys' => [
+        'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
+        'timeout' => 60000,
+    ],
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
@@ -65,5 +77,6 @@ return [
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication(),
+        Features::passkeys(),
     ],
 ];

--- a/resources/boost/skills/fortify-development/SKILL.md
+++ b/resources/boost/skills/fortify-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fortify-development
-description: 'ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.'
+description: 'ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), passkeys, profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, passkeys, WebAuthn, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.'
 license: MIT
 metadata:
   author: laravel
@@ -32,6 +32,7 @@ Enable in `config/fortify.php` features array:
 - `Features::updateProfileInformation()` - Profile updates
 - `Features::updatePasswords()` - Password changes
 - `Features::twoFactorAuthentication()` - 2FA with QR codes and recovery codes
+- `Features::passkeys()` - Passwordless authentication with WebAuthn passkeys
 
 > Use `search-docs` for feature configuration options and customization patterns.
 
@@ -49,6 +50,18 @@ Enable in `config/fortify.php` features array:
 ```
 
 > Use `search-docs` for TOTP implementation and recovery code handling patterns.
+
+### Passkeys Setup
+
+```
+- [ ] Add PasskeyAuthenticatable trait to User model and implement PasskeyUser
+- [ ] Enable passkeys feature in config/fortify.php
+- [ ] If the passkeys table migration is missing, publish via `php artisan vendor:publish --tag=fortify-migrations` and migrate
+- [ ] Configure passkeys relying_party_id, allowed_origins, user_handle_secret, and timeout if defaults are not suitable
+- [ ] Build UI with @laravel/passkeys for registration, login, confirmation, and deletion
+```
+
+> Use `search-docs` for passkey configuration options. For `@laravel/passkeys` frontend usage, refer to the package's README on npm.
 
 ### Email Verification Setup
 
@@ -129,3 +142,10 @@ Configure via `fortify.limiters.login` in config. Default configuration throttle
 | 2FA Challenge          | POST     | `/two-factor-challenge`                     |
 | Get QR Code            | GET      | `/user/two-factor-qr-code`                  |
 | Recovery Codes         | GET/POST | `/user/two-factor-recovery-codes`           |
+| Passkey Login Options  | GET      | `/passkeys/login/options`                   |
+| Passkey Login          | POST     | `/passkeys/login`                           |
+| Passkey Confirm Options| GET      | `/passkeys/confirm/options`                 |
+| Passkey Confirm        | POST     | `/passkeys/confirm`                         |
+| Passkey Options        | GET      | `/user/passkeys/options`                    |
+| Register Passkey       | POST     | `/user/passkeys`                            |
+| Delete Passkey         | DELETE   | `/user/passkeys/{passkey}`                  |

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -178,46 +178,38 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     // Passkeys...
     if (Features::enabled(Features::passkeys())) {
-        Route::get(RoutePath::for('passkey.login-options', '/passkeys/login/options'), [PasskeyLoginController::class, 'index'])
-            ->middleware(array_filter([
-                'guest:'.config('fortify.guard'),
-                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ]))->name('passkey.login-options');
-
-        Route::post(RoutePath::for('passkey.login', '/passkeys/login'), [PasskeyLoginController::class, 'store'])
-            ->middleware(array_filter([
-                'guest:'.config('fortify.guard'),
-                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ]))->name('passkey.login');
-
-        $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
-
-        Route::get(RoutePath::for('passkey.confirm-options', '/passkeys/confirm/options'), [PasskeyConfirmationController::class, 'index'])
-            ->middleware(array_filter(array_merge($passkeyAuthMiddleware, [
-                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ])))
-            ->name('passkey.confirm-options');
-
-        Route::post(RoutePath::for('passkey.confirm', '/passkeys/confirm'), [PasskeyConfirmationController::class, 'store'])
-            ->middleware(array_filter(array_merge($passkeyAuthMiddleware, [
-                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ])))
-            ->name('passkey.confirm');
-
+        $throttle = $passkeyLimiter ? ['throttle:' . $passkeyLimiter] : [];
+        $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth') . ':' . config('fortify.guard')];
         $passkeyMiddleware = Features::optionEnabled(Features::passkeys(), 'confirmPassword')
             ? [...$passkeyAuthMiddleware, 'password.confirm']
             : $passkeyAuthMiddleware;
 
+        $passkeyGuestMiddleware = ['guest:' . config('fortify.guard'), ...$throttle];
+        $passkeyConfirmMiddleware = [$passkeyAuthMiddleware, ...$throttle];
+        $passkeyManageMiddleware = [$passkeyMiddleware, ...$throttle];
+
+        Route::get(RoutePath::for('passkey.login-options', '/passkeys/login/options'), [PasskeyLoginController::class, 'index'])
+            ->middleware($passkeyGuestMiddleware)
+            ->name('passkey.login-options');
+
+        Route::post(RoutePath::for('passkey.login', '/passkeys/login'), [PasskeyLoginController::class, 'store'])
+            ->middleware($passkeyGuestMiddleware)
+            ->name('passkey.login');
+
+        Route::get(RoutePath::for('passkey.confirm-options', '/passkeys/confirm/options'), [PasskeyConfirmationController::class, 'index'])
+            ->middleware($passkeyConfirmMiddleware)
+            ->name('passkey.confirm-options');
+
+        Route::post(RoutePath::for('passkey.confirm', '/passkeys/confirm'), [PasskeyConfirmationController::class, 'store'])
+            ->middleware($passkeyConfirmMiddleware)
+            ->name('passkey.confirm');
+
         Route::get(RoutePath::for('passkey.registration-options', '/user/passkeys/options'), [PasskeyRegistrationController::class, 'index'])
-            ->middleware(array_filter(array_merge($passkeyMiddleware, [
-                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ])))
+            ->middleware($passkeyManageMiddleware)
             ->name('passkey.registration-options');
 
         Route::post(RoutePath::for('passkey.store', '/user/passkeys'), [PasskeyRegistrationController::class, 'store'])
-            ->middleware(array_filter(array_merge($passkeyMiddleware, [
-                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ])))
+            ->middleware($passkeyManageMiddleware)
             ->name('passkey.store');
 
         Route::delete(RoutePath::for('passkey.destroy', '/user/passkeys/{passkey}'), [PasskeyRegistrationController::class, 'destroy'])

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -185,8 +185,8 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
             : $passkeyAuthMiddleware;
 
         $passkeyGuestMiddleware = ['guest:'.config('fortify.guard'), ...$throttle];
-        $passkeyConfirmMiddleware = [$passkeyAuthMiddleware, ...$throttle];
-        $passkeyManageMiddleware = [$passkeyMiddleware, ...$throttle];
+        $passkeyConfirmMiddleware = [...$passkeyAuthMiddleware, ...$throttle];
+        $passkeyManageMiddleware = [...$passkeyMiddleware, ...$throttle];
 
         Route::get(RoutePath::for('passkey.login-options', '/passkeys/login/options'), [PasskeyLoginController::class, 'index'])
             ->middleware($passkeyGuestMiddleware)

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -179,7 +179,9 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
     // Passkeys...
     if (Features::enabled(Features::passkeys())) {
         $throttle = $passkeyLimiter ? ['throttle:'.$passkeyLimiter] : [];
+
         $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
+
         $passkeyMiddleware = Features::optionEnabled(Features::passkeys(), 'confirmPassword')
             ? [...$passkeyAuthMiddleware, 'password.confirm']
             : $passkeyAuthMiddleware;

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -178,13 +178,13 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     // Passkeys...
     if (Features::enabled(Features::passkeys())) {
-        $throttle = $passkeyLimiter ? ['throttle:' . $passkeyLimiter] : [];
-        $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth') . ':' . config('fortify.guard')];
+        $throttle = $passkeyLimiter ? ['throttle:'.$passkeyLimiter] : [];
+        $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
         $passkeyMiddleware = Features::optionEnabled(Features::passkeys(), 'confirmPassword')
             ? [...$passkeyAuthMiddleware, 'password.confirm']
             : $passkeyAuthMiddleware;
 
-        $passkeyGuestMiddleware = ['guest:' . config('fortify.guard'), ...$throttle];
+        $passkeyGuestMiddleware = ['guest:'.config('fortify.guard'), ...$throttle];
         $passkeyConfirmMiddleware = [$passkeyAuthMiddleware, ...$throttle];
         $passkeyManageMiddleware = [$passkeyMiddleware, ...$throttle];
 

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -20,6 +20,8 @@ use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
 use Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 use Laravel\Fortify\RoutePath;
+use Laravel\Passkeys\Http\Controllers\PasskeyRegistrationController;
+use Laravel\Passkeys\Http\Controllers\PasskeyVerificationController;
 
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
     $enableViews = config('fortify.views', true);
@@ -33,6 +35,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     $limiter = config('fortify.limiters.login');
     $twoFactorLimiter = config('fortify.limiters.two-factor');
+    $passkeyLimiter = config('fortify.limiters.passkeys');
     $verificationLimiter = config('fortify.limiters.verification', '6,1');
 
     Route::post(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'store'])
@@ -170,5 +173,40 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         Route::post(RoutePath::for('two-factor.recovery-codes', '/user/two-factor-recovery-codes'), [RecoveryCodeController::class, 'store'])
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.regenerate-recovery-codes');
+    }
+
+    // Passkeys...
+    if (Features::enabled(Features::passkeys())) {
+        Route::get(RoutePath::for('passkey.verification-options', '/passkeys/options'), [PasskeyVerificationController::class, 'index'])
+            ->middleware(array_filter([
+                'guest:'.config('fortify.guard'),
+                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
+            ]))->name('passkey.verification-options');
+
+        Route::post(RoutePath::for('passkey.verify', '/passkeys/verify'), [PasskeyVerificationController::class, 'store'])
+            ->middleware(array_filter([
+                'guest:'.config('fortify.guard'),
+                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
+            ]))->name('passkey.verify');
+
+        $passkeyMiddleware = Features::optionEnabled(Features::passkeys(), 'confirmPassword')
+            ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']
+            : [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
+
+        Route::get(RoutePath::for('passkey.registration-options', '/user/passkeys/options'), [PasskeyRegistrationController::class, 'index'])
+            ->middleware(array_filter(array_merge($passkeyMiddleware, [
+                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
+            ])))
+            ->name('passkey.registration-options');
+
+        Route::post(RoutePath::for('passkey.store', '/user/passkeys'), [PasskeyRegistrationController::class, 'store'])
+            ->middleware(array_filter(array_merge($passkeyMiddleware, [
+                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
+            ])))
+            ->name('passkey.store');
+
+        Route::delete(RoutePath::for('passkey.destroy', '/user/passkeys/{passkey}'), [PasskeyRegistrationController::class, 'destroy'])
+            ->middleware($passkeyMiddleware)
+            ->name('passkey.destroy');
     }
 });

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -20,8 +20,9 @@ use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
 use Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController;
 use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 use Laravel\Fortify\RoutePath;
+use Laravel\Passkeys\Http\Controllers\PasskeyConfirmationController;
+use Laravel\Passkeys\Http\Controllers\PasskeyLoginController;
 use Laravel\Passkeys\Http\Controllers\PasskeyRegistrationController;
-use Laravel\Passkeys\Http\Controllers\PasskeyVerificationController;
 
 Route::group(['middleware' => config('fortify.middleware', ['web'])], function () {
     $enableViews = config('fortify.views', true);
@@ -177,21 +178,35 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
     // Passkeys...
     if (Features::enabled(Features::passkeys())) {
-        Route::get(RoutePath::for('passkey.verification-options', '/passkeys/options'), [PasskeyVerificationController::class, 'index'])
+        Route::get(RoutePath::for('passkey.login-options', '/passkeys/login/options'), [PasskeyLoginController::class, 'index'])
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
                 $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ]))->name('passkey.verification-options');
+            ]))->name('passkey.login-options');
 
-        Route::post(RoutePath::for('passkey.verify', '/passkeys/verify'), [PasskeyVerificationController::class, 'store'])
+        Route::post(RoutePath::for('passkey.login', '/passkeys/login'), [PasskeyLoginController::class, 'store'])
             ->middleware(array_filter([
                 'guest:'.config('fortify.guard'),
                 $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
-            ]))->name('passkey.verify');
+            ]))->name('passkey.login');
+
+        $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
+
+        Route::get(RoutePath::for('passkey.confirm-options', '/passkeys/confirm/options'), [PasskeyConfirmationController::class, 'index'])
+            ->middleware(array_filter(array_merge($passkeyAuthMiddleware, [
+                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
+            ])))
+            ->name('passkey.confirm-options');
+
+        Route::post(RoutePath::for('passkey.confirm', '/passkeys/confirm'), [PasskeyConfirmationController::class, 'store'])
+            ->middleware(array_filter(array_merge($passkeyAuthMiddleware, [
+                $passkeyLimiter ? 'throttle:'.$passkeyLimiter : null,
+            ])))
+            ->name('passkey.confirm');
 
         $passkeyMiddleware = Features::optionEnabled(Features::passkeys(), 'confirmPassword')
-            ? [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard'), 'password.confirm']
-            : [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
+            ? [...$passkeyAuthMiddleware, 'password.confirm']
+            : $passkeyAuthMiddleware;
 
         Route::get(RoutePath::for('passkey.registration-options', '/user/passkeys/options'), [PasskeyRegistrationController::class, 'index'])
             ->middleware(array_filter(array_merge($passkeyMiddleware, [

--- a/src/Contracts/PasskeyUser.php
+++ b/src/Contracts/PasskeyUser.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Fortify\Contracts;
 
-interface PasskeyUser extends \Laravel\Passkeys\Contracts\PasskeyUser
+use Laravel\Passkeys\Contracts\PasskeyUser as BasePasskeyUser;
+
+interface PasskeyUser extends BasePasskeyUser
 {
     //
 }

--- a/src/Contracts/PasskeyUser.php
+++ b/src/Contracts/PasskeyUser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Fortify\Contracts;
+
+interface PasskeyUser extends \Laravel\Passkeys\Contracts\PasskeyUser
+{
+    //
+}

--- a/src/Features.php
+++ b/src/Features.php
@@ -37,7 +37,8 @@ class Features
     {
         return static::enabled(static::updateProfileInformation()) ||
                static::enabled(static::updatePasswords()) ||
-               static::enabled(static::twoFactorAuthentication());
+               static::enabled(static::twoFactorAuthentication()) ||
+               static::enabled(static::passkeys());
     }
 
     /**
@@ -58,7 +59,8 @@ class Features
     public static function hasSecurityFeatures()
     {
         return static::enabled(static::updatePasswords()) ||
-               static::canManageTwoFactorAuthentication();
+               static::canManageTwoFactorAuthentication() ||
+               static::canManagePasskeys();
     }
 
     /**
@@ -79,6 +81,16 @@ class Features
     public static function canManageTwoFactorAuthentication()
     {
         return static::enabled(static::twoFactorAuthentication());
+    }
+
+    /**
+     * Determine if the application can manage passkeys.
+     *
+     * @return bool
+     */
+    public static function canManagePasskeys()
+    {
+        return static::enabled(static::passkeys());
     }
 
     /**
@@ -144,5 +156,20 @@ class Features
         }
 
         return 'two-factor-authentication';
+    }
+
+    /**
+     * Enable the passkeys feature.
+     *
+     * @param  array  $options
+     * @return string
+     */
+    public static function passkeys(array $options = [])
+    {
+        if (! empty($options)) {
+            config(['fortify-options.passkeys' => $options]);
+        }
+
+        return 'passkeys';
     }
 }

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -128,6 +128,8 @@ class FortifyServiceProvider extends ServiceProvider
 
         config([
             'passkeys.relying_party_id' => config('fortify.passkeys.relying_party_id', parse_url(config('app.url'), PHP_URL_HOST)),
+            'passkeys.allowed_origins' => config('fortify.passkeys.allowed_origins', [config('app.url')]),
+            'passkeys.user_handle_secret' => config('fortify.passkeys.user_handle_secret', config('app.key')),
             'passkeys.timeout' => config('fortify.passkeys.timeout', 60000),
             'passkeys.guard' => config('fortify.guard', 'web'),
             'passkeys.middleware' => config('fortify.middleware', ['web']),

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -50,6 +50,7 @@ use Laravel\Fortify\Http\Responses\TwoFactorDisabledResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorEnabledResponse;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
 use Laravel\Fortify\Http\Responses\VerifyEmailResponse;
+use Laravel\Passkeys\Passkeys as LaravelPasskeys;
 use PragmaRX\Google2FA\Google2FA;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -62,6 +63,8 @@ class FortifyServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/fortify.php', 'fortify');
+
+        $this->configurePasskeys();
 
         $this->registerResponseBindings();
 
@@ -111,6 +114,58 @@ class FortifyServiceProvider extends ServiceProvider
     }
 
     /**
+     * Configure passkeys integration.
+     *
+     * @return void
+     */
+    protected function configurePasskeys()
+    {
+        LaravelPasskeys::ignoreRoutes();
+
+        if ($model = $this->passkeyUserModel()) {
+            LaravelPasskeys::useUserModel($model);
+        }
+
+        config([
+            'passkeys.relying_party_id' => config('fortify.passkeys.relying_party_id', parse_url(config('app.url'), PHP_URL_HOST)),
+            'passkeys.timeout' => config('fortify.passkeys.timeout', 60000),
+            'passkeys.guard' => config('fortify.guard', 'web'),
+            'passkeys.middleware' => config('fortify.middleware', ['web']),
+            'passkeys.redirect' => Fortify::redirects('login'),
+            'passkeys.throttle' => $this->passkeyThrottleMiddleware(),
+        ]);
+    }
+
+    /**
+     * Get the authentication model used by Fortify's guard.
+     *
+     * @return string|null
+     */
+    protected function passkeyUserModel()
+    {
+        $guard = config('fortify.guard', config('auth.defaults.guard', 'web'));
+        $provider = config("auth.guards.{$guard}.provider", config('auth.defaults.provider'));
+
+        if (! $provider) {
+            return config('auth.providers.users.model');
+        }
+
+        return config("auth.providers.{$provider}.model", config('auth.providers.users.model'));
+    }
+
+    /**
+     * Get the passkeys throttle middleware.
+     *
+     * @return string|null
+     */
+    protected function passkeyThrottleMiddleware()
+    {
+        $limiter = config('fortify.limiters.passkeys');
+
+        return $limiter ? 'throttle:'.$limiter : null;
+    }
+
+    /**
      * Bootstrap any application services.
      *
      * @return void
@@ -147,6 +202,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             $this->{$method}([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
+                LaravelPasskeys::migrationPath() => database_path('migrations'),
             ], 'fortify-migrations');
         }
     }

--- a/src/PasskeyAuthenticatable.php
+++ b/src/PasskeyAuthenticatable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Fortify;
+
+/**
+ * @phpstan-require-implements \Laravel\Fortify\Contracts\PasskeyUser
+ */
+trait PasskeyAuthenticatable
+{
+    use \Laravel\Passkeys\PasskeyAuthenticatable;
+}

--- a/src/PasskeyAuthenticatable.php
+++ b/src/PasskeyAuthenticatable.php
@@ -2,10 +2,12 @@
 
 namespace Laravel\Fortify;
 
+use Laravel\Passkeys\PasskeyAuthenticatable as BasePasskeyAuthenticatable;
+
 /**
  * @phpstan-require-implements \Laravel\Fortify\Contracts\PasskeyUser
  */
 trait PasskeyAuthenticatable
 {
-    use \Laravel\Passkeys\PasskeyAuthenticatable;
+    use BasePasskeyAuthenticatable;
 }

--- a/stubs/FortifyServiceProvider.php
+++ b/stubs/FortifyServiceProvider.php
@@ -44,5 +44,13 @@ class FortifyServiceProvider extends ServiceProvider
         RateLimiter::for('two-factor', function (Request $request) {
             return Limit::perMinute(5)->by($request->session()->get('login.id'));
         });
+
+        RateLimiter::for('passkeys', function (Request $request) {
+            $credentialId = $request->input('credential.id');
+
+            return Limit::perMinute(10)->by(
+                ($credentialId ?: $request->session()->getId()).'|'.$request->ip()
+            );
+        });
     }
 }

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -109,8 +109,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | By default, Fortify will throttle logins to five requests per minute for
-    | every email and IP address combination. If you would like to specify
-    | custom rate limiters, you may define them here.
+    | every email and IP address combination. However, if you would like to
+    | specify a custom rate limiter to call then you may specify it here.
     |
     */
 

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -145,7 +145,6 @@ return [
     'passkeys' => [
         'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
         'allowed_origins' => [config('app.url')],
-        'user_handle_secret' => env('PASSKEYS_USER_HANDLE_SECRET', config('app.key')),
         'timeout' => 60000,
     ],
 

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -109,14 +109,15 @@ return [
     |--------------------------------------------------------------------------
     |
     | By default, Fortify will throttle logins to five requests per minute for
-    | every email and IP address combination. However, if you would like to
-    | specify a custom rate limiter to call then you may specify it here.
+    | every email and IP address combination. If you would like to specify
+    | custom rate limiters, you may define them here.
     |
     */
 
     'limiters' => [
         'login' => 'login',
         'two-factor' => 'two-factor',
+        'passkeys' => 'passkeys',
     ],
 
     /*
@@ -131,6 +132,20 @@ return [
     */
 
     'views' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passkeys
+    |--------------------------------------------------------------------------
+    |
+    | These settings configure Fortify's passkey (WebAuthn) support.
+    |
+    */
+
+    'passkeys' => [
+        'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
+        'timeout' => 60000,
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -153,6 +168,9 @@ return [
             'confirm' => true,
             'confirmPassword' => true,
             // 'window' => 0,
+        ]),
+        Features::passkeys([
+            'confirmPassword' => true,
         ]),
     ],
 

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -144,6 +144,8 @@ return [
 
     'passkeys' => [
         'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
+        'allowed_origins' => [config('app.url')],
+        'user_handle_secret' => env('PASSKEYS_USER_HANDLE_SECRET', config('app.key')),
         'timeout' => 60000,
     ],
 

--- a/stubs/fortify.php
+++ b/stubs/fortify.php
@@ -138,7 +138,9 @@ return [
     | Passkeys
     |--------------------------------------------------------------------------
     |
-    | These settings configure Fortify's passkey (WebAuthn) support.
+    | These settings configure Fortify's passkey (WebAuthn) support. Passkeys
+    | allow users to sign in without needing to remember credentials since
+    | they use public-key cryptography - making them immune to breaches.
     |
     */
 

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -34,9 +34,47 @@ abstract class OrchestraTestCase extends TestCase
         tap($app['config'], function ($config) {
             $features = $config->get('fortify.features');
 
-            unset($features[array_search(Features::twoFactorAuthentication(), $features)]);
+            if (($key = array_search(Features::twoFactorAuthentication(), $features)) !== false) {
+                unset($features[$key]);
+            }
 
-            $config->set('fortify.features', $features);
+            $config->set('fortify.features', array_values($features));
+        });
+    }
+
+    protected function withPasskeys($app)
+    {
+        $app['config']->set('fortify.features', [
+            Features::passkeys(),
+        ]);
+    }
+
+    protected function withPasskeysConfirmingPasswords($app)
+    {
+        $app['config']->set('fortify.features', [
+            Features::passkeys(['confirmPassword' => true]),
+        ]);
+    }
+
+    protected function withPasskeysLimiter($app)
+    {
+        $app['config']->set('fortify.features', [
+            Features::passkeys(),
+        ]);
+
+        $app['config']->set('fortify.limiters.passkeys', 'passkeys');
+    }
+
+    protected function withoutPasskeys($app)
+    {
+        tap($app['config'], function ($config) {
+            $features = $config->get('fortify.features');
+
+            if (($key = array_search(Features::passkeys(), $features)) !== false) {
+                unset($features[$key]);
+            }
+
+            $config->set('fortify.features', array_values($features));
         });
     }
 }

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -5,6 +5,8 @@ namespace Laravel\Fortify\Tests;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
+use Laravel\Passkeys\Http\Controllers\PasskeyConfirmationController;
+use Laravel\Passkeys\Http\Controllers\PasskeyLoginController;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 
 class PasskeyTest extends OrchestraTestCase
@@ -21,11 +23,24 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertTrue(Features::hasSecurityFeatures());
         $this->assertTrue(Features::hasProfileFeatures());
 
-        $this->assertTrue(Route::has('passkey.verification-options'));
-        $this->assertTrue(Route::has('passkey.verify'));
+        $this->assertTrue(Route::has('passkey.login-options'));
+        $this->assertTrue(Route::has('passkey.login'));
+        $this->assertTrue(Route::has('passkey.confirm-options'));
+        $this->assertTrue(Route::has('passkey.confirm'));
         $this->assertTrue(Route::has('passkey.registration-options'));
         $this->assertTrue(Route::has('passkey.store'));
         $this->assertTrue(Route::has('passkey.destroy'));
+    }
+
+    public function test_passkeys_routes_use_the_expected_passkeys_controllers()
+    {
+        $verify = Route::getRoutes()->getByName('passkey.login');
+        $confirm = Route::getRoutes()->getByName('passkey.confirm');
+
+        $this->assertNotNull($verify);
+        $this->assertNotNull($confirm);
+        $this->assertSame(PasskeyLoginController::class.'@store', $verify->getActionName());
+        $this->assertSame(PasskeyConfirmationController::class.'@store', $confirm->getActionName());
     }
 
     #[DefineEnvironment('withoutPasskeys')]
@@ -33,8 +48,10 @@ class PasskeyTest extends OrchestraTestCase
     {
         $this->assertFalse(Features::enabled(Features::passkeys()));
 
-        $this->assertFalse(Route::has('passkey.verification-options'));
-        $this->assertFalse(Route::has('passkey.verify'));
+        $this->assertFalse(Route::has('passkey.login-options'));
+        $this->assertFalse(Route::has('passkey.login'));
+        $this->assertFalse(Route::has('passkey.confirm-options'));
+        $this->assertFalse(Route::has('passkey.confirm'));
         $this->assertFalse(Route::has('passkey.registration-options'));
         $this->assertFalse(Route::has('passkey.store'));
         $this->assertFalse(Route::has('passkey.destroy'));
@@ -57,7 +74,7 @@ class PasskeyTest extends OrchestraTestCase
     #[DefineEnvironment('withPasskeysLimiter')]
     public function test_passkeys_routes_use_the_passkeys_limiter()
     {
-        $route = Route::getRoutes()->getByName('passkey.verification-options');
+        $route = Route::getRoutes()->getByName('passkey.login-options');
 
         $this->assertNotNull($route);
         $this->assertContains('throttle:passkeys', $route->middleware());
@@ -70,5 +87,14 @@ class PasskeyTest extends OrchestraTestCase
 
         $this->assertNotNull($route);
         $this->assertContains('password.confirm', $route->middleware());
+    }
+
+    #[DefineEnvironment('withPasskeysConfirmingPasswords')]
+    public function test_passkey_confirmation_routes_are_not_protected_by_password_confirmation_middleware()
+    {
+        $route = Route::getRoutes()->getByName('passkey.confirm');
+
+        $this->assertNotNull($route);
+        $this->assertNotContains('password.confirm', $route->middleware());
     }
 }

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Fortify\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\Fortify;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+
+class PasskeyTest extends OrchestraTestCase
+{
+    public function test_passkeys_package_passkey_model_is_used_by_default()
+    {
+        $this->assertSame(\Laravel\Passkeys\Passkey::class, \Laravel\Passkeys\Passkeys::passkeyModel());
+    }
+
+    public function test_passkeys_routes_are_registered_by_default()
+    {
+        $this->assertTrue(Features::enabled(Features::passkeys()));
+        $this->assertTrue(Features::canManagePasskeys());
+        $this->assertTrue(Features::hasSecurityFeatures());
+        $this->assertTrue(Features::hasProfileFeatures());
+
+        $this->assertTrue(Route::has('passkey.verification-options'));
+        $this->assertTrue(Route::has('passkey.verify'));
+        $this->assertTrue(Route::has('passkey.registration-options'));
+        $this->assertTrue(Route::has('passkey.store'));
+        $this->assertTrue(Route::has('passkey.destroy'));
+    }
+
+    #[DefineEnvironment('withoutPasskeys')]
+    public function test_passkeys_routes_are_not_registered_when_feature_is_disabled()
+    {
+        $this->assertFalse(Features::enabled(Features::passkeys()));
+
+        $this->assertFalse(Route::has('passkey.verification-options'));
+        $this->assertFalse(Route::has('passkey.verify'));
+        $this->assertFalse(Route::has('passkey.registration-options'));
+        $this->assertFalse(Route::has('passkey.store'));
+        $this->assertFalse(Route::has('passkey.destroy'));
+    }
+
+    #[DefineEnvironment('withPasskeys')]
+    public function test_passkeys_configuration_is_synchronized_with_fortify_configuration()
+    {
+        $this->assertSame(config('fortify.guard'), config('passkeys.guard'));
+        $this->assertSame(config('fortify.middleware'), config('passkeys.middleware'));
+        $this->assertSame(config('fortify.passkeys.relying_party_id'), config('passkeys.relying_party_id'));
+        $this->assertSame(config('fortify.passkeys.timeout'), config('passkeys.timeout'));
+        $this->assertSame(Fortify::redirects('login'), config('passkeys.redirect'));
+        $this->assertSame(
+            config('fortify.limiters.passkeys') ? 'throttle:'.config('fortify.limiters.passkeys') : null,
+            config('passkeys.throttle')
+        );
+    }
+
+    #[DefineEnvironment('withPasskeysLimiter')]
+    public function test_passkeys_routes_use_the_passkeys_limiter()
+    {
+        $route = Route::getRoutes()->getByName('passkey.verification-options');
+
+        $this->assertNotNull($route);
+        $this->assertContains('throttle:passkeys', $route->middleware());
+    }
+
+    #[DefineEnvironment('withPasskeysConfirmingPasswords')]
+    public function test_passkeys_management_routes_can_require_password_confirmation()
+    {
+        $route = Route::getRoutes()->getByName('passkey.registration-options');
+
+        $this->assertNotNull($route);
+        $this->assertContains('password.confirm', $route->middleware());
+    }
+}

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -64,6 +64,8 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertSame(config('fortify.guard'), config('passkeys.guard'));
         $this->assertSame(config('fortify.middleware'), config('passkeys.middleware'));
         $this->assertSame(config('fortify.passkeys.relying_party_id'), config('passkeys.relying_party_id'));
+        $this->assertSame(config('fortify.passkeys.allowed_origins'), config('passkeys.allowed_origins'));
+        $this->assertSame(config('fortify.passkeys.user_handle_secret'), config('passkeys.user_handle_secret'));
         $this->assertSame(config('fortify.passkeys.timeout'), config('passkeys.timeout'));
         $this->assertSame(Fortify::redirects('login'), config('passkeys.redirect'));
         $this->assertSame(

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -9,6 +9,7 @@ use Laravel\Passkeys\Http\Controllers\PasskeyConfirmationController;
 use Laravel\Passkeys\Http\Controllers\PasskeyLoginController;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 
+#[DefineEnvironment('withPasskeys')]
 class PasskeyTest extends OrchestraTestCase
 {
     public function test_passkeys_package_passkey_model_is_used_by_default()

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -100,4 +100,36 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertNotNull($route);
         $this->assertNotContains('password.confirm', $route->middleware());
     }
+
+    public function test_passkeys_user_model_resolves_from_custom_guard()
+    {
+        config([
+            'fortify.guard' => 'admin',
+            'auth.guards.admin' => ['driver' => 'session', 'provider' => 'admins'],
+            'auth.providers.admins' => ['driver' => 'eloquent', 'model' => 'App\\Models\\Admin'],
+        ]);
+
+        $this->assertSame('App\\Models\\Admin', $this->resolvePasskeyUserModel());
+    }
+
+    public function test_passkeys_user_model_falls_back_when_guard_has_no_provider()
+    {
+        config([
+            'fortify.guard' => 'ghost',
+            'auth.guards.ghost' => ['driver' => 'session'],
+            'auth.defaults.provider' => null,
+            'auth.providers.users.model' => 'App\\Models\\FallbackUser',
+        ]);
+
+        $this->assertSame('App\\Models\\FallbackUser', $this->resolvePasskeyUserModel());
+    }
+
+    protected function resolvePasskeyUserModel(): ?string
+    {
+        $provider = $this->app->getProvider(\Laravel\Fortify\FortifyServiceProvider::class);
+        $method = new \ReflectionMethod($provider, 'passkeyUserModel');
+        $method->setAccessible(true);
+
+        return $method->invoke($provider);
+    }
 }


### PR DESCRIPTION
This PR adds support for passkeys to Fortify by wrapping the new [laravel/passkeys](https://packagist.org/packages/laravel/passkeys) composer package. For the frontend it can be paired with the official [`@laravel/passkeys`](https://www.npmjs.com/package/@laravel/passkeys) JavaScript client.

Passkeys can be enabled in the features section of `config/fortify.php`

```php
'features' => [
    // ...
    Features::passkeys(),
],
```

and configured via a dedicated `passkeys` block

```php
'passkeys' => [
    'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
    'allowed_origins' => [config('app.url')],
    'user_handle_secret' => config('app.key'),
    'timeout' => 60000,
],
```

The User model should implement `Laravel\Fortify\Contracts\PasskeyUser` and use the `Laravel\Fortify\PasskeyAuthenticatable` trait.

```php
use Laravel\Fortify\Contracts\PasskeyUser;
use Laravel\Fortify\PasskeyAuthenticatable;

class User extends Authenticatable implements PasskeyUser
{
    use Notifiable, PasskeyAuthenticatable;
}
```

Seven new endpoints are added for login (GET `/passkeys/login/options`, POST `/passkeys/login`), password confirmation (GET `/passkeys/confirm/options`, POST `/passkeys/confirm`), and passkey management (GET `/user/passkeys/options`, POST `/user/passkeys`, DELETE `/user/passkeys/{passkey}`)

A draft update to the Fortify docs with more information can be found here: https://github.com/laravel/docs/compare/fortify-passkeys?expand=1