### PR TITLE
Add doctor diagnostics

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,6 @@ permissions:
 
 jobs:
   tests:
-    uses: laravel/.github/.github/workflows/static-analysis.yml@9c15e86fffce728fb6c50ebeae24fd63e98f4d1d # main
+    uses: laravel/.github/.github/workflows/static-analysis.yml@41cb33d868e3f67ea2c9bb53f1ebd9a379400f63 # main
+    with:
+      php: "8.4"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,8 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11, 12, 13]
+        laravel: [12, 13]
         exclude:
-          - php: 8.5
-            laravel: 11
           - php: 8.2
             laravel: 13
 
@@ -43,6 +41,10 @@ jobs:
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
+
+      - name: Remove laravel/doctor on PHP 8.2
+        if: matrix.php == 8.2
+        run: composer remove laravel/doctor --dev --no-update --no-interaction
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/support=^${{ matrix.laravel }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,10 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [12, 13]
+        laravel: [11, 12, 13]
         exclude:
+          - php: 8.5
+            laravel: 11
           - php: 8.2
             laravel: 13
 
@@ -42,8 +44,8 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Remove laravel/doctor on PHP 8.2
-        if: matrix.php == 8.2
+      - name: Remove incompatible dependencies
+        if: matrix.laravel < 12 || matrix.php < 8.3
         run: composer remove laravel/doctor --dev --no-update --no-interaction
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         "php": "^8.2",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^3.0",
-        "illuminate/console": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/console": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
         "laravel/passkeys": "^0.2.0",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
         "laravel/doctor": "^0.1",
-        "orchestra/testbench": "^9.15|^10.8|^11.0",
+        "orchestra/testbench": "^10.8|^11.0",
         "phpstan/phpstan": "^1.10"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         "php": "^8.2",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^3.0",
-        "illuminate/console": "^12.0|^13.0",
-        "illuminate/support": "^12.0|^13.0",
+        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/passkeys": "^0.2.0",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
         "laravel/doctor": "^0.1",
-        "orchestra/testbench": "^10.8|^11.0",
+        "orchestra/testbench": "^9.15|^10.8|^11.0",
         "phpstan/phpstan": "^2.2.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
+        "laravel/doctor": "^0.1",
         "orchestra/testbench": "^9.15|^10.8|^11.0",
         "phpstan/phpstan": "^1.10"
     },

--- a/src/Diagnostics/FortifyEmailVerificationIsImplemented.php
+++ b/src/Diagnostics/FortifyEmailVerificationIsImplemented.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Fortify\Diagnostics;
+
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Route;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Fortify\Features;
+
+class FortifyEmailVerificationIsImplemented extends Diagnostic
+{
+    use ResolvesUserModel;
+
+    public string $name = 'Email verification is implemented';
+
+    public string $group = 'fortify';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'Email verification is not used.',
+            'no-model' => 'The Fortify user model could not be resolved.',
+            'implemented' => 'Email verification is enabled and [{model}] implements MustVerifyEmail.',
+            'routes-defined' => 'Email verification routes are defined outside Fortify for [{model}].',
+            'missing-interface' => Message::make(
+                summary: 'Email verification is enabled, but [{model}] does not implement MustVerifyEmail.',
+                remediation: 'Implement `Illuminate\Contracts\Auth\MustVerifyEmail` on [{model}] so verification emails are sent.',
+            )->link(Link::docs('fortify', 'email-verification')),
+            'missing-feature' => Message::make(
+                summary: '[{model}] implements MustVerifyEmail, but the email verification feature is disabled.',
+                remediation: 'Add `Features::emailVerification()` to fortify.features so the verification routes are registered.',
+            )->link(Link::docs('fortify', 'email-verification')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $enabled = Features::enabled(Features::emailVerification());
+        $model = $this->userModel();
+
+        if ($model === null) {
+            return $enabled ? $this->skip('no-model') : $this->skip('not-used');
+        }
+
+        $verifies = is_subclass_of($model, MustVerifyEmail::class);
+
+        return match (true) {
+            $enabled && $verifies => $this->pass('implemented', ['model' => $model]),
+            $enabled => $this->fail('missing-interface', ['model' => $model]),
+            $verifies && Route::has(['verification.verify', 'verification.notice']) => $this->pass('routes-defined', ['model' => $model]),
+            $verifies => $this->warn('missing-feature', ['model' => $model]),
+            default => $this->skip('not-used'),
+        };
+    }
+}

--- a/src/Diagnostics/FortifyGuardIsStateful.php
+++ b/src/Diagnostics/FortifyGuardIsStateful.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Fortify\Diagnostics;
+
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Throwable;
+
+class FortifyGuardIsStateful extends Diagnostic
+{
+    public string $name = 'Fortify guard is stateful';
+
+    public string $group = 'fortify';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'stateful' => 'The Fortify guard [{guard}] is a stateful guard.',
+            'undefined' => Message::make(
+                summary: 'The Fortify guard [{guard}] is not defined in auth.guards.',
+                remediation: 'Set fortify.guard to a session guard defined in config/auth.php.',
+            )->link(Link::docs('fortify', 'authentication-guard')),
+            'not-stateful' => Message::make(
+                summary: 'The Fortify guard [{guard}] is not a stateful guard.',
+                remediation: 'Set fortify.guard to a session guard; SPAs should use the web guard with Sanctum.',
+            )->link(Link::docs('fortify', 'authentication-guard')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $guard = Configured::string('fortify.guard', 'web');
+
+        try {
+            $resolved = Auth::guard($guard);
+        } catch (Throwable) {
+            return $this->fail('undefined', ['guard' => $guard]);
+        }
+
+        if ($resolved instanceof StatefulGuard) {
+            return $this->pass('stateful', ['guard' => $guard]);
+        }
+
+        return $this->fail('not-stateful', ['guard' => $guard]);
+    }
+}

--- a/src/Diagnostics/FortifyPasskeysAreConfigured.php
+++ b/src/Diagnostics/FortifyPasskeysAreConfigured.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Laravel\Fortify\Diagnostics;
+
+use Illuminate\Support\Facades\Schema;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\EnvironmentMode;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Fortify\Contracts\PasskeyUser;
+use Laravel\Fortify\Features;
+use Laravel\Passkeys\Passkeys;
+use Throwable;
+
+class FortifyPasskeysAreConfigured extends Diagnostic
+{
+    use ResolvesUserModel;
+
+    public string $name = 'Passkeys are configured';
+
+    public string $group = 'fortify';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'Passkeys are not used.',
+            'no-model' => Message::make(
+                summary: 'Passkeys are enabled, but the Fortify user model could not be resolved.',
+                remediation: 'Configure the Fortify guard with a provider whose model is a valid class.',
+            )->link(Link::docs('fortify', 'enabling-passkeys')),
+            'no-app-url' => 'The application URL could not be parsed, so the passkeys configuration was not checked.',
+            'database-unreachable' => 'The database could not be inspected for the passkeys table.',
+            'configured' => 'The passkeys configuration matches the application URL.',
+            'missing-contract' => Message::make(
+                summary: 'Passkeys are enabled, but [{model}] does not implement PasskeyUser.',
+                remediation: 'Implement `Laravel\Fortify\Contracts\PasskeyUser` and use the `PasskeyAuthenticatable` trait on [{model}].',
+            )->link(Link::docs('fortify', 'enabling-passkeys')),
+            'insecure-url' => Message::make(
+                summary: 'Passkeys require a secure context, but the application URL [{url}] is not HTTPS.',
+                remediation: 'Set APP_URL to an https URL; WebAuthn does not work over plain HTTP.',
+            )->link(Link::docs('fortify', 'enabling-passkeys')),
+            'mismatched-relying-party' => Message::make(
+                summary: 'The passkeys relying party [{id}] does not match the application host [{host}].',
+                remediation: 'Set fortify.passkeys.relying_party_id to [{host}] or a parent domain of it.',
+            )->link(Link::docs('fortify', 'enabling-passkeys')),
+            'origin-not-allowed' => Message::make(
+                summary: 'The application URL [{url}] is not listed in the passkeys allowed origins.',
+                remediation: 'Add [{url}] to fortify.passkeys.allowed_origins.',
+            )->link(Link::docs('fortify', 'enabling-passkeys')),
+            'missing-table' => Message::make(
+                summary: 'The [{table}] table required by passkeys does not exist.',
+                remediation: 'Publish the passkeys migrations and run `php artisan migrate`.',
+            )->link(Link::docs('fortify', 'enabling-passkeys')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if (! Features::enabled(Features::passkeys())) {
+            return $this->skip('not-used');
+        }
+
+        $model = $this->userModel();
+
+        if ($model === null) {
+            return $this->fail('no-model');
+        }
+
+        if (! is_subclass_of($model, PasskeyUser::class)) {
+            return $this->fail('missing-contract', ['model' => $model]);
+        }
+
+        $url = rtrim(Configured::string('app.url', ''), '/');
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if (! is_string($host) || $host === '') {
+            return $this->skip('no-app-url');
+        }
+
+        if ($this->requiresSecureUrl($host) && parse_url($url, PHP_URL_SCHEME) !== 'https') {
+            return $this->fail('insecure-url', ['url' => $url]);
+        }
+
+        $relyingParty = Configured::string('fortify.passkeys.relying_party_id', '');
+
+        if ($relyingParty !== '' && $host !== $relyingParty && ! str_ends_with($host, '.'.$relyingParty)) {
+            return $this->fail('mismatched-relying-party', ['id' => $relyingParty, 'host' => $host]);
+        }
+
+        if (! $this->originIsAllowed($url)) {
+            return $this->fail('origin-not-allowed', ['url' => $url]);
+        }
+
+        $passkey = new (Passkeys::passkeyModel());
+
+        try {
+            $schema = Schema::connection($passkey->getConnectionName());
+
+            if (! $schema->hasTable($passkey->getTable())) {
+                return $this->fail('missing-table', ['table' => $passkey->getTable()]);
+            }
+        } catch (Throwable) {
+            return $this->skip('database-unreachable');
+        }
+
+        return $this->pass('configured');
+    }
+
+    /**
+     * Determine whether the application URL must use HTTPS for passkeys.
+     */
+    private function requiresSecureUrl(string $host): bool
+    {
+        return EnvironmentMode::current()->isProduction()
+            && ! in_array($host, ['localhost', '127.0.0.1'], true);
+    }
+
+    /**
+     * Determine whether the application URL is an allowed passkey origin.
+     */
+    private function originIsAllowed(string $url): bool
+    {
+        foreach ((array) config('fortify.passkeys.allowed_origins', []) as $origin) {
+            if (is_string($origin) && rtrim($origin, '/') === $url) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Diagnostics/FortifyPasswordResetRouteIsDefined.php
+++ b/src/Diagnostics/FortifyPasswordResetRouteIsDefined.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Fortify\Diagnostics;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Route;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Fortify\Features;
+
+class FortifyPasswordResetRouteIsDefined extends Diagnostic
+{
+    public string $name = 'Password reset route is defined';
+
+    public string $group = 'fortify';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The password reset feature is disabled.',
+            'defined' => 'The [password.reset] route is defined.',
+            'customized' => 'Password reset notifications customize their URL or mail message.',
+            'missing' => Message::make(
+                summary: 'The password reset feature is enabled, but no [password.reset] route is defined.',
+                remediation: 'Define a route named `password.reset` that shows your reset password view; reset emails link to it.',
+            )->link(Link::docs('fortify', 'disabling-views-and-password-reset')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if (! Features::enabled(Features::resetPasswords())) {
+            return $this->skip('not-used');
+        }
+
+        if (Route::has('password.reset')) {
+            return $this->pass('defined');
+        }
+
+        if (ResetPassword::$createUrlCallback !== null || ResetPassword::$toMailCallback !== null) {
+            return $this->pass('customized');
+        }
+
+        return $this->fail('missing');
+    }
+}

--- a/src/Diagnostics/FortifyTwoFactorIsImplemented.php
+++ b/src/Diagnostics/FortifyTwoFactorIsImplemented.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Laravel\Fortify\Diagnostics;
+
+use Illuminate\Support\Facades\Schema;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Details;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\Fortify;
+use Laravel\Fortify\TwoFactorAuthenticatable;
+use Throwable;
+
+class FortifyTwoFactorIsImplemented extends Diagnostic
+{
+    use ResolvesUserModel;
+
+    public string $name = 'Two-factor authentication is implemented';
+
+    public string $group = 'fortify';
+
+    /**
+     * The columns added by Fortify's two-factor migration.
+     *
+     * @var list<string>
+     */
+    protected array $columns = [
+        'two_factor_secret',
+        'two_factor_recovery_codes',
+    ];
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'Two-factor authentication is not used.',
+            'no-model' => 'The Fortify user model could not be resolved.',
+            'database-unreachable' => 'The database could not be inspected for the two-factor columns.',
+            'implemented' => 'Two-factor authentication is enabled and [{model}] is configured.',
+            'missing-trait' => Message::make(
+                summary: 'Two-factor authentication is enabled, but [{model}] does not use the TwoFactorAuthenticatable trait.',
+                remediation: 'Use the `Laravel\Fortify\TwoFactorAuthenticatable` trait on [{model}].',
+            )->link(Link::docs('fortify', 'two-factor-authentication')),
+            'missing-columns' => Message::make(
+                summary: 'The [{table}] table is missing the two-factor authentication columns.',
+                remediation: 'Run `php artisan migrate` to add the two-factor columns published by `fortify:install`.',
+            )->link(Link::docs('fortify', 'two-factor-authentication')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->skip('not-used');
+        }
+
+        $model = $this->userModel();
+
+        if ($model === null) {
+            return $this->skip('no-model');
+        }
+
+        if (! in_array(TwoFactorAuthenticatable::class, class_uses_recursive($model), true)) {
+            return $this->fail('missing-trait', ['model' => $model]);
+        }
+
+        $instance = new $model;
+
+        try {
+            $schema = Schema::connection($instance->getConnectionName());
+
+            $missing = array_values(array_filter(
+                $this->requiredColumns(),
+                fn (string $column): bool => ! $schema->hasColumn($instance->getTable(), $column),
+            ));
+        } catch (Throwable) {
+            return $this->skip('database-unreachable');
+        }
+
+        if ($missing !== []) {
+            return $this->fail('missing-columns', ['table' => $instance->getTable()])
+                ->withDetails(Details::bullets($missing));
+        }
+
+        return $this->pass('implemented', ['model' => $model]);
+    }
+
+    /**
+     * Get the columns required by the configured two-factor options.
+     *
+     * @return list<string>
+     */
+    private function requiredColumns(): array
+    {
+        return Fortify::confirmsTwoFactorAuthentication()
+            ? [...$this->columns, 'two_factor_confirmed_at']
+            : $this->columns;
+    }
+}

--- a/src/Diagnostics/ResolvesUserModel.php
+++ b/src/Diagnostics/ResolvesUserModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Fortify\Diagnostics;
+
+trait ResolvesUserModel
+{
+    /**
+     * Get the authentication model class used by Fortify's guard.
+     *
+     * @return class-string|null
+     */
+    protected function userModel(): ?string
+    {
+        $guard = config('fortify.guard', config('auth.defaults.guard', 'web'));
+        $provider = config("auth.guards.{$guard}.provider", config('auth.defaults.provider'));
+
+        $model = $provider
+            ? config("auth.providers.{$provider}.model", config('auth.providers.users.model'))
+            : config('auth.providers.users.model');
+
+        return is_string($model) && class_exists($model) ? $model : null;
+    }
+}

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Doctor\Doctor;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\EmailVerificationNotificationSentResponse as EmailVerificationNotificationSentResponseContract;
 use Laravel\Fortify\Contracts\FailedPasswordConfirmationResponse as FailedPasswordConfirmationResponseContract;
@@ -180,6 +181,25 @@ class FortifyServiceProvider extends ServiceProvider
         $this->configurePublishing();
         $this->configureRoutes();
         $this->registerCommands();
+        $this->registerDiagnostics();
+    }
+
+    /**
+     * Register the package's Doctor diagnostics.
+     *
+     * @return void
+     */
+    protected function registerDiagnostics()
+    {
+        if ($this->app->bound(Doctor::class)) {
+            $this->app->make(Doctor::class)->diagnostics([
+                Diagnostics\FortifyGuardIsStateful::class,
+                Diagnostics\FortifyEmailVerificationIsImplemented::class,
+                Diagnostics\FortifyPasswordResetRouteIsDefined::class,
+                Diagnostics\FortifyTwoFactorIsImplemented::class,
+                Diagnostics\FortifyPasskeysAreConfigured::class,
+            ]);
+        }
     }
 
     /**

--- a/tests/Diagnostics/DiagnosticsTestCase.php
+++ b/tests/Diagnostics/DiagnosticsTestCase.php
@@ -7,6 +7,15 @@ use Laravel\Fortify\Tests\OrchestraTestCase;
 
 abstract class DiagnosticsTestCase extends OrchestraTestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(DoctorServiceProvider::class)) {
+            $this->markTestSkipped('laravel/doctor is not installed.');
+        }
+
+        parent::setUp();
+    }
+
     protected function getPackageProviders($app)
     {
         return array_merge(parent::getPackageProviders($app), [

--- a/tests/Diagnostics/DiagnosticsTestCase.php
+++ b/tests/Diagnostics/DiagnosticsTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Fortify\Tests\Diagnostics;
+
+use Laravel\Doctor\DoctorServiceProvider;
+use Laravel\Fortify\Tests\OrchestraTestCase;
+
+abstract class DiagnosticsTestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return array_merge(parent::getPackageProviders($app), [
+            DoctorServiceProvider::class,
+        ]);
+    }
+}

--- a/tests/Diagnostics/FortifyEmailVerificationIsImplementedTest.php
+++ b/tests/Diagnostics/FortifyEmailVerificationIsImplementedTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Fortify\Tests\Diagnostics;
+
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+use Laravel\Doctor\Results\Status;
+use Laravel\Fortify\Diagnostics\FortifyEmailVerificationIsImplemented;
+use Laravel\Fortify\Features;
+
+class FortifyEmailVerificationIsImplementedTest extends DiagnosticsTestCase
+{
+    public function test_diagnostic_passes_when_the_feature_and_interface_are_present()
+    {
+        config([
+            'fortify.features' => [Features::emailVerification()],
+            'auth.providers.users.model' => VerifyingUser::class,
+        ]);
+
+        $result = (new FortifyEmailVerificationIsImplemented)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertStringContainsString('implements MustVerifyEmail', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_model_is_missing_the_interface()
+    {
+        config(['fortify.features' => [Features::emailVerification()]]);
+
+        $result = (new FortifyEmailVerificationIsImplemented)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('does not implement MustVerifyEmail', $result->summary);
+    }
+
+    public function test_diagnostic_warns_when_the_interface_is_present_without_the_feature()
+    {
+        config([
+            'fortify.features' => [],
+            'auth.providers.users.model' => VerifyingUser::class,
+        ]);
+
+        $this->app['router']->setRoutes(new RouteCollection);
+
+        $result = (new FortifyEmailVerificationIsImplemented)->check();
+
+        $this->assertSame(Status::Warn, $result->status);
+        $this->assertStringContainsString('the email verification feature is disabled', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_verification_routes_are_defined_outside_fortify()
+    {
+        config([
+            'fortify.features' => [],
+            'auth.providers.users.model' => VerifyingUser::class,
+        ]);
+
+        $this->app['router']->setRoutes(new RouteCollection);
+
+        Route::get('/verify-email', fn () => null)->name('verification.notice');
+        Route::get('/verify-email/{id}/{hash}', fn () => null)->name('verification.verify');
+        $this->app['router']->getRoutes()->refreshNameLookups();
+
+        $result = (new FortifyEmailVerificationIsImplemented)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertStringContainsString('defined outside Fortify', $result->summary);
+    }
+
+    public function test_diagnostic_skips_when_the_feature_is_not_used()
+    {
+        config(['fortify.features' => []]);
+
+        $result = (new FortifyEmailVerificationIsImplemented)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('Email verification is not used.', $result->summary);
+    }
+}
+
+class VerifyingUser extends User implements MustVerifyEmail
+{
+    protected $table = 'users';
+}

--- a/tests/Diagnostics/FortifyGuardIsStatefulTest.php
+++ b/tests/Diagnostics/FortifyGuardIsStatefulTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Fortify\Tests\Diagnostics;
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Fortify\Diagnostics\FortifyEmailVerificationIsImplemented;
+use Laravel\Fortify\Diagnostics\FortifyGuardIsStateful;
+use Laravel\Fortify\Diagnostics\FortifyPasskeysAreConfigured;
+use Laravel\Fortify\Diagnostics\FortifyPasswordResetRouteIsDefined;
+use Laravel\Fortify\Diagnostics\FortifyTwoFactorIsImplemented;
+
+class FortifyGuardIsStatefulTest extends DiagnosticsTestCase
+{
+    public function test_diagnostics_are_registered_with_doctor()
+    {
+        $registered = Doctor::registered();
+
+        $this->assertContains(FortifyGuardIsStateful::class, $registered);
+        $this->assertContains(FortifyEmailVerificationIsImplemented::class, $registered);
+        $this->assertContains(FortifyPasswordResetRouteIsDefined::class, $registered);
+        $this->assertContains(FortifyTwoFactorIsImplemented::class, $registered);
+        $this->assertContains(FortifyPasskeysAreConfigured::class, $registered);
+    }
+
+    public function test_diagnostic_passes_for_a_session_guard()
+    {
+        $result = (new FortifyGuardIsStateful)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The Fortify guard [web] is a stateful guard.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_for_an_undefined_guard()
+    {
+        config(['fortify.guard' => 'missing']);
+
+        $result = (new FortifyGuardIsStateful)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The Fortify guard [missing] is not defined in auth.guards.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_for_a_stateless_guard()
+    {
+        config([
+            'auth.guards.api' => ['driver' => 'token', 'provider' => 'users'],
+            'fortify.guard' => 'api',
+        ]);
+
+        $result = (new FortifyGuardIsStateful)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The Fortify guard [api] is not a stateful guard.', $result->summary);
+    }
+}

--- a/tests/Diagnostics/FortifyPasskeysAreConfiguredTest.php
+++ b/tests/Diagnostics/FortifyPasskeysAreConfiguredTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Laravel\Fortify\Tests\Diagnostics;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Doctor\Results\Status;
+use Laravel\Fortify\Contracts\PasskeyUser;
+use Laravel\Fortify\Diagnostics\FortifyPasskeysAreConfigured;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\PasskeyAuthenticatable;
+
+class FortifyPasskeysAreConfiguredTest extends DiagnosticsTestCase
+{
+    protected function withPasskeyUser(array $config = [], bool $withTable = true): void
+    {
+        config(array_merge([
+            'fortify.features' => [Features::passkeys()],
+            'auth.providers.users.model' => PasskeyCapableUser::class,
+        ], $config));
+
+        if ($withTable) {
+            Schema::create('passkeys', function ($table) {
+                $table->id();
+            });
+        }
+    }
+
+    public function test_diagnostic_skips_when_the_feature_is_not_used()
+    {
+        config(['fortify.features' => []]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('Passkeys are not used.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_model_is_missing_the_contract()
+    {
+        config(['fortify.features' => [Features::passkeys()]]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('does not implement PasskeyUser', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_user_model_cannot_be_resolved()
+    {
+        config([
+            'fortify.features' => [Features::passkeys()],
+            'auth.providers.users.model' => 'App\\Models\\MissingUser',
+        ]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('could not be resolved', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_the_configuration_matches()
+    {
+        $this->withPasskeyUser([
+            'app.url' => 'https://example.com',
+            'fortify.passkeys.relying_party_id' => 'example.com',
+            'fortify.passkeys.allowed_origins' => ['https://example.com'],
+        ]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+
+    public function test_diagnostic_allows_a_parent_domain_relying_party()
+    {
+        $this->withPasskeyUser([
+            'app.url' => 'https://app.example.com',
+            'fortify.passkeys.relying_party_id' => 'example.com',
+            'fortify.passkeys.allowed_origins' => ['https://app.example.com'],
+        ]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+
+    public function test_diagnostic_fails_when_the_application_url_is_not_https_in_production()
+    {
+        $this->withPasskeyUser([
+            'app.url' => 'http://example.com',
+            'fortify.passkeys.relying_party_id' => 'example.com',
+            'fortify.passkeys.allowed_origins' => ['http://example.com'],
+        ]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('not HTTPS', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_relying_party_does_not_match()
+    {
+        $this->withPasskeyUser([
+            'app.url' => 'https://example.com',
+            'fortify.passkeys.relying_party_id' => 'other.com',
+            'fortify.passkeys.allowed_origins' => ['https://example.com'],
+        ]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The passkeys relying party [other.com] does not match the application host [example.com].', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_application_url_is_not_an_allowed_origin()
+    {
+        $this->withPasskeyUser([
+            'app.url' => 'https://example.com',
+            'fortify.passkeys.relying_party_id' => 'example.com',
+            'fortify.passkeys.allowed_origins' => ['https://other.com'],
+        ]);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('not listed in the passkeys allowed origins', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_passkeys_table_is_missing()
+    {
+        $this->withPasskeyUser([
+            'app.url' => 'https://example.com',
+            'fortify.passkeys.relying_party_id' => 'example.com',
+            'fortify.passkeys.allowed_origins' => ['https://example.com'],
+        ], withTable: false);
+
+        $result = (new FortifyPasskeysAreConfigured)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('[passkeys] table', $result->summary);
+    }
+}
+
+class PasskeyCapableUser extends User implements PasskeyUser
+{
+    use PasskeyAuthenticatable;
+
+    protected $table = 'users';
+}

--- a/tests/Diagnostics/FortifyPasswordResetRouteIsDefinedTest.php
+++ b/tests/Diagnostics/FortifyPasswordResetRouteIsDefinedTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laravel\Fortify\Tests\Diagnostics;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Routing\RouteCollection;
+use Laravel\Doctor\Results\Status;
+use Laravel\Fortify\Diagnostics\FortifyPasswordResetRouteIsDefined;
+use Laravel\Fortify\Features;
+
+class FortifyPasswordResetRouteIsDefinedTest extends DiagnosticsTestCase
+{
+    public function test_diagnostic_skips_when_the_feature_is_disabled()
+    {
+        config(['fortify.features' => []]);
+
+        $result = (new FortifyPasswordResetRouteIsDefined)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('The password reset feature is disabled.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_the_route_is_defined()
+    {
+        config(['fortify.features' => [Features::resetPasswords()]]);
+
+        $result = (new FortifyPasswordResetRouteIsDefined)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The [password.reset] route is defined.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_views_are_disabled_without_a_replacement_route()
+    {
+        config(['fortify.features' => [Features::resetPasswords()]]);
+
+        $this->app['router']->setRoutes(new RouteCollection);
+
+        $result = (new FortifyPasswordResetRouteIsDefined)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('password.reset', $result->remediation);
+    }
+
+    public function test_diagnostic_passes_when_password_reset_notifications_use_a_custom_url()
+    {
+        config(['fortify.features' => [Features::resetPasswords()]]);
+
+        $this->app['router']->setRoutes(new RouteCollection);
+        ResetPassword::createUrlUsing(fn () => 'https://frontend.example.com/reset-password');
+
+        try {
+            $result = (new FortifyPasswordResetRouteIsDefined)->check();
+
+            $this->assertSame(Status::Pass, $result->status);
+            $this->assertSame('Password reset notifications customize their URL or mail message.', $result->summary);
+        } finally {
+            ResetPassword::$createUrlCallback = null;
+        }
+    }
+}

--- a/tests/Diagnostics/FortifyTwoFactorIsImplementedTest.php
+++ b/tests/Diagnostics/FortifyTwoFactorIsImplementedTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Laravel\Fortify\Tests\Diagnostics;
+
+use Illuminate\Support\Facades\Schema;
+use Laravel\Doctor\Results\Status;
+use Laravel\Fortify\Diagnostics\FortifyTwoFactorIsImplemented;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
+
+class FortifyTwoFactorIsImplementedTest extends DiagnosticsTestCase
+{
+    protected function withTwoFactorUser(array $options = [], bool $withColumns = true, bool $withConfirmedAt = false): void
+    {
+        config([
+            'fortify.features' => [Features::twoFactorAuthentication($options)],
+            'auth.providers.users.model' => UserWithTwoFactor::class,
+        ]);
+
+        Schema::create('users', function ($table) use ($withColumns, $withConfirmedAt) {
+            $table->increments('id');
+            $table->string('email');
+
+            if ($withColumns) {
+                $table->text('two_factor_secret')->nullable();
+                $table->text('two_factor_recovery_codes')->nullable();
+            }
+
+            if ($withConfirmedAt) {
+                $table->timestamp('two_factor_confirmed_at')->nullable();
+            }
+        });
+    }
+
+    public function test_diagnostic_skips_when_the_feature_is_not_used()
+    {
+        config(['fortify.features' => []]);
+
+        $result = (new FortifyTwoFactorIsImplemented)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('Two-factor authentication is not used.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_model_is_missing_the_trait()
+    {
+        config(['fortify.features' => [Features::twoFactorAuthentication()]]);
+
+        $result = (new FortifyTwoFactorIsImplemented)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('does not use the TwoFactorAuthenticatable trait', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_columns_are_missing()
+    {
+        $this->withTwoFactorUser(withColumns: false);
+
+        $result = (new FortifyTwoFactorIsImplemented)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The [users] table is missing the two-factor authentication columns.', $result->summary);
+        $this->assertStringContainsString('two_factor_secret', (string) $result->details);
+        $this->assertStringNotContainsString('two_factor_confirmed_at', (string) $result->details);
+    }
+
+    public function test_diagnostic_requires_the_confirmation_column_when_confirmation_is_enabled()
+    {
+        $this->withTwoFactorUser(['confirm' => true]);
+
+        $result = (new FortifyTwoFactorIsImplemented)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertStringContainsString('two_factor_confirmed_at', (string) $result->details);
+    }
+
+    public function test_diagnostic_does_not_require_the_confirmation_column_when_confirmation_is_disabled()
+    {
+        $this->withTwoFactorUser();
+
+        $result = (new FortifyTwoFactorIsImplemented)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+
+    public function test_diagnostic_passes_when_the_trait_and_columns_are_present()
+    {
+        $this->withTwoFactorUser(['confirm' => true], withConfirmedAt: true);
+
+        $result = (new FortifyTwoFactorIsImplemented)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+}


### PR DESCRIPTION
This PR registers five Fortify diagnostics with [laravel/doctor](https://github.com/laravel/doctor) when it is installed.

- `FortifyGuardIsStateful` fails if `fortify.guard` is undefined or not a session-based guard.
- `FortifyEmailVerificationIsImplemented` checks that the email verification feature and `MustVerifyEmail` on the user model agree, warning when the interface is present but the feature is disabled, unless verification routes are defined outside Fortify.
- `FortifyPasswordResetRouteIsDefined` fails if password resets are enabled but no `password.reset` route exists and the reset notification URL isn't customized.
- `FortifyTwoFactorIsImplemented` verifies the user model uses `TwoFactorAuthenticatable` and the two-factor columns exist, including `two_factor_confirmed_at` when confirmation is enabled.
- `FortifyPasskeysAreConfigured` verifies the user model implements `PasskeyUser`, the app URL is HTTPS in production, the relying party ID and allowed origins match the app URL, and the passkeys table exists.

Each diagnostic skips when its feature is disabled, and the database backed checks skip rather than error when the database is unreachable.