### PR TITLE
[1.x] Bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
### Description

GitHub Actions has announced the deprecation of Node.js 20 actions. Currently, `.github/workflows/tests.yml` uses `actions/checkout@v4`, which runs on Node.js 20 and triggers the following deprecation warning during CI runs:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR updates `actions/checkout` from `v4` to `v6` to run on a supported Node environment, ensuring that the continuous integration pipeline remains fully supported, warning-free, and stable for future runs.

### Changes

- Updated `actions/checkout@v4` to `actions/checkout@v6` in `.github/workflows/tests.yml`.

### Benefits

- Resolves the Node.js 20 deprecation warning in the GitHub Actions runner.
- Ensures CI pipelines continue to run reliably without unexpected failures due to outdated dependencies.

### Breaking Changes

None. This is strictly an infrastructure/CI update and has no impact on the framework's behavior or end-users.