### PR TITLE
Fix incompatibility between Laravel Fortify and `FormRequest::failOnUnknownFields()`

### DIFF
--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -27,6 +27,7 @@ class LoginRequest extends FormRequest
         return [
             Fortify::username() => 'required|string',
             'password' => 'required|string',
+            'remember' => 'sometimes',
         ];
     }
 }

--- a/src/Http/Requests/VerifyEmailRequest.php
+++ b/src/Http/Requests/VerifyEmailRequest.php
@@ -33,4 +33,14 @@ class VerifyEmailRequest extends FormRequest
     {
         return [];
     }
+
+    /**
+     * Determine if fields not present in rules should fail validation.
+     *
+     * @return bool
+     */
+    protected function shouldFailOnUnknownFields(): bool
+    {
+        return false;
+    }
 }

--- a/tests/AuthenticatedSessionControllerTest.php
+++ b/tests/AuthenticatedSessionControllerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Events\Logout;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -13,8 +14,10 @@ use Illuminate\Support\Facades\Event;
 use Laravel\Fortify\Contracts\LoginViewResponse;
 use Laravel\Fortify\LoginRateLimiter;
 use Mockery;
+use Orchestra\Testbench\Attributes\RequiresLaravel;
 use Orchestra\Testbench\Attributes\WithMigration;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 
 #[WithMigration]
 class AuthenticatedSessionControllerTest extends OrchestraTestCase
@@ -33,7 +36,26 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
         $response->assertSeeText('hello world');
     }
 
-    public function test_user_can_authenticate()
+    #[TestWith([null])]
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function test_user_can_authenticate(?bool $remember)
+    {
+        $this->assertUserCanBeAuthenticated($remember);
+    }
+
+    #[TestWith([null])]
+    #[TestWith([true])]
+    #[TestWith([false])]
+    #[RequiresLaravel('>=13.4.0')]
+    public function test_user_can_authenticate_using_failed_on_unknown_fields(?bool $remember)
+    {
+        FormRequest::failOnUnknownFields();
+
+        $this->assertUserCanBeAuthenticated($remember);
+    }
+
+    protected function assertUserCanBeAuthenticated(?bool $remember = null)
     {
         User::forceCreate([
             'name' => 'Taylor Otwell',
@@ -41,10 +63,11 @@ class AuthenticatedSessionControllerTest extends OrchestraTestCase
             'password' => bcrypt('secret'),
         ]);
 
-        $response = $this->withoutExceptionHandling()->post('/login', [
+        $response = $this->withoutExceptionHandling()->post('/login', array_filter([
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-        ]);
+            'remember' => $remember,
+        ]));
 
         $response->assertRedirect('/home');
     }

--- a/tests/VerifyEmailControllerTest.php
+++ b/tests/VerifyEmailControllerTest.php
@@ -2,29 +2,47 @@
 
 namespace Laravel\Fortify\Tests;
 
+use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\URL;
 use Mockery;
+use Orchestra\Testbench\Attributes\RequiresLaravel;
+use Orchestra\Testbench\Attributes\WithMigration;
 
+#[WithMigration]
 class VerifyEmailControllerTest extends OrchestraTestCase
 {
+    use RefreshDatabase;
+
     public function test_the_email_can_be_verified()
     {
+        $this->assertEmailCanBeVerified();
+    }
+
+    #[RequiresLaravel('>=13.4.0')]
+    public function test_the_email_can_be_verified_using_failed_on_unknown_fields()
+    {
+        FormRequest::failOnUnknownFields(true);
+
+        $this->assertEmailCanBeVerified();
+    }
+
+    protected function assertEmailCanBeVerified(): void
+    {
+        $user = UserFactory::new()->unverified()->create([
+            'email' => 'taylor@laravel.com',
+        ]);
+
         $url = URL::temporarySignedRoute(
             'verification.verify',
             now()->addMinutes(60),
             [
-                'id' => 1,
-                'hash' => sha1('taylor@laravel.com'),
+                'id' => $user->getKey(),
+                'hash' => sha1($user->email),
             ]
         );
-
-        $user = Mockery::mock(Authenticatable::class);
-        $user->shouldReceive('getKey')->andReturn(1);
-        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
-        $user->shouldReceive('getEmailForVerification')->andReturn('taylor@laravel.com');
-        $user->shouldReceive('hasVerifiedEmail')->andReturn(false);
-        $user->shouldReceive('markEmailAsVerified')->once();
 
         $response = $this->actingAs($user)
             ->withSession(['url.intended' => 'http://foo.com/bar'])


### PR DESCRIPTION
fixes https://github.com/laravel/fortify/issues/667