### PR TITLE
Drop support for PHP 8.1 and Laravel 10

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yml
@@ -15,14 +15,14 @@ body:
     attributes:
       label: Laravel Version
       description: Provide the Laravel version that you are using. [Please ensure it is still supported.](https://laravel.com/docs/releases#support-policy)
-      placeholder: 10.4.1
+      placeholder: 11.0.0
     validations:
       required: true
   - type: input
     attributes:
       label: PHP Version
       description: Provide the PHP version that you are using.
-      placeholder: 8.1.4
+      placeholder: 8.2.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,22 +16,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10, 11, 12, 13]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [11, 12, 13]
         exclude:
           - php: 8.5
-            laravel: 10
-          - php: 8.5
             laravel: 11
-          - php: 8.4
-            laravel: 10
           - php: 8.2
-            laravel: 13
-          - php: 8.1
-            laravel: 11
-          - php: 8.1
-            laravel: 12
-          - php: 8.1
             laravel: 13
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^3.0",
-        "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+        "orchestra/testbench": "^9.15|^10.8|^11.0",
         "phpstan/phpstan": "^1.10"
     },
     "autoload": {


### PR DESCRIPTION
This PR drops PHP 8.1 and Laravel 10.

PHP’s supported versions page currently lists PHP 8.2+ as supported ([php.net](https://www.php.net/supported-versions.php)), while Laravel’s support policy shows Laravel 10 security support ended on February 4, 2025 and Laravel 11+ requires PHP 8.2+ ([Laravel support policy](https://laravel.com/docs/13.x/releases#support-policy)).

This also aligns Fortify with the upcoming passkeys work in [laravel/fortify#668](https://github.com/laravel/fortify/pull/668), since [laravel/passkeys](https://packagist.org/packages/laravel/passkeys) supports Laravel 11+ and PHP 8.2+.