### PR TITLE
Fix repeat 2FA enable deleting pending secret

### DIFF
--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -25,10 +25,6 @@ class TwoFactorAuthenticationController extends Controller
 
         $enable($user, $request->boolean('force', false));
 
-        // If the user already had a pending, unconfirmed secret, EnableTwoFactorAuthentication
-        // is a no-op above and leaves the previous "confirming_at" session value in place.
-        // InteractsWithTwoFactorState reads that as an abandoned setup on the very next
-        // request and deletes the secret, so we clear it and let the state be re-established.
         if (Fortify::confirmsTwoFactorAuthentication() &&
             ! is_null($user->two_factor_secret) &&
             is_null($user->two_factor_confirmed_at)) {

--- a/src/Http/Controllers/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/TwoFactorAuthenticationController.php
@@ -8,6 +8,7 @@ use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Contracts\TwoFactorDisabledResponse;
 use Laravel\Fortify\Contracts\TwoFactorEnabledResponse;
+use Laravel\Fortify\Fortify;
 
 class TwoFactorAuthenticationController extends Controller
 {
@@ -20,7 +21,19 @@ class TwoFactorAuthenticationController extends Controller
      */
     public function store(Request $request, EnableTwoFactorAuthentication $enable)
     {
-        $enable($request->user(), $request->boolean('force', false));
+        $user = $request->user();
+
+        $enable($user, $request->boolean('force', false));
+
+        // If the user already had a pending, unconfirmed secret, EnableTwoFactorAuthentication
+        // is a no-op above and leaves the previous "confirming_at" session value in place.
+        // InteractsWithTwoFactorState reads that as an abandoned setup on the very next
+        // request and deletes the secret, so we clear it and let the state be re-established.
+        if (Fortify::confirmsTwoFactorAuthentication() &&
+            ! is_null($user->two_factor_secret) &&
+            is_null($user->two_factor_confirmed_at)) {
+            $request->session()->remove('two_factor_confirming_at');
+        }
 
         return app(TwoFactorEnabledResponse::class);
     }

--- a/tests/InteractsWithTwoFactorStateTest.php
+++ b/tests/InteractsWithTwoFactorStateTest.php
@@ -3,7 +3,10 @@
 namespace Laravel\Fortify\Tests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Features;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
 use Laravel\Fortify\Tests\Models\UserWithTwoFactor;
 use Laravel\Fortify\Tests\Requests\FormRequestInteractsWithTwoFactorState;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -214,6 +217,45 @@ class InteractsWithTwoFactorStateTest extends OrchestraTestCase
         $timestamp = $formRequest->session()->get('two_factor_confirming_at');
         $this->assertGreaterThanOrEqual($beforeTime, $timestamp);
         $this->assertLessThanOrEqual($afterTime, $timestamp);
+    }
+
+    public function test_repeat_enable_request_does_not_disable_pending_confirmation()
+    {
+        $user = $this->createUser([
+            'two_factor_secret' => encrypt('secret'),
+            'two_factor_confirmed_at' => null,
+        ]);
+        $formRequest = $this->createFormRequestWithUser($user);
+        $formRequest->session()->put('two_factor_empty_at', time() - 10);
+
+        // The settings page is loaded right after the secret was generated, so
+        // confirming_at gets stamped for the first time here.
+        $formRequest->ensureStateIsValid();
+        $this->assertTrue($formRequest->session()->has('two_factor_confirming_at'));
+
+        $secret = $user->two_factor_secret;
+
+        // A moment later the user clicks "Enable 2FA" again without ever confirming.
+        // The secret already exists, so EnableTwoFactorAuthentication no-ops, but the
+        // controller should still clear the now-stale confirming_at value.
+        $enableRequest = Request::create('/user/two-factor-authentication', 'POST');
+        $enableRequest->setUserResolver(fn () => $user);
+        $enableRequest->setLaravelSession($formRequest->session());
+
+        app(TwoFactorAuthenticationController::class)->store(
+            $enableRequest,
+            app(EnableTwoFactorAuthentication::class)
+        );
+
+        $this->assertFalse($formRequest->session()->has('two_factor_confirming_at'));
+
+        // The settings page loads again, sees a fresh confirmation attempt starting,
+        // and should not treat it as abandoned.
+        $formRequest = $this->createFormRequestWithUser($user);
+        $formRequest->ensureStateIsValid();
+
+        $this->assertEquals($secret, $user->fresh()->two_factor_secret);
+        $this->assertTrue($formRequest->session()->has('two_factor_confirming_at'));
     }
 
     private function createUser(array $attributes = []): UserWithTwoFactor


### PR DESCRIPTION
Fixes #693

When two-factor confirmation is required, clicking "Enable 2FA" a second time before confirming ends up deleting the secret that was just generated, and the setup screen 404s trying to fetch a secret key that no longer exists.

Two separate changes interact here. `EnableTwoFactorAuthentication` (#518) intentionally no-ops if a secret already exists and `force` isn't passed, so a second click doesn't touch the secret. But `InteractsWithTwoFactorState` (#604) stamps `two_factor_confirming_at` in the session the first time it sees a pending secret, and on any later request treats a `confirming_at` that doesn't match the current timestamp as an abandoned confirmation, disabling 2FA and wiping the secret.

So the sequence is: first click creates the secret, the redirect back stamps `confirming_at`. Second click no-ops (secret already exists), but the following redirect sees the old `confirming_at` value and decides the confirmation was abandoned, deleting the secret it just preserved.

The fix clears the stale `confirming_at` session value in the controller when the enable action is a no-op (secret exists, still unconfirmed). That lets the state trait treat the next request as the start of a new confirmation window instead of an abandoned one, so the same secret survives.

Test plan:
- Added a test that reproduces the exact repeat-click sequence against `InteractsWithTwoFactorState` and the controller together, asserting the secret is unchanged and `confirming_at` gets re-established.
- Ran the full suite locally: 120 passed, 378 assertions.
- `phpstan analyse`: no errors.
