### PR TITLE
[1.x] Respect lowercase_usernames config when resetting password

### DIFF
--- a/src/Http/Controllers/NewPasswordController.php
+++ b/src/Http/Controllers/NewPasswordController.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\CompletePasswordReset;
 use Laravel\Fortify\Contracts\FailedPasswordResetResponse;
 use Laravel\Fortify\Contracts\PasswordResetResponse;
@@ -54,6 +55,12 @@ class NewPasswordController extends Controller
      */
     public function store(Request $request): Responsable
     {
+        if (config('fortify.lowercase_usernames') && $request->has(Fortify::email())) {
+            $request->merge([
+                Fortify::email() => Str::lower($request->{Fortify::email()}),
+            ]);
+        }
+
         $request->validate([
             'token' => 'required',
             Fortify::email() => 'required|email',

--- a/tests/NewPasswordControllerTest.php
+++ b/tests/NewPasswordControllerTest.php
@@ -139,4 +139,42 @@ class NewPasswordControllerTest extends OrchestraTestCase
         $response->assertStatus(302);
         $response->assertSessionHasErrors(['password']);
     }
+
+    public function test_case_insensitive_usernames_can_be_used()
+    {
+        Config::set('fortify.lowercase_usernames', true);
+        Password::shouldReceive('broker')->andReturn($broker = Mockery::mock(PasswordBroker::class));
+
+        $guard = $this->mock(StatefulGuard::class);
+        $user = Mockery::mock(Authenticatable::class);
+
+        $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('save')->once();
+        $guard->shouldReceive('login')->never();
+
+        $updater = $this->mock(ResetsUserPasswords::class);
+        $updater->shouldReceive('reset')->once()->with($user, Mockery::type('array'));
+
+        $broker->shouldReceive('reset')
+            ->once()
+            ->with(
+                Mockery::on(fn ($credentials) => $credentials['email'] === 'john.doe@example.com'),
+                Mockery::type('callable')
+            )
+            ->andReturnUsing(function ($input, $callback) use ($user) {
+                $callback($user, 'password');
+
+                return Password::PASSWORD_RESET;
+            });
+
+        $response = $this->withoutExceptionHandling()->post('/reset-password', [
+            'token' => 'token',
+            'email' => 'John.Doe@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect(Fortify::redirects('password-reset', route('login')));
+    }
 }


### PR DESCRIPTION
This respects the `lowercase_usernames` configuration option when resetting a password, mirroring the handling already applied when requesting a reset link (added in #562).
  
`PasswordResetLinkController` already lowercases the email before sending the reset link, but  `NewPasswordController` does not. So with `lowercase_usernames` enabled, a user who submits the reset  form with different casing gets "We can't find a user with that email address." even though the link  was issued correctly.
  
Steps to reproduce:
1. Enable `fortify.lowercase_usernames`.
2. Request a reset link for `john.doe@example.com`.
3. Open the link and submit the form with `John.Doe@example.com`.
4. Before this change the request fails with "We can't find a user with that email address."; after it, the password resets correctly.
  
Added a regression test (`test_case_insensitive_usernames_can_be_used`) asserting the broker receives the lowercased email.

Fixes #661.