### PR TITLE
[1.x] Fix passkey password confirmation defaults

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -81,8 +81,6 @@ return [
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication(),
-        Features::passkeys([
-            'confirmPassword' => true,
-        ]),
+        Features::passkeys(),
     ],
 ];

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -182,7 +182,7 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
 
         $passkeyAuthMiddleware = [config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')];
 
-        $passkeyMiddleware = Features::optionEnabled(Features::passkeys(), 'confirmPassword')
+        $passkeyMiddleware = config('fortify-options.passkeys.confirmPassword', true)
             ? [...$passkeyAuthMiddleware, 'password.confirm']
             : $passkeyAuthMiddleware;
 

--- a/src/Features.php
+++ b/src/Features.php
@@ -167,7 +167,12 @@ class Features
     public static function passkeys(array $options = [])
     {
         if (! empty($options)) {
-            config(['fortify-options.passkeys' => $options]);
+            config([
+                'fortify-options.passkeys' => array_replace(
+                    config('fortify-options.passkeys', []),
+                    $options,
+                ),
+            ]);
         }
 
         return 'passkeys';

--- a/src/Features.php
+++ b/src/Features.php
@@ -167,12 +167,7 @@ class Features
     public static function passkeys(array $options = [])
     {
         if (! empty($options)) {
-            config([
-                'fortify-options.passkeys' => array_replace(
-                    config('fortify-options.passkeys', []),
-                    $options,
-                ),
-            ]);
+            config(['fortify-options.passkeys' => $options]);
         }
 
         return 'passkeys';

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -133,7 +133,7 @@ class FortifyServiceProvider extends ServiceProvider
             'passkeys.timeout' => config('fortify.passkeys.timeout', 60000),
             'passkeys.guard' => config('fortify.guard', 'web'),
             'passkeys.middleware' => config('fortify.middleware', ['web']),
-            'passkeys.management_middleware' => Features::optionEnabled(Features::passkeys(), 'confirmPassword')
+            'passkeys.management_middleware' => config('fortify-options.passkeys.confirmPassword', true)
                 ? ['password.confirm']
                 : [],
             'passkeys.redirect' => Fortify::redirects('login'),

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -45,7 +45,7 @@ abstract class OrchestraTestCase extends TestCase
     protected function withPasskeys($app)
     {
         $app['config']->set('fortify.features', [
-            Features::passkeys(['confirmPassword' => true]),
+            Features::passkeys(),
         ]);
     }
 
@@ -66,7 +66,7 @@ abstract class OrchestraTestCase extends TestCase
     protected function withPasskeysLimiter($app)
     {
         $app['config']->set('fortify.features', [
-            Features::passkeys(['confirmPassword' => true]),
+            Features::passkeys(),
         ]);
 
         $app['config']->set('fortify.limiters.passkeys', 'passkeys');

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -56,6 +56,13 @@ abstract class OrchestraTestCase extends TestCase
         ]);
     }
 
+    protected function withPasskeysWithoutPasswordConfirmation($app)
+    {
+        $app['config']->set('fortify.features', [
+            Features::passkeys(['confirmPassword' => false]),
+        ]);
+    }
+
     protected function withPasskeysLimiter($app)
     {
         $app['config']->set('fortify.features', [

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -93,6 +93,15 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertContains('password.confirm', $route->middleware());
     }
 
+    #[DefineEnvironment('withPasskeysWithoutPasswordConfirmation')]
+    public function test_passkeys_management_routes_can_disable_password_confirmation()
+    {
+        $route = Route::getRoutes()->getByName('passkey.registration-options');
+
+        $this->assertNotNull($route);
+        $this->assertNotContains('password.confirm', $route->middleware());
+    }
+
     #[DefineEnvironment('withPasskeysConfirmingPasswords')]
     public function test_passkey_confirmation_routes_are_not_protected_by_password_confirmation_middleware()
     {

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -67,7 +67,7 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertSame(config('fortify.passkeys.allowed_origins'), config('passkeys.allowed_origins'));
         $this->assertSame(config('fortify.passkeys.user_handle_secret'), config('passkeys.user_handle_secret'));
         $this->assertSame(config('fortify.passkeys.timeout'), config('passkeys.timeout'));
-        $this->assertSame([], config('passkeys.management_middleware'));
+        $this->assertSame(['password.confirm'], config('passkeys.management_middleware'));
         $this->assertSame(Fortify::redirects('login'), config('passkeys.redirect'));
         $this->assertSame(
             config('fortify.limiters.passkeys') ? 'throttle:'.config('fortify.limiters.passkeys') : null,
@@ -82,6 +82,14 @@ class PasskeyTest extends OrchestraTestCase
 
         $this->assertNotNull($route);
         $this->assertContains('throttle:passkeys', $route->middleware());
+    }
+
+    public function test_passkeys_management_routes_require_password_confirmation_by_default()
+    {
+        $route = Route::getRoutes()->getByName('passkey.registration-options');
+
+        $this->assertNotNull($route);
+        $this->assertContains('password.confirm', $route->middleware());
     }
 
     #[DefineEnvironment('withPasskeysConfirmingPasswords')]
@@ -100,6 +108,15 @@ class PasskeyTest extends OrchestraTestCase
 
         $this->assertNotNull($route);
         $this->assertNotContains('password.confirm', $route->middleware());
+    }
+
+    public function test_package_config_does_not_overwrite_app_passkey_options()
+    {
+        config(['fortify-options.passkeys' => ['confirmPassword' => false]]);
+
+        require __DIR__.'/../config/fortify.php';
+
+        $this->assertSame(['confirmPassword' => false], config('fortify-options.passkeys'));
     }
 
     #[DefineEnvironment('withPasskeysConfirmingPasswords')]

--- a/tests/PasskeyTest.php
+++ b/tests/PasskeyTest.php
@@ -67,7 +67,7 @@ class PasskeyTest extends OrchestraTestCase
         $this->assertSame(config('fortify.passkeys.allowed_origins'), config('passkeys.allowed_origins'));
         $this->assertSame(config('fortify.passkeys.user_handle_secret'), config('passkeys.user_handle_secret'));
         $this->assertSame(config('fortify.passkeys.timeout'), config('passkeys.timeout'));
-        $this->assertSame(['password.confirm'], config('passkeys.management_middleware'));
+        $this->assertSame([], config('passkeys.management_middleware'));
         $this->assertSame(Fortify::redirects('login'), config('passkeys.redirect'));
         $this->assertSame(
             config('fortify.limiters.passkeys') ? 'throttle:'.config('fortify.limiters.passkeys') : null,


### PR DESCRIPTION
Fixes a regression introduced in #676 that prevented applications from overriding the default value of `fortify-options.passkeys`.