### PR TITLE
[1.x] Use literal status code in LockoutResponse to fix PHPStan analysis

### DIFF
--- a/src/Http/Responses/LockoutResponse.php
+++ b/src/Http/Responses/LockoutResponse.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Fortify\Http\Responses;
 
-use Illuminate\Http\Response;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\LockoutResponse as LockoutResponseContract;
 use Laravel\Fortify\Fortify;
@@ -46,7 +45,7 @@ class LockoutResponse implements LockoutResponseContract
                         'minutes' => ceil($seconds / 60),
                     ]),
                 ],
-            ])->status(Response::HTTP_TOO_MANY_REQUESTS);
+            ])->status(429);
         });
     }
 }


### PR DESCRIPTION
`composer lint` currently fails on a fresh `1.x` checkout because `LockoutResponse` references `Illuminate\Http\Response::HTTP_TOO_MANY_REQUESTS`, which PHPStan reports as an undefined constant (the lint setup runs without Larastan's mappings).
  
This switches to the literal `429`, which is how every other response in the package already sets its status code (e.g. `new JsonResponse('', 202)`) - `LockoutResponse` was the only place using a named HTTP constant. It also removes the now-unused `Illuminate\Http\Response` import. Behavior is unchanged; `429` is the value of `HTTP_TOO_MANY_REQUESTS`.

Fixes #682.