### PR TITLE
[1.x] Preserve pending two-factor setup on repeat enable

### DIFF
--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -8,6 +8,7 @@ use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Contracts\TwoFactorDisabledResponse;
 use Laravel\Fortify\Contracts\TwoFactorEnabledResponse;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorAuthenticationController extends Controller
 {
@@ -21,6 +22,12 @@ class TwoFactorAuthenticationController extends Controller
     public function store(Request $request, EnableTwoFactorAuthentication $enable)
     {
         $enable($request->user(), $request->boolean('force', false));
+
+        if (Fortify::confirmsTwoFactorAuthentication() &&
+            ! is_null($request->user()->two_factor_secret) &&
+            is_null($request->user()->two_factor_confirmed_at)) {
+            $request->session()->remove('two_factor_confirming_at');
+        }
 
         return app(TwoFactorEnabledResponse::class);
     }

--- a/tests/TwoFactorAuthenticationControllerTest.php
+++ b/tests/TwoFactorAuthenticationControllerTest.php
@@ -5,12 +5,16 @@ namespace Laravel\Fortify\Tests;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
 use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
 use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
+use Laravel\Fortify\Tests\Requests\FormRequestInteractsWithTwoFactorState;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\Attributes\ResetRefreshDatabaseState;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -83,6 +87,51 @@ class TwoFactorAuthenticationControllerTest extends OrchestraTestCase
         $this->assertNull($user->two_factor_confirmed_at);
         $this->assertIsArray(json_decode(decrypt($user->two_factor_recovery_codes), true));
         $this->assertNotNull($user->twoFactorQrCodeSvg());
+    }
+
+    #[DefineEnvironment('withConfirmedTwoFactorAuthentication')]
+    #[ResetRefreshDatabaseState]
+    public function test_repeating_two_factor_authentication_enable_preserves_pending_setup()
+    {
+        Event::fake();
+
+        $user = UserWithTwoFactor::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $session = $this->app['session']->driver();
+        $stateRequest = FormRequestInteractsWithTwoFactorState::create('/settings/security');
+        $stateRequest->setUserResolver(fn () => $user);
+        $stateRequest->setLaravelSession($session);
+
+        $enableRequest = Request::create('/user/two-factor-authentication', 'POST');
+        $enableRequest->setUserResolver(fn () => $user);
+        $enableRequest->setLaravelSession($session);
+
+        $stateRequest->ensureStateIsValid();
+
+        app(TwoFactorAuthenticationController::class)->store(
+            $enableRequest,
+            app(EnableTwoFactorAuthentication::class),
+        );
+
+        $stateRequest->ensureStateIsValid();
+
+        $secret = $user->fresh()->two_factor_secret;
+
+        $session->put('two_factor_confirming_at', time() - 10);
+
+        app(TwoFactorAuthenticationController::class)->store(
+            $enableRequest,
+            app(EnableTwoFactorAuthentication::class),
+        );
+
+        $stateRequest->ensureStateIsValid();
+
+        $this->assertSame($secret, $user->fresh()->two_factor_secret);
+        $this->assertTrue($session->has('two_factor_confirming_at'));
     }
 
     #[ResetRefreshDatabaseState]


### PR DESCRIPTION
Fixes #693

A repeated request to enable two-factor authentication intentionally preserves an existing unconfirmed secret, but it also leaves the previous `two_factor_confirming_at` session value in place. The next request using `InteractsWithTwoFactorState` interprets that stale value as an abandoned setup and deletes the secret.

This clears the stale confirmation marker after the enable action when confirmation is required and the user still has a pending setup. The following request can then begin confirmation again while retaining the same secret and recovery codes. Confirmed users and installations that do not require confirmation are unaffected.

The regression test covers the complete disabled-to-pending-to-repeat-enable transition and verifies that the original secret remains available.

Tests:

- Focused controller and state tests: 22 passed, 72 assertions
- Full test suite: 120 passed, 376 assertions
- PHPStan: no errors
- Composer validation: passed
