### PR TITLE
[1.x] update passkeys and set passkeys management middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "bacon/bacon-qr-code": "^3.0",
         "illuminate/console": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
-        "laravel/passkeys": "^0.1.0",
+        "laravel/passkeys": "^0.2.0",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -81,6 +81,8 @@ return [
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication(),
-        Features::passkeys(),
+        Features::passkeys([
+            'confirmPassword' => true,
+        ]),
     ],
 ];

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -133,6 +133,9 @@ class FortifyServiceProvider extends ServiceProvider
             'passkeys.timeout' => config('fortify.passkeys.timeout', 60000),
             'passkeys.guard' => config('fortify.guard', 'web'),
             'passkeys.middleware' => config('fortify.middleware', ['web']),
+            'passkeys.management_middleware' => Features::optionEnabled(Features::passkeys(), 'confirmPassword')
+                ? ['password.confirm']
+                : [],
             'passkeys.redirect' => Fortify::redirects('login'),
             'passkeys.throttle' => $this->passkeyThrottleMiddleware(),
         ]);

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -45,7 +45,7 @@ abstract class OrchestraTestCase extends TestCase
     protected function withPasskeys($app)
     {
         $app['config']->set('fortify.features', [
-            Features::passkeys(),
+            Features::passkeys(['confirmPassword' => true]),
         ]);
     }
 
@@ -59,7 +59,7 @@ abstract class OrchestraTestCase extends TestCase
     protected function withPasskeysLimiter($app)
     {
         $app['config']->set('fortify.features', [
-            Features::passkeys(),
+            Features::passkeys(['confirmPassword' => true]),
         ]);
 
         $app['config']->set('fortify.limiters.passkeys', 'passkeys');

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -74,6 +74,12 @@ class PasskeyTest extends OrchestraTestCase
             config('passkeys.throttle')
         );
     }
+    
+    #[DefineEnvironment('withPasskeysWithoutPasswordConfirmation')]
+    public function test_passkeys_management_middleware_is_empty_when_confirm_password_disabled()
+    {
+        $this->assertSame([], config('passkeys.management_middleware'));
+    }
 
     #[DefineEnvironment('withPasskeysLimiter')]
     public function test_passkeys_routes_use_the_passkeys_limiter()

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -75,12 +75,6 @@ class PasskeyTest extends OrchestraTestCase
         );
     }
 
-    #[DefineEnvironment('withPasskeysWithoutPasswordConfirmation')]
-    public function test_passkeys_management_middleware_is_empty_when_confirm_password_disabled()
-    {
-        $this->assertSame([], config('passkeys.management_middleware'));
-    }
-
     #[DefineEnvironment('withPasskeysLimiter')]
     public function test_passkeys_routes_use_the_passkeys_limiter()
     {

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -67,6 +67,7 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertSame(config('fortify.passkeys.allowed_origins'), config('passkeys.allowed_origins'));
         $this->assertSame(config('fortify.passkeys.user_handle_secret'), config('passkeys.user_handle_secret'));
         $this->assertSame(config('fortify.passkeys.timeout'), config('passkeys.timeout'));
+        $this->assertSame(['password.confirm'], config('passkeys.management_middleware'));
         $this->assertSame(Fortify::redirects('login'), config('passkeys.redirect'));
         $this->assertSame(
             config('fortify.limiters.passkeys') ? 'throttle:'.config('fortify.limiters.passkeys') : null,

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -74,7 +74,7 @@ class PasskeyTest extends OrchestraTestCase
             config('passkeys.throttle')
         );
     }
-    
+
     #[DefineEnvironment('withPasskeysWithoutPasswordConfirmation')]
     public function test_passkeys_management_middleware_is_empty_when_confirm_password_disabled()
     {


### PR DESCRIPTION
This updates Fortify’s passkey integration to `laravel/passkeys` v0.2 and wires Fortify’s confirmPassword feature option into the passkeys package management middleware.